### PR TITLE
Enable all tests again

### DIFF
--- a/Sources/TemporalTestKit/TemporalTestServer.swift
+++ b/Sources/TemporalTestKit/TemporalTestServer.swift
@@ -153,8 +153,8 @@ public struct TemporalTestServer: Sendable {
     /// - Returns: The result value returned by the closure.
     /// - Throws: Any errors thrown by the closure or during server lifecycle management.
     public static func withTestServer<Result: Sendable>(
-        _ body: (borrowing TemporalTestServer) async throws -> sending Result
-    ) async throws -> sending Result {
+        _ body: (borrowing TemporalTestServer) async throws -> Result
+    ) async throws -> Result {
         try await BridgeTestServer.withBridgeDevServer(
             devServerOptions: Self.devServerOptions,
         ) { bridgeTestServer, target in

--- a/Tests/TemporalTests/Converters/DataConverterTests.swift
+++ b/Tests/TemporalTests/Converters/DataConverterTests.swift
@@ -90,7 +90,6 @@ struct DataConverterTests {
         }
     }
 
-    #if compiler(>=6.2)
     @Test
     func convertVoidPayloads() async throws {
         let dataConverter = DataConverter(
@@ -107,7 +106,6 @@ struct DataConverterTests {
 
         #expect(void! == ())
     }
-    #endif
 
     @Test
     func convertPayloads() async throws {

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalClientOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalClientOutboundTracingInterceptorTests.swift
@@ -21,7 +21,6 @@ import TemporalTestKit
 import Testing
 import Tracing
 
-#if !(os(Linux) && swift(>=6.2))  // TODO: reenable once Swift 6.2 compiler crash / Swift 6.1 runtime crash on Linux (in RELEASE only) is fixed
 @Suite(.tags(.instrumentationTests))
 struct TemporalClientOutboundTracingInterceptorTests {
     @Workflow
@@ -165,4 +164,3 @@ struct TemporalClientOutboundTracingInterceptorTests {
         }
     }
 }
-#endif

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
@@ -17,7 +17,6 @@ import Temporal
 import Testing
 import Tracing
 
-#if !(os(Linux) && swift(>=6.2))  // TODO: reenable once Swift 6.2 compiler crash / Swift 6.1 runtime crash on Linux (in RELEASE only) is fixed
 @Suite(.tags(.instrumentationTests))
 struct TemporalWorkerOutboundTracingInterceptorTests {
     @Workflow
@@ -74,18 +73,20 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
                     ).makeWorkflowOutboundInterceptor()
                 )
 
-                _ = try await interceptor.executeActivity(
-                    input: ScheduleActivityInput(
-                        name: Self.activityInfo.name,
-                        options: ActivityOptions(
-                            scheduleToCloseTimeout: Self.scheduleToCloseTimeout,
-                            disableEagerActivityExecution: Self.disableEagerActivityExecution,
-                            cancellationType: Self.cancellationType,
-                            versioningIntent: Self.versioningIntent
-                        ),
-                        headers: [:],
-                        input: ()
+                let input = ScheduleActivityInput<Void>(
+                    name: Self.activityInfo.name,
+                    options: ActivityOptions(
+                        scheduleToCloseTimeout: Self.scheduleToCloseTimeout,
+                        disableEagerActivityExecution: Self.disableEagerActivityExecution,
+                        cancellationType: Self.cancellationType,
+                        versioningIntent: Self.versioningIntent
                     ),
+                    headers: [:],
+                    input: ()
+                )
+
+                _ = try await interceptor.executeActivity(
+                    input: input,
                     next: { input in
                         // Assert that headers contain the injected traceID
                         let traceHeaderPayload = try #require(
@@ -155,18 +156,20 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
                 )
 
                 do {
-                    _ = try await interceptor.executeActivity(
-                        input: ScheduleActivityInput(
-                            name: Self.activityInfo.name,
-                            options: ActivityOptions(
-                                scheduleToCloseTimeout: Self.scheduleToCloseTimeout,
-                                disableEagerActivityExecution: Self.disableEagerActivityExecution,
-                                cancellationType: Self.cancellationType,
-                                versioningIntent: Self.versioningIntent
-                            ),
-                            headers: [:],
-                            input: ()
+                    let input = ScheduleActivityInput<Void>(
+                        name: Self.activityInfo.name,
+                        options: ActivityOptions(
+                            scheduleToCloseTimeout: Self.scheduleToCloseTimeout,
+                            disableEagerActivityExecution: Self.disableEagerActivityExecution,
+                            cancellationType: Self.cancellationType,
+                            versioningIntent: Self.versioningIntent
                         ),
+                        headers: [:],
+                        input: ()
+                    )
+
+                    _ = try await interceptor.executeActivity(
+                        input: input,
                         next: { input in
                             // Assert that headers contain the injected traceID
                             let traceHeaderPayload = try #require(
@@ -204,4 +207,3 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
         }
     }
 }
-#endif

--- a/Tests/TemporalTests/Worker/Activities/ActivityInterceptorTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityInterceptorTests.swift
@@ -16,7 +16,6 @@ import Synchronization
 import Temporal
 import Testing
 
-#if !(os(Linux) && swift(>=6.2))  // TODO: reenable once Swift 6.2 compiler crash on Linux is fixed
 extension TestServerDependentTests {
     @Suite
     struct ActivityInterceptorTests {
@@ -150,16 +149,15 @@ extension TestServerDependentTests {
                 ) {
                     var i = 0
                     for d in repeat each input.details {
-                        guard i == 0 else {
-                            break
-                        }
-
-                        guard let first = d as? String else {
+                        // This is written slightly mor complicated since currently
+                        // early returns in `repeat each` loops are not allowed and
+                        // result in SIL verification crashes
+                        if let first = d as? String, i == 0 {
+                            #expect(first == "Foo", #"First heartbeat detail wasn't "Foo""#)
+                            i += 1
+                        } else {
                             Issue.record("Wrong type passed to heartbeat first detail, expected `String`")
-                            return
                         }
-                        #expect(first == "Foo", #"First heartbeat detail wasn't "Foo""#)
-                        i += 1
                     }
 
                     interceptor.counter.withLock { $0 += 1 }
@@ -228,4 +226,3 @@ extension TestServerDependentTests {
         }
     }
 }
-#endif


### PR DESCRIPTION
This enables the disabled tests again which were blocked by a few compiler crashers on assert toolchains. I was able to workaround those crashers by moving logic around and accounting for non-implemented features such as parameter pack iteration not supporting breaks.