### PR TITLE
Properly reflect workflow cancellation in the workflow history

### DIFF
--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachine.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachine.swift
@@ -805,6 +805,18 @@ struct WorkflowStateMachine: ~Copyable {
         }
     }
 
+    mutating func cancelWorkflowExecution() {
+        switch consume self.state {
+        case .active(var active):
+            active.commands.append(
+                .with {
+                    $0.cancelWorkflowExecution = .init()
+                }
+            )
+            self = .init(state: .active(active))
+        }
+    }
+
     // MARK: Memo
 
     func memo() -> [String: TemporalRawValue] {

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
@@ -495,6 +495,10 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
         self.stateMachine.continueAsNew(continueAsNewError)
     }
 
+    func cancelWorkflowExecution() {
+        self.stateMachine.cancelWorkflowExecution()
+    }
+
     func commands() -> WorkflowStateMachine.CommandsAction {
         return self.stateMachine.commands()
     }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowCancellationTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowCancellationTests.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Synchronization
+import Temporal
+import TemporalTestKit
+import Testing
+
+extension TestServerDependentTests {
+    @Suite(.tags(.workflowTests))
+    struct WorkflowCancellationTests {
+        enum Scenario: Hashable, Codable, CaseIterable {
+            case swiftCancellationError
+            case cancelledError
+            case activityCancelled
+            case childWorkflowCancelled
+        }
+
+        @ActivityContainer
+        final class CancellationActivities {
+            @Activity
+            static func activityCancellation() async throws {
+                try await Task.sleep(for: .seconds(40))
+            }
+        }
+
+        @Workflow
+        final class CancellationWorkflow {
+            func run(input: Scenario) async throws {
+                switch input {
+                case .swiftCancellationError:
+                    do {
+                        try await Workflow.condition { true }
+                    } catch {
+                        // ignore cancellation handling from Workflow/condition(_:)
+                        try Task.checkCancellation()
+                    }
+                case .cancelledError:
+                    try await Workflow.sleep(for: .seconds(40))
+                case .activityCancelled:
+                    try await Workflow.executeActivity(
+                        CancellationActivities.Activities.ActivityCancellation.self,
+                        options: ActivityOptions(scheduleToCloseTimeout: .seconds(60))
+                    )
+                case .childWorkflowCancelled:
+                    try await Workflow.executeChildWorkflow(
+                        CancellationWorkflow.self,
+                        options: .init(),
+                        input: .cancelledError
+                    )
+                }
+            }
+        }
+
+        @Workflow
+        final class ThrowingWorkflow {
+            func run(input: Void) async throws {
+                throw CanceledError(message: "Workflow wasn't actually cancelled.")
+            }
+        }
+
+        @Test("Workflow Cancellation", arguments: Scenario.allCases)
+        func workflowCancellation(scenario: Scenario) async throws {
+            try await workflowHandle(for: CancellationWorkflow.self, input: scenario) { handle in
+                try await Task.sleep(for: .milliseconds(200))
+                await #expect(throws: Never.self) {
+                    try await handle.cancel()
+                }
+
+                let error = try await #require(throws: WorkflowFailedError.self) {
+                    try await handle.result()
+                }
+
+                // `workflowExecutionCanceled` command translates to exactly this error
+                let cancelledError = try #require(error.cause as? CanceledError)
+                #expect(cancelledError.message == "Workflow execution canceled")
+            }
+        }
+
+        @Test("Workflow Task must be cancelled")
+        func workflowNotCancelled() async throws {
+            // Make sure that we only treat Workflow cancelled if Task.isCancelled
+            let error = try await #require(throws: WorkflowFailedError.self) {
+                try await executeWorkflow(ThrowingWorkflow.self, input: ())
+            }
+
+            // CanceledError message didn't get translated, so wasn't treated as cancellation
+            let cancelledError = try #require(error.cause as? CanceledError)
+            #expect(cancelledError.message == "Workflow wasn't actually cancelled.")
+        }
+    }
+}

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowChildWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowChildWorkflowTests.swift
@@ -465,8 +465,9 @@ extension TestServerDependentTests {
                         .result()
                 }
 
+                // `workflowExecutionCanceled` command translates to exactly this error
                 let cancelledError = try #require(error.cause as? CanceledError)
-                #expect(cancelledError.message == "Wait condition cancelled")
+                #expect(cancelledError.message == "Workflow execution canceled")
             }
         }
 


### PR DESCRIPTION
### Motivation

We previously treated cancellation errors thrown out of the Workflow as we would treat any other error. This resulted in cancelled Workflows showing up as "failed" instead of "cancelled" in the Temporal UI and returning a `workflowExecutionFailed` close event.

### Modifications & Result

We inspect top level errors for cancellation errors now, similar to the [C# SDK](https://github.com/temporalio/sdk-dotnet/blob/e13113b422ff633d44500fef392243b237f9d46a/src/Temporalio/Worker/WorkflowInstance.cs#L1013-L1022) and enqueue a `cancelWorkflowExecution` command instead of a `failWorkflowExecution`. Similar, workflow handles will receive a `workflowExecutionCanceled` close event and return a uniform `CanceledError`.

### Test Plan

Additional unit tests were added to test all possible cancellation scenarios.
