### PR TITLE
Check for `Void` value instead of underlying type

### DIFF
--- a/Sources/Temporal/Converters/DataConverter.swift
+++ b/Sources/Temporal/Converters/DataConverter.swift
@@ -64,7 +64,7 @@ public struct DataConverter: Sendable {
     package func convertValue<Value>(
         _ value: Value?
     ) async throws -> TemporalPayload {
-        if Value.self == Void.self {
+        if value is Void {
             return .init(data: .init(), metadata: [:])
         }
 

--- a/Sources/Temporal/Converters/PayloadConverter.swift
+++ b/Sources/Temporal/Converters/PayloadConverter.swift
@@ -52,7 +52,7 @@ extension PayloadConverter {
     package func convertValueHandlingVoid<Value>(
         _ value: Value
     ) throws -> TemporalPayload {
-        if Value.self == Void.self {
+        if value is Void {
             return .init(data: .init(), metadata: [:])
         }
 


### PR DESCRIPTION
### Motivation

Previously, the heartbeat details container type was not type-erased with the `any Sendable` type. Hence, performing a type-check for `Void` with `if Value.self == Void.self` for some `Value` type would work, since the concrete type was known at compile time. Now that the logic has been reworked to instead use `any Sendable`, the actual underlying type of the heartbeat details field is erased, and this if-condition fails to correctly catch the usage of `Void` values. This results in `EncodingError()` being thrown if a heartbeat is sent with a `Void` value, i.e. `()`.

### Modifications

This patch updates the logic to instead check if the actual value is a `Void` value instead of comparing the underlying type of the value as received by the method.

### Result

Values of the `Void` type, i.e. `()` are correctly handled when provided in the heartbeat details, and the previously occuring `EncodingError()` is no longer thrown.

### Test Plan

A unit test has been added to verify that type-erased `Void` values are correctly handled.