### PR TITLE
[Config] Depend on a minor while pre-1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift-extras.git", from: "2.0.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-configuration.git", from: "0.1.0", traits: []),
+        .package(url: "https://github.com/apple/swift-configuration.git", .upToNextMinor(from: "0.1.0"), traits: []),
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION

### Motivation

Swift Configuration is only API stable within each minor pre-1.0.

### Modifications

Depend on the 0.1.x minor.

### Result

Will not break this package when 0.2.0 ships with breaking changes.

### Test Plan

N/A
