### PR TITLE
Add support for Temporal Cloud API key based authentication

### DIFF
--- a/Sources/Temporal/Client/TemporalClient.swift
+++ b/Sources/Temporal/Client/TemporalClient.swift
@@ -105,6 +105,11 @@ public final class TemporalClient: Sendable {
         metadata.addString(configuration.clientName, forKey: "client-name")
         metadata.addString(configuration.clientVersion, forKey: "client-version")
 
+        if let apiKey = configuration.apiKey {
+            metadata.addString("Bearer \(apiKey)", forKey: "authorization")
+            metadata.addString(configuration.namespace, forKey: "temporal-namespace")
+        }
+
         // type-erasure of `GRPCClient`
         let configuredClient = ConfiguredClient(
             client: client,

--- a/Sources/Temporal/Statics/ConfigKeys+Client.swift
+++ b/Sources/Temporal/Statics/ConfigKeys+Client.swift
@@ -22,4 +22,7 @@ extension ConfigKey {
 
     /// The required Temporal server hostname for instrumentation of the ``TemporalClient``.
     static let clientServerHostname: ConfigKey = ["client", "instrumentation", "serverhostname"]
+
+    /// The optional Temporal Cloud API key of the ``TemporalClient``.
+    static let clientAPIKey: ConfigKey = ["client", "apiKey"]
 }

--- a/Sources/Temporal/Statics/ConfigKeys+Worker.swift
+++ b/Sources/Temporal/Statics/ConfigKeys+Worker.swift
@@ -28,4 +28,7 @@ extension ConfigKey {
     ///
     /// If not provided, a default will be used.
     static let workerClientIdentity: ConfigKey = ["worker", "client", "identity"]
+
+    /// The optional Temporal Cloud API key of the ``TemporalWorker``.
+    static let workerClientAPIKey: ConfigKey = ["worker", "client", "apiKey"]
 }

--- a/Sources/TemporalInstrumentation/Metrics/Utils/SpanAttributes+RPC.swift
+++ b/Sources/TemporalInstrumentation/Metrics/Utils/SpanAttributes+RPC.swift
@@ -95,11 +95,11 @@ extension RPCAttributes {
             }
 
             package static var requestMetadata: Key<String> {
-                "rpc.grpc.request.metdata"
+                "rpc.grpc.request.metadata"
             }
 
             package static var responseMetadata: Key<String> {
-                "rpc.grpc.response.metdata"
+                "rpc.grpc.response.metadata"
             }
 
             package init() {}

--- a/Tests/TemporalTests/Instrumentation/Logs/ClientOTelLoggingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Logs/ClientOTelLoggingInterceptorTests.swift
@@ -145,7 +145,7 @@ struct ClientOTelLoggingInterceptorTests {
             let metadataKeys2 = try #require(log2.metadata?.keys)
             #expect(Set(metadataKeys2).isSuperset(of: Set(metadataKeys1)))
             // check additional response header
-            let responseHeader = try #require(log2.metadata?["rpc.grpc.response.metdata.test-key"])
+            let responseHeader = try #require(log2.metadata?["rpc.grpc.response.metadata.test-key"])
             #expect(responseHeader == "test-value")
         }
     }
@@ -245,7 +245,7 @@ struct ClientOTelLoggingInterceptorTests {
             #expect(exceptionMessage == "Test failure")
             let exceptionStacktrace = try #require(log2.metadata?["exception.stacktrace"])
             #expect(exceptionStacktrace == "TestError()")
-            let metadata = try #require(log2.metadata?["rpc.grpc.response.metdata.test-key-error"])
+            let metadata = try #require(log2.metadata?["rpc.grpc.response.metadata.test-key-error"])
             #expect(metadata == "test-value-error")
         }
     }


### PR DESCRIPTION
## Motivation

We need to support Temporal Cloud API key based authentication to offer the second mechanism besides mTLS based authentication.

## Modifications

This adds a new `apiKey` configuration and exposes it through the `ConfigReader` based APIs as well. Furthermore, correctly set the `authorization` and `temporal-namespace` headers.

## Result

You can now connect to Temporal Cloud using API key based authentication.