### PR TITLE
Add TestFailureError to fix flaky signal tests

### DIFF
--- a/Tests/TemporalTests/Converters/TestError.swift
+++ b/Tests/TemporalTests/Converters/TestError.swift
@@ -12,4 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Temporal
+
+/// A simple error for testing that does not conform to `TemporalFailureError`.
 struct TestError: Error {}
+
+/// A test error that conforms to `TemporalFailureError`.
+struct TestFailureError: TemporalFailureError {
+    var message: String = "TestFailureError"
+    var cause: (any Error)?
+    var stackTrace: String = ""
+}

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
@@ -25,7 +25,7 @@ extension TestServerDependentTests {
         final class SignalWorkflow {
             enum SignalScenario: Codable {
                 case updateState
-                case throwTestError
+                case throwTestFailureError
                 case throwApplicationError
                 case timer
                 case updateStateAndWaitCondition
@@ -44,8 +44,8 @@ extension TestServerDependentTests {
                 switch input {
                 case .updateState:
                     self.state = "signaled"
-                case .throwTestError:
-                    throw TestError()
+                case .throwTestFailureError:
+                    throw TestFailureError()
                 case .throwApplicationError:
                     throw ApplicationError(
                         message: "CustomApplicationError",
@@ -82,7 +82,7 @@ extension TestServerDependentTests {
         }
 
         @Test
-        func signalThrowTestError() async throws {
+        func signalThrowTestFailureError() async throws {
             try await withTestWorkerAndClient(
                 workflows: [SignalWorkflow.self]
             ) { taskQueue, client in
@@ -96,7 +96,7 @@ extension TestServerDependentTests {
 
                 try await handle.signal(
                     signalType: SignalWorkflow.Signal.self,
-                    input: .throwTestError
+                    input: .throwTestFailureError
                 )
 
                 await #expect(throws: WorkflowFailedError.self) {


### PR DESCRIPTION
### Motivation

The signalThrowTestError test was flaky because `TestError` did not conform to `TemporalFailureError`. When a non-TemporalFailureError is thrown from a signal handler, it causes a workflow task failure (with retries) rather than failing the workflow immediately. This meant the test was passing by hitting the 3-second timeout rather than properly failing the workflow.

Closes #33

### Modifications

Added `TestFailureError` struct that conforms to `TemporalFailureError` in `TestError.swift`. Updated `WorkflowSignalTests` to use `TestFailureError` instead of `TestError` for the signal error test case. Renamed the test from `signalThrowTestError` to `signalThrowTestFailureError `to reflect the change.

