### PR TITLE
Expose configuration for worker_heartbeat_interval_millis

### DIFF
--- a/Sources/Temporal/Bridge/BridgeRuntime.swift
+++ b/Sources/Temporal/Bridge/BridgeRuntime.swift
@@ -19,13 +19,14 @@ package final class BridgeRuntime: Sendable {
     nonisolated(unsafe) let runtime: OpaquePointer
 
     init(
-        telemetryOptions: TelemetryOptions = .init()
+        telemetryOptions: TelemetryOptions = .init(),
+        workerHeartbeatInterval: Duration = .zero
     ) throws {
         self.runtime = try telemetryOptions.withBridgeOptions { bridgeTelemetryOptions in
             return try withUnsafePointer(to: bridgeTelemetryOptions) { bridgeTelemetryOptionsPointer in
                 var options: TemporalCoreRuntimeOptions = TemporalCoreRuntimeOptions(
                     telemetry: bridgeTelemetryOptionsPointer,
-                    worker_heartbeat_interval_millis: 0  // TODO: Expose this as configuration
+                    worker_heartbeat_interval_millis: workerHeartbeatInterval.milliseconds
                 )
                 let maybeRuntime = temporal_core_runtime_new(&options)
 

--- a/Sources/Temporal/Statics/ConfigKeys+Worker.swift
+++ b/Sources/Temporal/Statics/ConfigKeys+Worker.swift
@@ -31,4 +31,7 @@ extension ConfigKey {
 
     /// The optional Temporal Cloud API key of the ``TemporalWorker``.
     static let workerClientAPIKey: ConfigKey = ["worker", "client", "apiKey"]
+
+    /// The optional worker heartbeat interval in milliseconds of the ``TemporalWorker``.
+    static let workerHeartbeatIntervalMs: ConfigKey = ["worker", "heartbeatintervalms"]
 }

--- a/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
+++ b/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
@@ -348,6 +348,13 @@ extension TemporalWorker {
         public var maxHeartbeatThrottleInterval: Duration = .seconds(60)
 
         // –– Misc ––
+        /// The interval at which the worker sends heartbeats to the server.
+        ///
+        /// Worker heartbeats are separate from activity heartbeats. They indicate that the worker
+        /// process is alive and connected to the server. A value of `.zero` disables worker
+        /// heartbeats (default `.zero`).
+        public var workerHeartbeatInterval: Duration = .zero
+
         /// Milliseconds to wait for in-flight tasks on shutdown before force exit (default `0 sec`).
         public var gracefulShutdownPeriod: Duration = .seconds(0)
         /// Polling behavior for nexus tasks (default max `5`).
@@ -411,6 +418,8 @@ extension TemporalWorker {
         /// - `worker.client.identity`: A human-readable worker client identifier (defaults to
         /// SDK name and version)
         /// - `worker.client.apiKey`: The Temporal Cloud API key.
+        /// - `worker.heartbeatintervalms`: The worker heartbeat interval in milliseconds (defaults to 0,
+        /// which disables worker heartbeats).
         ///
         /// - Parameters:
         ///   - configReader: The configuration reader containing the required configuration values.
@@ -440,6 +449,11 @@ extension TemporalWorker {
                 interceptors: interceptors,
                 apiKey: apiKey
             )
+
+            // Set optional configuration values that have defaults
+            if let heartbeatIntervalMs = snapshot.int(forKey: .workerHeartbeatIntervalMs) {
+                self.workerHeartbeatInterval = .milliseconds(heartbeatIntervalMs)
+            }
         }
     }
 }

--- a/Sources/Temporal/Worker/TemporalWorker.swift
+++ b/Sources/Temporal/Worker/TemporalWorker.swift
@@ -218,7 +218,12 @@ where
     ///
     /// - Throws: An error when the worker is cancelled, or other errors during startup or operation.
     package func run() async throws {
-        try await self.run(bridgeRuntime: .init(telemetryOptions: .init()))  // TODO: Capture telemetry from bridge
+        try await self.run(
+            bridgeRuntime: .init(
+                telemetryOptions: .init(),  // TODO: Capture telemetry from bridge
+                workerHeartbeatInterval: self.configuration.workerHeartbeatInterval
+            )
+        )
     }
 
     /// Runs the Temporal worker to process activities and workflows.


### PR DESCRIPTION
### Motivation

The `worker_heartbeat_interval_millis` setting in `BridgeRuntime` was hardcoded to 0, with a TODO comment to expose it as configuration. Worker heartbeats are separate from activity heartbeats - they indicate that the worker process is alive and connected to the server.

Closes #67

### Modifications

Added `workerHeartbeatInterval` property to `TemporalWorker.Configuration` as an optional `Duration`. Updated `BridgeRuntime.init()` to accept the `workerHeartbeatInterval` parameter and convert it to milliseconds using the existing `Duration.milliseconds` extension. Modified `GenericTemporalWorker.run()` to pass the configuration value through to `BridgeRuntime`.

### Test Plan

Added unit tests in WorkerConfigurationTests to verify the new property defaults to nil and can be set to various `Duration` values.
