### PR TITLE
Fix flaky signal error tests by increasing timeout

### DIFF
--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
@@ -88,7 +88,7 @@ extension TestServerDependentTests {
             ) { taskQueue, client in
                 let workflowID = UUID().uuidString
                 var options = WorkflowOptions(id: workflowID, taskQueue: taskQueue)
-                options.executionTimeOut = .seconds(3)
+                options.executionTimeOut = .seconds(30)
                 let handle = try await client.startWorkflow(
                     type: SignalWorkflow.self,
                     options: options
@@ -112,7 +112,7 @@ extension TestServerDependentTests {
             ) { taskQueue, client in
                 let workflowID = UUID().uuidString
                 var options = WorkflowOptions(id: workflowID, taskQueue: taskQueue)
-                options.executionTimeOut = .seconds(3)
+                options.executionTimeOut = .seconds(30)
                 let handle = try await client.startWorkflow(
                     type: SignalWorkflow.self,
                     options: options


### PR DESCRIPTION
### Motivation

The signalThrowTestFailureError and signalThrowApplicationError tests were flaky because they had a 3-second executionTimeOut. In slower CI environments (especially Linux), this timeout could be hit before the workflow had time to process the signal and propagate the failure properly.

### Modifications

Increased executionTimeOut from 3 seconds to 30 seconds for both tests, providing adequate time for the workflow to fail properly even in slower environments.

### Test Plan

Ran the affected tests multiple times to verify they pass consistently.

