### PR TITLE
Add `ExternalWorkflowHandle` for signaling and canceling external workflows

### DIFF
--- a/Sources/Temporal/Worker/Interceptors/Inputs/CancelExternalWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/CancelExternalWorkflowInput.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Input structure containing parameters for canceling an external workflow in interceptor chains.
+public struct CancelExternalWorkflowInput: Sendable {
+    /// The workflow id of the external workflow to cancel.
+    public var id: String
+
+    /// The run ID of the external workflow.
+    ///
+    /// If `nil`, targets the latest run.
+    public var runId: String?
+}

--- a/Sources/Temporal/Worker/Interceptors/Inputs/SignalExternalWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/SignalExternalWorkflowInput.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Input structure containing parameters and context for external workflow signaling operations in interceptor chains.
+public struct SignalExternalWorkflowInput<each Input: Sendable>: Sendable {
+    /// The workfliw id of the external workflow to signal.
+    public var id: String
+
+    /// The run ID of the external workflow.
+    ///
+    /// If `nil`, targets the latest run.
+    public var runId: String?
+
+    /// The name identifying the type of signal being sent to the external workflow.
+    public var name: String
+
+    /// Headers containing metadata and context information for external workflow signal execution.
+    public var headers: [String: Api.Common.V1.Payload]
+
+    /// The input parameters to be passed to the external workflow signal handler for processing.
+    public var input: (repeat each Input)
+}

--- a/Sources/Temporal/Worker/Interceptors/WorkflowOutboundInterceptor.swift
+++ b/Sources/Temporal/Worker/Interceptors/WorkflowOutboundInterceptor.swift
@@ -83,6 +83,28 @@ public protocol WorkflowOutboundInterceptor: Sendable {
         input: SignalChildWorkflowInput<repeat each Input>,
         next: (SignalChildWorkflowInput<repeat each Input>) async throws -> Void
     ) async throws
+
+    /// Intercepts external workflow signaling requests.
+    ///
+    /// - Parameters:
+    ///   - input: The external workflow signaling input containing signal details and payload.
+    ///   - next: A closure to invoke the next interceptor in the chain.
+    /// - Throws: Any error that occurs during signal delivery.
+    func signalExternalWorkflow<each Input>(
+        input: SignalExternalWorkflowInput<repeat each Input>,
+        next: (SignalExternalWorkflowInput<repeat each Input>) async throws -> Void
+    ) async throws
+
+    /// Intercepts external workflow cancellation requests.
+    ///
+    /// - Parameters:
+    ///   - input: The external workflow cancellation input containing workflow identification details.
+    ///   - next: A closure to invoke the next interceptor in the chain.
+    /// - Throws: Any error that occurs during cancellation.
+    func cancelExternalWorkflow(
+        input: CancelExternalWorkflowInput,
+        next: (CancelExternalWorkflowInput) async throws -> Void
+    ) async throws
 }
 
 extension WorkflowOutboundInterceptor {
@@ -164,6 +186,32 @@ extension WorkflowOutboundInterceptor {
     public func signalWorkflow<each Input>(
         input: SignalChildWorkflowInput<repeat each Input>,
         next: (SignalChildWorkflowInput<repeat each Input>) async throws -> Void
+    ) async throws {
+        try await next(input)
+    }
+
+    /// Default implementation that forwards external workflow signaling to the next interceptor without modification.
+    ///
+    /// - Parameters:
+    ///   - input: The external workflow signaling input containing signal details and payload.
+    ///   - next: A closure to invoke the next interceptor in the chain.
+    /// - Throws: Any error that occurs during signal delivery.
+    public func signalExternalWorkflow<each Input>(
+        input: SignalExternalWorkflowInput<repeat each Input>,
+        next: (SignalExternalWorkflowInput<repeat each Input>) async throws -> Void
+    ) async throws {
+        try await next(input)
+    }
+
+    /// Default implementation that forwards external workflow cancellation to the next interceptor without modification.
+    ///
+    /// - Parameters:
+    ///   - input: The external workflow cancellation input containing workflow identification details.
+    ///   - next: A closure to invoke the next interceptor in the chain.
+    /// - Throws: Any error that occurs during cancellation.
+    public func cancelExternalWorkflow(
+        input: CancelExternalWorkflowInput,
+        next: (CancelExternalWorkflowInput) async throws -> Void
     ) async throws {
         try await next(input)
     }

--- a/Sources/Temporal/Worker/Workflow/ExternalWorkflowHandle.swift
+++ b/Sources/Temporal/Worker/Workflow/ExternalWorkflowHandle.swift
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// A handle for interacting with an external workflow providing type-safe signaling and cancellation capabilities.
+///
+/// `ExternalWorkflowHandle` provides a type-safe interface for communicating with external workflows.
+///
+/// - Note: ``UntypedExternalWorkflowHandle`` provides the same functionality as ``ExternalWorkflowHandle``
+/// without binding to a specific ``WorkflowDefinition``, simplifying interoperability with
+/// Temporal workflows not implemented in Swift and/or do not share the ``WorkflowDefinition``.
+///
+/// ## Usage
+///
+/// ```swift
+/// // Get a typed handle to an external workflow
+/// let handle = Workflow.getExternalWorkflowHandle(
+///     ExternalTargetWorkflow.self,
+///     id: "other-workflow-id"
+/// )
+///
+/// // Signal the external workflow with type safety
+/// try await handle.signal(
+///     signalType: ExternalTargetWorkflow.MySignal.self,
+///     input: signalData
+/// )
+///
+/// // Cancel the external workflow
+/// try await handle.cancel()
+/// ```
+public struct ExternalWorkflowHandle<Workflow: WorkflowDefinition>: Sendable {
+    /// The unique identifier of the external workflow execution.
+    ///
+    /// This identifier uniquely identifies the external workflow within its namespace
+    /// and is used for signaling and cancellation operations.
+    public var id: String { self.untypedHandle.id }
+
+    /// The run ID of the external workflow execution.
+    ///
+    /// If `nil`, operations target the latest run of the workflow with the given ID.
+    public var runId: String? { self.untypedHandle.runId }
+
+    /// The underlying untyped handle that provides the actual implementation.
+    private let untypedHandle: UntypedExternalWorkflowHandle
+
+    init(untypedHandle: UntypedExternalWorkflowHandle) {
+        self.untypedHandle = untypedHandle
+    }
+
+    /// Sends a signal to the external workflow.
+    ///
+    /// Signals provide a mechanism for workflows to communicate with external workflows.
+    /// The signal is delivered asynchronously and processed by the external workflow's signal handler.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// try await handle.signal(
+    ///     signalType: UpdateConfigSignal.self,
+    ///     input: newConfiguration
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - signalType: The type of signal to send.
+    ///   - input: The input data for the signal.
+    /// - Throws: Signal delivery errors or serialization errors.
+    public func signal<Signal: WorkflowSignalDefinition>(
+        signalType: Signal.Type,
+        input: Signal.Input
+    ) async throws {
+        try await self.untypedHandle.signal(
+            signalName: Signal.name,
+            input: input
+        )
+    }
+
+    /// Sends a signal to the external workflow.
+    ///
+    /// This convenience method is used for signals that don't require input data, where the
+    /// signal itself conveys all necessary information.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// try await handle.signal(signalType: CancelOperationSignal.self)
+    /// ```
+    ///
+    /// - Parameter signalType: The type of signal to send.
+    /// - Throws: Signal delivery errors or serialization errors.
+    public func signal<Signal: WorkflowSignalDefinition>(
+        signalType: Signal.Type
+    ) async throws where Signal.Input == Void {
+        try await self.signal(
+            signalType: signalType,
+            input: ()
+        )
+    }
+
+    /// Cancels the external workflow.
+    ///
+    /// Sends a cancellation request to the external workflow. The workflow will receive
+    /// a cancellation notification and can handle it gracefully.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// try await handle.cancel()
+    /// ```
+    ///
+    /// - Throws: Cancellation delivery errors.
+    public func cancel() async throws {
+        try await self.untypedHandle.cancel()
+    }
+}

--- a/Sources/Temporal/Worker/Workflow/UntypedExternalWorkflowHandle.swift
+++ b/Sources/Temporal/Worker/Workflow/UntypedExternalWorkflowHandle.swift
@@ -1,0 +1,158 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// A handle for interacting with an external workflow providing signaling and cancellation capabilities.
+///
+/// The external workflow handle allows a workflow to send signals to and cancel
+/// arbitrary workflows by ID, regardless of whether they are child workflows.
+///
+/// - Note: For type-safe workflow interaction, prefer using ``ExternalWorkflowHandle`` when the
+///   external workflow type is known at compile time.
+///
+/// ## Usage
+///
+/// ```swift
+/// // Get a handle to an external workflow
+/// let handle = Workflow.getExternalWorkflowHandle(id: "other-workflow-id")
+///
+/// // Signal the external workflow
+/// try await handle.signal(
+///     signalName: "mySignal",
+///     input: signalData
+/// )
+///
+/// // Cancel the external workflow
+/// try await handle.cancel()
+/// ```
+public struct UntypedExternalWorkflowHandle: Sendable {
+    /// The unique identifier of the external workflow execution.
+    ///
+    /// This identifier uniquely identifies the external workflow within its namespace
+    /// and is used for signaling and cancellation operations.
+    public let id: String
+
+    /// The run ID of the external workflow execution.
+    ///
+    /// If `nil`, operations target the latest run of the workflow with the given ID.
+    public let runId: String?
+
+    /// The internal implementation handling interceptor chains and operations.
+    private let implementation: Implementation
+
+    package init(
+        id: String,
+        runId: String?,
+        stateMachine: WorkflowStateMachineStorage,
+        interceptors: [any WorkflowOutboundInterceptor],
+        payloadConverter: any PayloadConverter
+    ) {
+        self.id = id
+        self.runId = runId
+        self.implementation = .init(
+            interceptors: interceptors,
+            stateMachine: stateMachine,
+            payloadConverter: payloadConverter
+        )
+    }
+
+    /// Sends a signal to the external workflow by signal name.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// try await handle.signal(
+    ///     signalName: "updateConfig",
+    ///     input: newConfiguration
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - signalName: The name of the signal to send to the external workflow.
+    ///   - input: The input data for the signal.
+    /// - Throws: Signal delivery errors or serialization errors.
+    public func signal<each Input: Sendable>(
+        signalName: String,
+        input: repeat each Input
+    ) async throws {
+        try await implementation.signalExternalWorkflow(
+            input: SignalExternalWorkflowInput<repeat each Input>(
+                id: self.id,
+                runId: self.runId,
+                name: signalName,
+                headers: [:],
+                input: (repeat each input)
+            )
+        )
+    }
+
+    /// Cancels the external workflow.
+    ///
+    /// Sends a cancellation request to the external workflow. The workflow will receive
+    /// a cancellation notification and can handle it gracefully.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// try await handle.cancel()
+    /// ```
+    ///
+    /// - Throws: Cancellation delivery errors.
+    public func cancel() async throws {
+        try await implementation.cancelExternalWorkflow(
+            input: CancelExternalWorkflowInput(
+                id: self.id,
+                runId: self.runId
+            )
+        )
+    }
+}
+
+extension UntypedExternalWorkflowHandle {
+    struct Implementation: InterceptorImplementation {
+        let interceptors: [any WorkflowOutboundInterceptor]
+        let stateMachine: WorkflowStateMachineStorage
+        let payloadConverter: any PayloadConverter
+    }
+}
+
+extension UntypedExternalWorkflowHandle.Implementation {
+    func signalExternalWorkflow<each Input>(
+        input: SignalExternalWorkflowInput<repeat each Input>
+    ) async throws {
+        try await intercept((any WorkflowOutboundInterceptor).signalExternalWorkflow, input: input) { input in
+            let payloads = try self.payloadConverter.convertValues(repeat each input.input)
+
+            try await self.stateMachine.signalExternalWorkflow(
+                namespace: Workflow.info.namespace,
+                workflowID: input.id,
+                runID: input.runId,
+                signalName: input.name,
+                headers: input.headers,
+                inputs: payloads
+            )
+        }
+    }
+
+    func cancelExternalWorkflow(
+        input: CancelExternalWorkflowInput
+    ) async throws {
+        try await intercept((any WorkflowOutboundInterceptor).cancelExternalWorkflow, input: input) { input in
+            try await self.stateMachine.cancelExternalWorkflow(
+                namespace: Workflow.info.namespace,
+                workflowID: input.id,
+                runID: input.runId
+            )
+        }
+    }
+}

--- a/Sources/Temporal/Worker/Workflow/Workflow.swift
+++ b/Sources/Temporal/Worker/Workflow/Workflow.swift
@@ -666,9 +666,74 @@ public struct Workflow: Sendable {
         )
     }
 
-    // MARK: - Child Workflow
+    // MARK: - External Workflow
 
-    /// Starts a child workflow.
+    /// Returns a typed handle to an external workflow for type-safe signaling and cancellation.
+    ///
+    /// The external workflow handle allows a workflow to interact with any other workflow by ID,
+    /// regardless of whether it is a child workflow. This typed variant provides compile-time
+    /// safety for signal operations using ``WorkflowSignalDefinition``.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// let handle = Workflow.getExternalWorkflowHandle(
+    ///     ExternalTargetWorkflow.self,
+    ///     id: "other-workflow-id"
+    /// )
+    ///
+    /// // Signal the external workflow with type safety
+    /// try await handle.signal(signalType: ExternalTargetWorkflow.MySignal.self, input: signalData)
+    ///
+    /// // Cancel the external workflow
+    /// try await handle.cancel()
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - type: The workflow type of the external workflow.
+    ///   - id: The workflow ID of the external workflow.
+    ///   - runId: The optional run ID of the external workflow. If `nil`, targets the latest run.
+    /// - Returns: A typed handle to the external workflow.
+    public static func getExternalWorkflowHandle<W: WorkflowDefinition>(
+        _ type: W.Type,
+        id: String,
+        runId: String? = nil
+    ) -> ExternalWorkflowHandle<W> {
+        ExternalWorkflowHandle(
+            untypedHandle: self._context.getExternalWorkflowHandle(id: id, runId: runId)
+        )
+    }
+
+    /// Returns an untyped handle to an external workflow for signaling and cancellation.
+    ///
+    /// The external workflow handle allows a workflow to interact with any other workflow by ID,
+    /// regardless of whether it is a child workflow. This is useful for cross-workflow communication
+    /// and coordination when the workflow type is not known at compile time.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// let handle = Workflow.getExternalWorkflowHandle(id: "other-workflow-id")
+    ///
+    /// // Signal the external workflow
+    /// try await handle.signal(signalName: "mySignal", input: signalData)
+    ///
+    /// // Cancel the external workflow
+    /// try await handle.cancel()
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - id: The workflow ID of the external workflow.
+    ///   - runId: The optional run ID of the external workflow. If `nil`, targets the latest run.
+    /// - Returns: An untyped handle to the external workflow.
+    public static func getExternalWorkflowHandle(
+        id: String,
+        runId: String? = nil
+    ) -> UntypedExternalWorkflowHandle {
+        self._context.getExternalWorkflowHandle(id: id, runId: runId)
+    }
+
+    // MARK: - Child Workflow
     ///
     /// ## Usage
     ///

--- a/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
@@ -272,6 +272,21 @@ package struct WorkflowContext: Sendable {
         )
     }
 
+    // MARK: External Workflow
+
+    func getExternalWorkflowHandle(
+        id: String,
+        runId: String?
+    ) -> UntypedExternalWorkflowHandle {
+        UntypedExternalWorkflowHandle(
+            id: id,
+            runId: runId,
+            stateMachine: self.stateMachine,
+            interceptors: self.outboundInterceptors,
+            payloadConverter: self.payloadConverter
+        )
+    }
+
     // MARK: Memo
 
     func getMemoValue<T>(for key: String) async throws -> T? {
@@ -436,6 +451,35 @@ extension WorkflowContext.Implementation {
                 inputs: inputPayloads,
                 options: input.options,
                 payloadConverter: self.payloadConverter
+            )
+        }
+    }
+
+    func signalExternalWorkflow<each Input>(
+        input: SignalExternalWorkflowInput<repeat each Input>
+    ) async throws {
+        try await intercept((any WorkflowOutboundInterceptor).signalExternalWorkflow, input: input) { input in
+            let payloads = try self.payloadConverter.convertValues(repeat each input.input)
+
+            try await self.stateMachine.signalExternalWorkflow(
+                namespace: Workflow.info.namespace,
+                workflowID: input.id,
+                runID: input.runId,
+                signalName: input.name,
+                headers: input.headers,
+                inputs: payloads
+            )
+        }
+    }
+
+    func cancelExternalWorkflow(
+        input: CancelExternalWorkflowInput
+    ) async throws {
+        try await intercept((any WorkflowOutboundInterceptor).cancelExternalWorkflow, input: input) { input in
+            try await self.stateMachine.cancelExternalWorkflow(
+                namespace: Workflow.info.namespace,
+                workflowID: input.id,
+                runID: input.runId
             )
         }
     }

--- a/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
@@ -366,8 +366,10 @@ struct WorkflowInstance: Sendable {
                 await Self.$isOnWorkflowInstance.withValue(true) {
                     await self.stateMachine.resolveExternalWorkflowSignal(resolveSignalExternalWorkflow)
                 }
-            case .resolveRequestCancelExternalWorkflow:
-                break
+            case .resolveRequestCancelExternalWorkflow(let resolveRequestCancelExternalWorkflow):
+                await Self.$isOnWorkflowInstance.withValue(true) {
+                    await self.stateMachine.resolveRequestCancelExternalWorkflow(resolveRequestCancelExternalWorkflow)
+                }
             case .queryWorkflow(let queryWorkflow):
                 self.queryWorkflow(
                     queryWorkflow,

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachine.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachine.swift
@@ -47,6 +47,9 @@ struct WorkflowStateMachine: ~Copyable {
             /// Next sequence number for signaling external workflows (including child workflows).
             var nextExternalSignalSequenceNumber: UInt32
 
+            /// Next sequence number for canceling external workflows.
+            var nextExternalCancelSequenceNumber: UInt32
+
             /// Number of current running and unfinished handlers.
             var numberOfActiveHandlers: Int
 
@@ -89,6 +92,9 @@ struct WorkflowStateMachine: ~Copyable {
             /// These are the current external workflow signal continuations that the workflow is waiting on.
             var externalWorkflowSignalContinuations: [UInt32: (CheckedContinuation<Void, any Error>)]
 
+            /// These are the current external workflow cancel continuations that the workflow is waiting on.
+            var externalWorkflowCancelContinuations: [UInt32: (CheckedContinuation<Void, any Error>)]
+
             /// Patches that have been detected.
             var patchesNotified: Set<String>
 
@@ -130,6 +136,7 @@ struct WorkflowStateMachine: ~Copyable {
             nextConditionSequenceNumber: 0,
             nextChildWorkflowSequenceNumber: 0,
             nextExternalSignalSequenceNumber: 0,
+            nextExternalCancelSequenceNumber: 0,
             numberOfActiveHandlers: 0,
             isReplaying: false,
             now: .now,
@@ -143,6 +150,7 @@ struct WorkflowStateMachine: ~Copyable {
             childWorkflowStartContinuations: [:],
             childWorkflowResultStates: [:],
             externalWorkflowSignalContinuations: [:],
+            externalWorkflowCancelContinuations: [:],
             patchesNotified: [],
             patchesMemoized: [:],
             headers: [:],
@@ -209,6 +217,16 @@ struct WorkflowStateMachine: ~Copyable {
         }
     }
 
+    mutating func nextExternalCancelSequenceNumber() -> UInt32 {
+        switch consume self.state {
+        case .active(var active):
+            let sequenceNumber = active.nextExternalCancelSequenceNumber
+            active.nextExternalCancelSequenceNumber += 1
+            self = .init(state: .active(active))
+            return sequenceNumber
+        }
+    }
+
     mutating func updateRandomnessSeed(_ seed: UInt64) {
         switch consume self.state {
         case .active(var active):
@@ -270,6 +288,12 @@ struct WorkflowStateMachine: ~Copyable {
             let externalWorkflowSignalContinuations = active.externalWorkflowSignalContinuations
             active.externalWorkflowSignalContinuations.removeAll()
             for continuation in externalWorkflowSignalContinuations {
+                continuation.value.resume(throwing: error)
+            }
+
+            let externalWorkflowCancelContinuations = active.externalWorkflowCancelContinuations
+            active.externalWorkflowCancelContinuations.removeAll()
+            for continuation in externalWorkflowCancelContinuations {
                 continuation.value.resume(throwing: error)
             }
 
@@ -758,6 +782,82 @@ struct WorkflowStateMachine: ~Copyable {
         case .active(var active):
             guard let continuation = active.externalWorkflowSignalContinuations.removeValue(forKey: sequenceNumber) else {
                 fatalError("Internal inconsistency: No continuation found for \(sequenceNumber)")
+            }
+
+            self = .init(state: .active(active))
+            return continuation
+        }
+    }
+
+    mutating func signalExternalWorkflow(
+        sequenceNumber: UInt32,
+        namespace: String,
+        workflowID: String,
+        runID: String?,
+        signalName: String,
+        headers: [String: Api.Common.V1.Payload],
+        inputs: [Api.Common.V1.Payload],
+        continuation: CheckedContinuation<Void, any Error>
+    ) {
+        switch consume self.state {
+        case .active(var active):
+            active.commands.append(
+                .with {
+                    $0.signalExternalWorkflowExecution = .with {
+                        $0.seq = sequenceNumber
+                        $0.workflowExecution = .with {
+                            $0.namespace = namespace
+                            $0.workflowID = workflowID
+                            $0.runID = runID ?? ""
+                        }
+                        $0.signalName = signalName
+                        $0.args = inputs
+                        $0.headers = headers
+                    }
+                }
+            )
+
+            active.externalWorkflowSignalContinuations[sequenceNumber] = continuation
+
+            self = .init(state: .active(active))
+        }
+    }
+
+    mutating func requestCancelExternalWorkflow(
+        sequenceNumber: UInt32,
+        namespace: String,
+        workflowID: String,
+        runID: String?,
+        continuation: CheckedContinuation<Void, any Error>
+    ) {
+        switch consume self.state {
+        case .active(var active):
+            active.commands.append(
+                .with {
+                    $0.requestCancelExternalWorkflowExecution = .with {
+                        $0.seq = sequenceNumber
+                        $0.workflowExecution = .with {
+                            $0.namespace = namespace
+                            $0.workflowID = workflowID
+                            $0.runID = runID ?? ""
+                        }
+                    }
+                }
+            )
+
+            active.externalWorkflowCancelContinuations[sequenceNumber] = continuation
+
+            self = .init(state: .active(active))
+        }
+    }
+
+    mutating func removeExternalWorkflowCancelContinuation(
+        sequenceNumber: UInt32
+    ) -> CheckedContinuation<Void, any Error> {
+        switch consume self.state {
+        case .active(var active):
+            guard let continuation = active.externalWorkflowCancelContinuations.removeValue(forKey: sequenceNumber) else {
+                fatalError("Internal inconsistency: No cancel continuation found for \(sequenceNumber)")
             }
 
             self = .init(state: .active(active))

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
@@ -433,6 +433,80 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
         }
     }
 
+    func signalExternalWorkflow(
+        namespace: String,
+        workflowID: String,
+        runID: String?,
+        signalName: String,
+        headers: [String: Api.Common.V1.Payload],
+        inputs: [Api.Common.V1.Payload]
+    ) async throws {
+        if Task.isCancelled {
+            throw CanceledError(
+                message: "Task cancelled before signal scheduled"
+            )
+        }
+
+        let sequenceNumber = self.stateMachine.nextExternalSignalSequenceNumber()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.stateMachine.signalExternalWorkflow(
+                    sequenceNumber: sequenceNumber,
+                    namespace: namespace,
+                    workflowID: workflowID,
+                    runID: runID,
+                    signalName: signalName,
+                    headers: headers,
+                    inputs: inputs,
+                    continuation: continuation
+                )
+            }
+        } onCancel: {
+            self.stateMachine.cancelExternalSignalWorkflow(sequenceNumber: sequenceNumber)
+        }
+    }
+
+    func cancelExternalWorkflow(
+        namespace: String,
+        workflowID: String,
+        runID: String?
+    ) async throws {
+        if Task.isCancelled {
+            throw CanceledError(
+                message: "Task cancelled before cancel request scheduled"
+            )
+        }
+
+        let sequenceNumber = self.stateMachine.nextExternalCancelSequenceNumber()
+        try await withCheckedThrowingContinuation { continuation in
+            self.stateMachine.requestCancelExternalWorkflow(
+                sequenceNumber: sequenceNumber,
+                namespace: namespace,
+                workflowID: workflowID,
+                runID: runID,
+                continuation: continuation
+            )
+        }
+    }
+
+    func resolveRequestCancelExternalWorkflow(
+        _ resolveRequestCancelExternalWorkflow: Coresdk.WorkflowActivation.ResolveRequestCancelExternalWorkflow
+    ) async {
+        let continuation = self.stateMachine.removeExternalWorkflowCancelContinuation(
+            sequenceNumber: resolveRequestCancelExternalWorkflow.seq
+        )
+
+        if resolveRequestCancelExternalWorkflow.hasFailure {
+            let error = self.failureConverter.convertFailure(
+                resolveRequestCancelExternalWorkflow.failure,
+                payloadConverter: self.payloadConverter
+            )
+            continuation.resume(throwing: error)
+        } else {
+            continuation.resume()
+        }
+    }
+
     func workflowFinished(temporalPayload: Api.Common.V1.Payload) {
         self.stateMachine.workflowFinished(temporalPayload: temporalPayload)
     }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowExternalWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowExternalWorkflowTests.swift
@@ -1,0 +1,301 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Synchronization
+import Temporal
+import TemporalTestKit
+import Testing
+
+extension TestServerDependentTests {
+    @Suite(.tags(.workflowTests))
+    struct WorkflowExternalWorkflowTests {
+        @Workflow
+        final class ExternalTargetWorkflow {
+            private var signals = [String]()
+            private var finished = false
+
+            func run(input: Void) async throws -> String {
+                try await Workflow.condition { self.finished }
+                return "done"
+            }
+
+            @WorkflowSignal
+            func signal(input: String) {
+                self.signals.append(input)
+            }
+
+            @WorkflowSignal
+            func finish(input: Void) {
+                self.finished = true
+            }
+
+            @WorkflowQuery
+            func getSignals(input: Void) -> [String] {
+                self.signals
+            }
+        }
+
+        @Workflow
+        final class SignalExternalWorkflow {
+            func run(input: String) async throws -> String {
+                let handle = Workflow.getExternalWorkflowHandle(
+                    ExternalTargetWorkflow.self,
+                    id: input
+                )
+                try await handle.signal(
+                    signalType: ExternalTargetWorkflow.Signal.self,
+                    input: "hello"
+                )
+                try await handle.signal(
+                    signalType: ExternalTargetWorkflow.Signal.self,
+                    input: "world"
+                )
+                return "signaled"
+            }
+        }
+
+        @Workflow
+        final class CancelExternalWorkflow {
+            func run(input: String) async throws -> String {
+                let handle = Workflow.getExternalWorkflowHandle(
+                    ExternalTargetWorkflow.self,
+                    id: input
+                )
+                try await handle.cancel()
+                return "cancelled"
+            }
+        }
+
+        @Workflow
+        final class SignalExternalWithInputWorkflow {
+            func run(input: String) async throws -> String {
+                let handle = Workflow.getExternalWorkflowHandle(id: input)
+                try await handle.signal(
+                    signalName: "Signal",
+                    input: "custom-signal-data"
+                )
+                return "signaled-with-input"
+            }
+        }
+
+        @Workflow
+        final class CancelExternalUntypedWorkflow {
+            func run(input: String) async throws -> String {
+                let handle = Workflow.getExternalWorkflowHandle(id: input)
+                try await handle.cancel()
+                return "cancelled-untyped"
+            }
+        }
+
+        @Test
+        func signalExternalWorkflow() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [
+                    ExternalTargetWorkflow.self,
+                    SignalExternalWorkflow.self,
+                ]
+            ) { taskQueue, client in
+                // Start the target workflow
+                let targetHandle = try await client.startWorkflow(
+                    type: ExternalTargetWorkflow.self,
+                    options: .init(id: "target-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: ()
+                )
+
+                // Start the parent workflow that signals the target
+                let parentResult = try await client.startWorkflow(
+                    type: SignalExternalWorkflow.self,
+                    options: .init(id: "parent-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: targetHandle.id
+                ).result()
+
+                #expect(parentResult == "signaled")
+
+                // Verify the signals were received
+                let signals = try await targetHandle.query(queryType: ExternalTargetWorkflow.GetSignals.self)
+                #expect(signals == ["hello", "world"])
+
+                // Finish the target workflow
+                try await targetHandle.signal(signalType: ExternalTargetWorkflow.Finish.self)
+                let targetResult = try await targetHandle.result()
+                #expect(targetResult == "done")
+            }
+        }
+
+        @Test
+        func cancelExternalWorkflow() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [
+                    ExternalTargetWorkflow.self,
+                    CancelExternalWorkflow.self,
+                ]
+            ) { taskQueue, client in
+                // Start the target workflow
+                let targetHandle = try await client.startWorkflow(
+                    type: ExternalTargetWorkflow.self,
+                    options: .init(id: "target-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: ()
+                )
+
+                // Start the parent workflow that cancels the target
+                let parentResult = try await client.startWorkflow(
+                    type: CancelExternalWorkflow.self,
+                    options: .init(id: "parent-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: targetHandle.id
+                ).result()
+
+                #expect(parentResult == "cancelled")
+
+                // Verify the target workflow was cancelled
+                let error = try await #require(throws: WorkflowFailedError.self) {
+                    try await targetHandle.result()
+                }
+                #expect(error.cause is CanceledError)
+            }
+        }
+
+        @Test
+        func signalExternalWorkflowWithInput() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [
+                    ExternalTargetWorkflow.self,
+                    SignalExternalWithInputWorkflow.self,
+                ]
+            ) { taskQueue, client in
+                // Start the target workflow
+                let targetHandle = try await client.startWorkflow(
+                    type: ExternalTargetWorkflow.self,
+                    options: .init(id: "target-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: ()
+                )
+
+                // Start the parent workflow that signals with custom input
+                let parentResult = try await client.startWorkflow(
+                    type: SignalExternalWithInputWorkflow.self,
+                    options: .init(id: "parent-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: targetHandle.id
+                ).result()
+
+                #expect(parentResult == "signaled-with-input")
+
+                // Verify the signal was received with the correct data
+                let signals = try await targetHandle.query(queryType: ExternalTargetWorkflow.GetSignals.self)
+                #expect(signals == ["custom-signal-data"])
+
+                // Finish the target workflow
+                try await targetHandle.signal(signalType: ExternalTargetWorkflow.Finish.self)
+                let targetResult = try await targetHandle.result()
+                #expect(targetResult == "done")
+            }
+        }
+
+        @Test
+        func interceptSignalExternalWorkflow() async throws {
+            final class CountingInterceptor: WorkerInterceptor {
+                let signalCount: Mutex<Int> = .init(0)
+                let cancelCount: Mutex<Int> = .init(0)
+
+                struct Outbound: WorkflowOutboundInterceptor {
+                    let interceptor: CountingInterceptor
+
+                    func signalExternalWorkflow<each Input>(
+                        input: SignalExternalWorkflowInput<repeat each Input>,
+                        next: (SignalExternalWorkflowInput<repeat each Input>) async throws -> Void
+                    ) async throws {
+                        interceptor.signalCount.withLock { $0 += 1 }
+                        try await next(input)
+                    }
+
+                    func cancelExternalWorkflow(
+                        input: CancelExternalWorkflowInput,
+                        next: (CancelExternalWorkflowInput) async throws -> Void
+                    ) async throws {
+                        interceptor.cancelCount.withLock { $0 += 1 }
+                        try await next(input)
+                    }
+                }
+
+                func makeWorkflowOutboundInterceptor() -> Outbound? {
+                    return Outbound(interceptor: self)
+                }
+            }
+
+            let interceptor = CountingInterceptor()
+
+            try await withTestWorkerAndClient(
+                interceptors: [interceptor],
+                workflows: [
+                    ExternalTargetWorkflow.self,
+                    SignalExternalWorkflow.self,
+                ]
+            ) { taskQueue, client in
+                // Start the target workflow
+                let targetHandle = try await client.startWorkflow(
+                    type: ExternalTargetWorkflow.self,
+                    options: .init(id: "target-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: ()
+                )
+
+                // Start the parent workflow that signals the target
+                let parentResult = try await client.startWorkflow(
+                    type: SignalExternalWorkflow.self,
+                    options: .init(id: "parent-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: targetHandle.id
+                ).result()
+
+                #expect(parentResult == "signaled")
+
+                // Verify interceptor was called for both signals
+                #expect(interceptor.signalCount.withLock { $0 } == 2)
+
+                // Finish the target workflow
+                try await targetHandle.signal(signalType: ExternalTargetWorkflow.Finish.self)
+                _ = try await targetHandle.result()
+            }
+        }
+
+        @Test
+        func cancelExternalWorkflowUntyped() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [
+                    ExternalTargetWorkflow.self,
+                    CancelExternalUntypedWorkflow.self,
+                ]
+            ) { taskQueue, client in
+                // Start the target workflow
+                let targetHandle = try await client.startWorkflow(
+                    type: ExternalTargetWorkflow.self,
+                    options: .init(id: "target-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: ()
+                )
+
+                // Start the parent workflow that cancels the target using untyped handle
+                let parentResult = try await client.startWorkflow(
+                    type: CancelExternalUntypedWorkflow.self,
+                    options: .init(id: "parent-wf-\(UUID().uuidString)", taskQueue: taskQueue),
+                    input: targetHandle.id
+                ).result()
+
+                #expect(parentResult == "cancelled-untyped")
+
+                // Verify the target workflow was cancelled
+                let error = try await #require(throws: WorkflowFailedError.self) {
+                    try await targetHandle.result()
+                }
+                #expect(error.cause is CanceledError)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability for workflows to signal and cancel arbitrary external workflows by ID, matching the C# and Ruby SDK capabilities.