### PR TITLE
Audit the artifact bundles for the Core SDK

### DIFF
--- a/.github/workflows/build-temporal-core-artifacts.yml
+++ b/.github/workflows/build-temporal-core-artifacts.yml
@@ -1,8 +1,5 @@
 name: Build Temporal Core SDK artifacts
 
-permissions:
-  contents: write
-
 on:
   workflow_dispatch:
 
@@ -18,6 +15,8 @@ jobs:
   setup:
     name: Setup release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_id: ${{ steps.create_release.outputs.id }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -547,6 +546,8 @@ jobs:
     # Running on a nightly container since we need https://github.com/swiftlang/swift-package-manager/pull/9360 & https://github.com/swiftlang/swift-package-manager/pull/9359
     container: swiftlang/swift:nightly-main
     needs: [setup, build-macos, build-linux-x86, build-linux-arm, build-linux-musl-x86, build-linux-musl-arm]
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Motivation

The artifact bundles for the Core SDK are only depending on libC. SwiftPM added a new experimental command to audit artifact bundles for this.

## Modifications

Add a new step in the workflow that produces the artifact bundles to validate them.

## Result

We can be sure our artifact bundles are working correctly.
