### PR TITLE
Temporal should not override global service.name metadata

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -161,7 +161,6 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftDiagnostics", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),

--- a/Sources/Temporal/Client/TemporalClient+Interceptors.swift
+++ b/Sources/Temporal/Client/TemporalClient+Interceptors.swift
@@ -44,10 +44,8 @@ extension TemporalClient {
             ),
             ClientOTelLoggingInterceptor(
                 logger: logger,
-                serviceName: "swift-temporal-sdk.TemporalClient",
                 serverHostname: serverHostname,
                 networkTransportMethod: .tcp,
-                serviceVersion: Constants.sdkVersion,
                 includeRequestMetadata: true,
                 includeResponseMetadata: true
             ),

--- a/Sources/Temporal/Worker/TemporalWorker.swift
+++ b/Sources/Temporal/Worker/TemporalWorker.swift
@@ -160,10 +160,8 @@ where
                 ),
                 ClientOTelLoggingInterceptor(
                     logger: logger,
-                    serviceName: "swift-temporal-sdk.TemporalWorker.WorkerClient",
                     serverHostname: configuration.instrumentation.serverHostname,
                     networkTransportMethod: .tcp,
-                    serviceVersion: Constants.sdkVersion,
                     includeRequestMetadata: true,
                     includeResponseMetadata: true
                 ),

--- a/Sources/TemporalInstrumentation/Logs/ClientContext+Metadata.swift
+++ b/Sources/TemporalInstrumentation/Logs/ClientContext+Metadata.swift
@@ -19,19 +19,11 @@ import Tracing
 
 extension ClientContext {
     func metadata(
-        serviceName: String,
-        serviceVersion: String?,
         serverHostname: String,
         networkTransportMethod: SpanAttributes.NetworkAttributes.NestedSpanAttributes.TransportEnum,
         requestMetadata: GRPCCore.Metadata
     ) -> Logger.Metadata {
         var metadata: Logger.Metadata = [:]
-
-        // service-level identification
-        metadata.append(attribute: \.service.name, serviceName)
-        if let serviceVersion {
-            metadata.append(attribute: \.service.version, serviceVersion)
-        }
 
         // RPC info
         metadata.append(attribute: \.rpc.system, "grpc")

--- a/Sources/TemporalInstrumentation/Logs/ClientOTelLoggingInterceptor.swift
+++ b/Sources/TemporalInstrumentation/Logs/ClientOTelLoggingInterceptor.swift
@@ -22,8 +22,6 @@ package struct ClientOTelLoggingInterceptor: ClientInterceptor {
     private let logger: Logger
     private let serverHostname: String
     private let networkTransportMethod: SpanAttributes.NetworkAttributes.NestedSpanAttributes.TransportEnum
-    private let serviceName: String
-    private let serviceVersion: String?
     private var includeRequestMetadata: Bool
     private var includeResponseMetadata: Bool
 
@@ -31,26 +29,20 @@ package struct ClientOTelLoggingInterceptor: ClientInterceptor {
     ///
     /// - Parameters:
     ///   - logger: The `Logger` instance to-be-used in the interceptor. The `Logger.Metadata` should include trace and span IDs for log correlation.
-    ///   - serviceName: The name of the service being instrumented.
     ///   - severHostname: The hostname of the RPC server. This will be the value for the `server.address` attribute in spans.
     ///   - networkTransportMethod: The transport in use (e.g. "tcp", "unix"). This will be the value for the `network.transport` attribute in spans.
-    ///   - serviceVersion: Optional version of the service being instrumented, defaults to `nil`.
     ///   - includeRequestMetadata: if `true`, **all** metadata keys with string values included in the request will be added to the logger metadata.
     ///   - includeResponseMetadata: if `true`, **all** metadata keys with string values included in the response will be added to the logger metadata.
     package init(
         logger: Logger,
-        serviceName: String,
         serverHostname: String,
         networkTransportMethod: SpanAttributes.NetworkAttributes.NestedSpanAttributes.TransportEnum,
-        serviceVersion: String? = nil,
         includeRequestMetadata: Bool = false,
         includeResponseMetadata: Bool = false
     ) {
         self.logger = logger  // Should include trace and span IDs for log correlation
-        self.serviceName = serviceName
         self.serverHostname = serverHostname
         self.networkTransportMethod = networkTransportMethod
-        self.serviceVersion = serviceVersion
         self.includeRequestMetadata = includeRequestMetadata
         self.includeResponseMetadata = includeResponseMetadata
     }
@@ -65,8 +57,6 @@ package struct ClientOTelLoggingInterceptor: ClientInterceptor {
     ) async throws -> StreamingClientResponse<Output> {
         // Build logging metadata
         var metadata = context.metadata(
-            serviceName: self.serviceName,
-            serviceVersion: self.serviceVersion,
             serverHostname: self.serverHostname,
             networkTransportMethod: self.networkTransportMethod,
             requestMetadata: self.includeRequestMetadata ? request.metadata : [:]

--- a/Tests/TemporalTests/Instrumentation/Logs/ClientOTelLoggingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Logs/ClientOTelLoggingInterceptorTests.swift
@@ -40,17 +40,14 @@ struct ClientOTelLoggingInterceptorTests {
         let serviceName = "ClientOTelLoggingInterceptorTest"
         let serverHostname = "test.com"
         let transport: SpanAttributes.NetworkAttributes.NestedSpanAttributes.TransportEnum = .tcp
-        let serviceVersion = "1.2.3"
         let descriptor = MethodDescriptor(fullyQualifiedService: serviceName, method: "TestMethod")
         let remotePeer = "ipv4:123.45.67.89:1234"
         let localPeer = "ipv4:145.32.54.12:4321"
 
         let interceptor = ClientOTelLoggingInterceptor(
             logger: logger,
-            serviceName: serviceName,
             serverHostname: serverHostname,
             networkTransportMethod: transport,
-            serviceVersion: serviceVersion,
             includeRequestMetadata: true,
             includeResponseMetadata: true
         )
@@ -118,12 +115,6 @@ struct ClientOTelLoggingInterceptorTests {
             let rpcMethodName = try #require(log1.metadata?["rpc.method"])
             #expect(rpcMethodName == .string(descriptor.method))
 
-            // service metadata
-            let serviceName = try #require(log1.metadata?["service.name"])
-            #expect(serviceName == serviceName)
-            let serviceVersion = try #require(log1.metadata?["service.version"])
-            #expect(serviceVersion == serviceVersion)
-
             // network metadata
             let type = try #require(log1.metadata?["network.type"])
             #expect(type == "ipv4")
@@ -177,7 +168,6 @@ struct ClientOTelLoggingInterceptorTests {
 
         let interceptor = ClientOTelLoggingInterceptor(
             logger: logger,
-            serviceName: serviceName,
             serverHostname: "test.com",
             networkTransportMethod: .tcp,
             includeRequestMetadata: true,
@@ -238,10 +228,6 @@ struct ClientOTelLoggingInterceptorTests {
             #expect(rpcServiceName == .string(descriptor.service.fullyQualifiedService))
             let rpcMethodName = try #require(log1.metadata?["rpc.method"])
             #expect(rpcMethodName == .string(descriptor.method))
-
-            // service metadata
-            let serviceName = try #require(log1.metadata?["service.name"])
-            #expect(serviceName == serviceName)
 
             // Second "rejected RPC" log
             let log2 = try #require(entries.dropFirst().first)


### PR DESCRIPTION
### Motivation

Temporal should not override global service.name metadata that is used to identity the running service.
