### PR TITLE
Add line on how to install/upgrade Swift to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ business processes such as:
 
 - Swift version: Swift 6.2+
 
+To install/upgrade Swift, see https://www.swift.org/install/
+
 ### Adding as a dependency
 
 To use the Swift Temporal SDK in your Swift project, add it as a dependency in


### PR DESCRIPTION
### Motivation

Since right now the vast majority of the Temporal community uses something _other_ than Swift :) it might be nice to throw them a breadcrumb on how to get it.

In my case I had it, but the wrong version (6.1.0) and because I wasn't familiar with Swift (yet!) I wasn't sure how to proceed. Hoping to make this easier for the next person.

### Modifications

One liner to add a pointer to https://www.swift.org/install/ as per Temporal Community Slack.

### Result

^ :)

### Test Plan

N/A