### PR TITLE
Bump `swift-configuration` dependency to 0.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift-extras.git", from: "2.0.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-configuration.git", .upToNextMinor(from: "0.1.0"), traits: []),
+        .package(url: "https://github.com/apple/swift-configuration.git", .upToNextMinor(from: "0.2.0"), traits: []),
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
### Motivation

To be compatible with other libraries / users that depend on the most up-to-date `swift-configuration` 0.2, we should lift our `swift-configuration` dependency as well.

### Modifications

Bumps `swift-configuration` dependency to 0.2.0

### Result

All of our library users must upgrade to `swift-configuration` 0.2

### Test Plan

Verified via our CI and local tests