### PR TITLE
Build static libraries on older Linux distro

### DIFF
--- a/.github/workflows/build-temporal-core-artifacts.yml
+++ b/.github/workflows/build-temporal-core-artifacts.yml
@@ -311,6 +311,9 @@ jobs:
   build-linux-x86:
     name: Build Linux x86_64
     runs-on: ubuntu-24.04
+    # Build in manylinux_2_28 container (glibc 2.28) for compatibility with Swift 6.2 Linux images
+    # This ensures the binary works with all official Swift images including amazonlinux2 (glibc 2.26)
+    container: quay.io/pypa/manylinux_2_28_x86_64
     needs: setup
     steps:
       - name: Checkout repository
@@ -320,8 +323,11 @@ jobs:
 
       - name: Install protoc
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq protobuf-compiler
+          # Install newer protobuf compiler that supports ruby_package option
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
+          unzip -q protoc-28.3-linux-x86_64.zip -d /usr/local
+          rm protoc-28.3-linux-x86_64.zip
+          protoc --version
 
       - name: Install Rust
         run: |
@@ -350,6 +356,9 @@ jobs:
   build-linux-arm:
     name: Build Linux ARM64
     runs-on: ubuntu-24.04-arm
+    # Build in manylinux_2_28 container (glibc 2.28) for compatibility with Swift 6.2 Linux images
+    # This ensures the binary works with all official Swift images including amazonlinux2 (glibc 2.26)
+    container: quay.io/pypa/manylinux_2_28_aarch64
     needs: setup
     steps:
       - name: Checkout repository
@@ -359,8 +368,11 @@ jobs:
 
       - name: Install protoc
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq protobuf-compiler
+          # Install newer protobuf compiler that supports ruby_package option
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-aarch_64.zip
+          unzip -q protoc-28.3-linux-aarch_64.zip -d /usr/local
+          rm protoc-28.3-linux-aarch_64.zip
+          protoc --version
 
       - name: Install Rust
         run: |

--- a/Package.swift
+++ b/Package.swift
@@ -50,13 +50,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Bridge",
-            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-682d441/temporal.artifactbundle.zip",
-            checksum: "a457355ef39ef2d8609221e632682bbc06cfeb7a57691c96422fafa7a6350a39"
+            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-682d441-6/temporal.artifactbundle.zip",
+            checksum: "c9c2e8f709e3b05362cae68a9ae45a437a1212b435e38d150e8925bded0a0973"
         ),
         .binaryTarget(
             name: "BridgeDarwin",
-            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-682d441/temporal.xcframework.zip",
-            checksum: "edac56be6bf723f7f46e5dd13af59c9192e2660a2bf74953b96fa807abb54688"
+            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-682d441-6/temporal.xcframework.zip",
+            checksum: "70a1a83a349058a0e2d422331012184256ee70199e6bb9f1cb946794f8bf8c7f"
         ),
         .target(
             name: "Temporal",


### PR DESCRIPTION
### Motivation

The Linux binary artifacts we produce are currently built on Ubuntu 24.04, which uses glibc 2.39. When these binaries are linked into applications running on older Linux distributions with older glibc versions (e.g., CentOS 7 with glibc 2.17, Ubuntu 16.04 with glibc 2.23), they fail due to glibc version incompatibility.

### Modifications

- Updated `build-linux-x86` and `build-linux-arm` jobs to run in `quay.io/pypa/manylinux_2_28_x86_64` and `quay.io/pypa/manylinux_2_28_aarch64` containers respectively
- These containers are based on CentOS 7 with glibc 2.28, ensuring maximum compatibility across Linux distributions

### Result

Linux binary artifacts will now be compatible with a much wider range of distributions:
- Any Linux distribution with glibc 2.28 or newer

This ensures users can link our temporal-sdk-core binaries into their Swift applications regardless of their target Linux distribution.

### Test Plan

N/A