### PR TITLE
Fix flaky asyncCompletionSucceeds test by increasing timeout

### DIFF
--- a/Tests/TemporalTests/Client/AsyncActivityHandleTests.swift
+++ b/Tests/TemporalTests/Client/AsyncActivityHandleTests.swift
@@ -99,7 +99,7 @@ extension TestServerDependentTests {
                 let activity = CompleteExternalContainer.Activities.ActivityDefault.self
                 return try await Workflow.executeActivity(
                     activity,
-                    options: .init(scheduleToCloseTimeout: .seconds(1)),
+                    options: .init(scheduleToCloseTimeout: .seconds(30)),
                     input: input
                 )
             }
@@ -222,6 +222,19 @@ extension TestServerDependentTests {
                 let activity = CompleteExternalContainer.Activities.ActivityDefault.self
                 return try await Workflow.executeActivity(
                     activity,
+                    options: .init(scheduleToCloseTimeout: .seconds(30), cancellationType: .waitCancellationCompleted),
+                    input: input
+                )
+            }
+        }
+
+        /// Workflow with a short timeout specifically for testing timeout behavior.
+        @Workflow
+        final class AsyncCompletionShortTimeoutWorkflow {
+            func run(input: String) async throws -> String {
+                let activity = CompleteExternalContainer.Activities.ActivityDefault.self
+                return try await Workflow.executeActivity(
+                    activity,
                     options: .init(scheduleToCloseTimeout: .seconds(1), cancellationType: .waitCancellationCompleted),
                     input: input
                 )
@@ -297,10 +310,10 @@ extension TestServerDependentTests {
             try await withTestWorkerAndClient(
                 clientInterceptors: [interceptor],
                 activities: CompleteExternalContainer(taskTokenContinuation: taskTokenContinuation).allActivities,
-                workflows: [AsyncCompletionCancellationWaitingWorkflow.self]
+                workflows: [AsyncCompletionShortTimeoutWorkflow.self]
             ) { taskQueue, client in
                 _ = try await client.startWorkflow(
-                    type: AsyncCompletionCancellationWaitingWorkflow.self,
+                    type: AsyncCompletionShortTimeoutWorkflow.self,
                     options: .init(id: workflowID, taskQueue: taskQueue),
                     input: "input"
                 )


### PR DESCRIPTION
### Motivation

The asyncCompletionSucceeds test was flaky because the activity had a very tight 1-second scheduleToCloseTimeout. In slower CI environments (especially Linux), this timeout could be hit before the async activity completion was processed, causing intermittent test failures.

Closes #36

### Modifications

Increased scheduleToCloseTimeout from 1 second to 30 seconds in AsyncCompletionWorkflow and AsyncCompletionCancellationWaitingWorkflow to provide adequate time for async activity completion in slower environments.

Created a new AsyncCompletionShortTimeoutWorkflow with the original 1-second timeout specifically for the asyncCompletionStartToCloseTimeoutReportsCancel test that needs to test timeout behavior.

### Test Plan

Ran the AsyncActivityHandleTests multiple times to verify they pass consistently.