### PR TITLE
Support ServerError in workflow history

### DIFF
--- a/Sources/Temporal/API/ProtoConversions/TemporalFailure+Proto.swift
+++ b/Sources/Temporal/API/ProtoConversions/TemporalFailure+Proto.swift
@@ -47,6 +47,8 @@ extension Temporal_Api_Failure_V1_Failure.OneOf_FailureInfo {
             self = .activityFailureInfo(.init(activity: activity))
         case .timeout(let timeout):
             self = .timeoutFailureInfo(.init(timeout: timeout))
+        case .server(let server):
+            self = .serverFailureInfo(.init(server: server))
         case .DO_NOT_EXHAUSTIVELY_MATCH_OVER_THIS_ENUM:
             fatalError("Unexpected case DO_NOT_EXHAUSTIVELY_MATCH_OVER_THIS_ENUM")
         }
@@ -107,6 +109,14 @@ extension Temporal_Api_Failure_V1_ActivityFailureInfo {
             $0.activityType.name = activity.activityType
             $0.activityID = activity.activityID
             $0.retryState = .init(retryState: activity.retryState)
+        }
+    }
+}
+
+extension Temporal_Api_Failure_V1_ServerFailureInfo {
+    init(server: TemporalFailure.FailureInfo.Server) {
+        self = .with {
+            $0.nonRetryable = server.isNonRetryable
         }
     }
 }
@@ -198,9 +208,8 @@ extension TemporalFailure.FailureInfo {
             )
         case .terminatedFailureInfo:
             self = .terminated(.init())
-        case .serverFailureInfo:
-            // TODO: Add support
-            fatalError("Unsupported failure info")
+        case let .serverFailureInfo(failureInfo):
+            self = .server(.init(isNonRetryable: failureInfo.nonRetryable))
         case .resetWorkflowFailureInfo:
             // TODO: Add support
             fatalError("Unsupported failure info")

--- a/Sources/Temporal/API/TemporalFailure.swift
+++ b/Sources/Temporal/API/TemporalFailure.swift
@@ -57,7 +57,7 @@ public struct TemporalFailure: Hashable, Sendable {
             /// The string type of the error if any.
             public var type: String
 
-            /// Boolean indicating wehter the error was set as non-retry.
+            /// Boolean indicating whether the error was set as non-retry.
             public var isNonRetryable: Bool
 
             /// Delay duration before the next retry attempt.
@@ -80,6 +80,19 @@ public struct TemporalFailure: Hashable, Sendable {
                 self.type = type
                 self.isNonRetryable = isNonRetryable
                 self.nextRetryDelay = nextRetryDelay
+            }
+        }
+
+        public struct Server: Sendable, Hashable {
+            /// Boolean indicating whether the error was set as non-retry.
+            public var isNonRetryable: Bool
+
+            /// Initializes a new server error.
+            ///
+            /// - Parameters:
+            ///   - isNonRetryable: Boolean indicating whether the error was set as non-retry. Defaults to `false`.
+            public init(isNonRetryable: Bool) {
+                self.isNonRetryable = isNonRetryable
             }
         }
 
@@ -211,6 +224,8 @@ public struct TemporalFailure: Hashable, Sendable {
         case terminated(Terminated)
         /// Indicates a child workflow execution failure.
         case childWorkflowExecution(ChildWorkflowExecution)
+        /// Indicates a server-side error.
+        case server(Server)
         /// Indicates an activity failure.
         case activity(Activity)
         /// Indicates a timeout failure.

--- a/Sources/Temporal/Converters/DefaultFailureConverter.swift
+++ b/Sources/Temporal/Converters/DefaultFailureConverter.swift
@@ -159,7 +159,13 @@ public struct DefaultFailureConverter: FailureConverter {
                 stackTrace: temporalFailure.stackTrace,
                 lastHeartbeatDetails: timeout.lastHeartbeatDetails
             )
-
+        case .server(let server):
+            return ServerError(
+                message: temporalFailure.message,
+                cause: cause,
+                stackTrace: temporalFailure.stackTrace,
+                isNonRetryable: server.isNonRetryable
+            )
         case .none:
             return BasicTemporalFailureError(
                 message: temporalFailure.message,

--- a/Sources/Temporal/Converters/PayloadCodec.swift
+++ b/Sources/Temporal/Converters/PayloadCodec.swift
@@ -60,7 +60,7 @@ extension PayloadCodec {
             cancelled.details = encodedDetails
             temporalFailure.failureInfo = .cancelled(cancelled)
 
-        case .childWorkflowExecution, .terminated, .activity:
+        case .childWorkflowExecution, .terminated, .activity, .server:
             // No details so nothing to encode
             break
 
@@ -136,7 +136,7 @@ extension PayloadCodec {
             timeout.lastHeartbeatDetails = decodedDetails
             temporalFailure.failureInfo = .timeout(timeout)
 
-        case .childWorkflowExecution, .activity:
+        case .childWorkflowExecution, .activity, .server:
             // No details so nothing to decode
             break
 

--- a/Sources/Temporal/Errors/Failures/ServerError.swift
+++ b/Sources/Temporal/Errors/Failures/ServerError.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Error representing a server-side error.
+public struct ServerError: TemporalFailureError {
+    /// The error's message.
+    public var message: String
+
+    /// The cause of the current error.
+    public var cause: (any Error)?
+
+    /// The stack trace of the current error.
+    public var stackTrace: String
+
+    /// Boolean indicating whether the error was set as non-retry.
+    public var isNonRetryable: Bool
+
+    /// Initializes a new server error.
+    /// - Parameters:
+    ///   - message: The error's message.
+    ///   - cause: The cause of the current error. Defaults to `nil`.
+    ///   - stackTrace: The stack trace of the current error.
+    ///   - isNonRetryable: Boolean indicating whether the error was set as non-retry.
+    public init(
+        message: String,
+        cause: (any Error)? = nil,
+        stackTrace: String = "",
+        isNonRetryable: Bool = false
+    ) {
+        self.message = message
+        self.cause = cause
+        self.stackTrace = stackTrace
+        self.isNonRetryable = isNonRetryable
+    }
+}


### PR DESCRIPTION
### Motivation

Server error was currently not supported. This is helpful for clients that fetch workflow histories of Workflows that encountered a server error.

### Modifications

Added a new `ServerError` and updated the corresponding failure conversion.


### Test Plan

_TBA_
