### PR TITLE
Add `WorkflowReplayer`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -242,6 +242,9 @@ let package = Package(
                 .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
                 "Temporal",
                 "TemporalTestKit",
+            ],
+            resources: [
+                .copy("Worker/Histories")
             ]
         ),
         .testTarget(

--- a/Sources/Temporal/Bridge/BridgeReplayer.swift
+++ b/Sources/Temporal/Bridge/BridgeReplayer.swift
@@ -1,0 +1,247 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Bridge
+import Foundation
+internal import SwiftProtobuf
+
+package final class BridgeReplayer: Sendable {
+    /// The underlying worker pointer from the Core SDK.
+    private nonisolated(unsafe) let worker: OpaquePointer
+
+    /// The pusher pointer for pushing histories to the replayer.
+    private nonisolated(unsafe) let pusher: OpaquePointer
+
+    /// The runtime associated with this replayer.
+    private let runtime: BridgeRuntime
+
+    /// Creates a new bridge replayer.
+    ///
+    /// - Parameters:
+    ///   - runtime: The bridge runtime to use.
+    ///   - namespace: The namespace for replay context.
+    ///   - taskQueue: The task queue for replay context.
+    /// - Throws: An error if the replayer cannot be created.
+    init(
+        runtime: BridgeRuntime,
+        namespace: String,
+        taskQueue: String
+    ) throws {
+        self.runtime = runtime
+
+        var tuner = TemporalCoreTunerHolder()
+        tuner.workflow_slot_supplier.tag = FixedSize
+        tuner.workflow_slot_supplier.fixed_size.num_slots = 1
+        tuner.activity_slot_supplier.tag = FixedSize
+        tuner.activity_slot_supplier.fixed_size.num_slots = 0
+        tuner.local_activity_slot_supplier.tag = FixedSize
+        tuner.local_activity_slot_supplier.fixed_size.num_slots = 0
+        tuner.nexus_task_slot_supplier.tag = FixedSize
+        tuner.nexus_task_slot_supplier.fixed_size.num_slots = 0
+
+        let result = Self.withReplayerOptions(
+            namespace: namespace,
+            taskQueue: taskQueue,
+            tuner: tuner
+        ) { options in
+            temporal_core_worker_replayer_new(runtime.runtime, options)
+        }
+
+        if let fail = result.fail {
+            throw BridgeError(messagePointer: fail)
+        }
+
+        guard let worker = result.worker else {
+            throw BridgeError(message: "`temporal_core_worker_replayer_new()` returned nil worker")
+        }
+
+        guard let pusher = result.worker_replay_pusher else {
+            throw BridgeError(message: "`temporal_core_worker_replayer_new()` returned nil pusher")
+        }
+
+        self.worker = worker
+        self.pusher = pusher
+    }
+
+    deinit {
+        temporal_core_worker_replay_pusher_free(self.pusher)
+        temporal_core_worker_free(self.worker)
+    }
+
+    /// Pushes a workflow history for replay.
+    func pushHistory(workflowID: String, history: Data) throws {
+        let result = workflowID.withByteArrayRef { workflowIDRef in
+            history.withByteArrayRef { historyRef in
+                temporal_core_worker_replay_push(
+                    self.worker,
+                    self.pusher,
+                    workflowIDRef,
+                    historyRef
+                )
+            }
+        }
+
+        if let fail = result.fail {
+            throw BridgeError(messagePointer: fail)
+        }
+    }
+
+    // MARK: - BridgeWorkerProtocol Methods
+
+    /// Initiates shutdown of the replayer worker.
+    func initiateShutdown() {
+        temporal_core_worker_initiate_shutdown(self.worker)
+    }
+
+    /// Finalizes shutdown of the replayer worker.
+    func finalizeShutdown() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            let continuationHolder = ContinuationHolder(continuation)
+            let continuationHolderPointer = Unmanaged.passRetained(continuationHolder).toOpaque()
+            temporal_core_worker_finalize_shutdown(self.worker, continuationHolderPointer) { userData, failure in
+                let continuationHolder = Unmanaged<ContinuationHolder<Void>>.fromOpaque(userData!).takeRetainedValue()
+                if let failure {
+                    continuationHolder.continuation.resume(throwing: BridgeError(messagePointer: failure))
+                } else {
+                    continuationHolder.continuation.resume()
+                }
+            }
+        }
+    }
+
+    /// Polls for the next workflow activation.
+    func pollWorkflowActivation() async throws -> Coresdk.WorkflowActivation.WorkflowActivation {
+        let result: Data = try await withCheckedThrowingContinuation { continuation in
+            let holder = ContinuationHolder(continuation)
+            let holderPtr = Unmanaged.passRetained(holder).toOpaque()
+
+            temporal_core_worker_poll_workflow_activation(self.worker, holderPtr) { user_data, success, fail in
+                let holder = Unmanaged<ContinuationHolder<Data>>.fromOpaque(user_data!).takeRetainedValue()
+
+                switch (success, fail) {
+                // Success
+                case (.some(let success), nil):
+                    holder.continuation.resume(returning: Data(byteArrayPointer: success))
+
+                // Failure
+                case (nil, .some(let fail)):
+                    holder.continuation.resume(throwing: BridgeError(messagePointer: fail))
+
+                // Cancelled
+                case (nil, nil):
+                    holder.continuation.resume(throwing: CancellationError())
+
+                default:
+                    holder.continuation.resume(
+                        throwing:
+                            BridgeError(
+                                message:
+                                    "Unexpected result from worker_poll_workflow_activation, both success and fail are set"
+                            )
+                    )
+                }
+            }
+        }
+
+        return try Coresdk.WorkflowActivation.WorkflowActivation(serializedBytes: result)
+    }
+
+    /// Completes a workflow activation.
+    func completeWorkflowActivation(
+        completion: Coresdk.WorkflowCompletion.WorkflowActivationCompletion
+    ) async throws {
+        let completionBytes = try completion.serializedData()
+        try await withCheckedThrowingContinuation { continuation in
+            let holder = ContinuationHolder<Void>(continuation)
+            let holderPtr = Unmanaged.passRetained(holder).toOpaque()
+
+            completionBytes.withByteArrayRef { completionBytesRef in
+                temporal_core_worker_complete_workflow_activation(
+                    self.worker,
+                    completionBytesRef,
+                    holderPtr
+                ) { user_data, fail in
+                    let holder = Unmanaged<ContinuationHolder<Void>>.fromOpaque(user_data!).takeRetainedValue()
+
+                    if let fail {
+                        holder.continuation.resume(throwing: BridgeError(messagePointer: fail))
+                    } else {
+                        holder.continuation.resume()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    /// Creates worker options for the replayer.
+    private static func withReplayerOptions<T>(
+        namespace: String,
+        taskQueue: String,
+        tuner: TemporalCoreTunerHolder,
+        _ body: (UnsafePointer<TemporalCoreWorkerOptions>) throws -> T
+    ) rethrows -> T {
+        try namespace.withByteArrayRef { namespaceRef in
+            try taskQueue.withByteArrayRef { taskQueueRef in
+                // Create a minimal versioning strategy (none)
+                try "".withByteArrayRef { emptyRef in
+                    var versioningStrategy = TemporalCoreWorkerVersioningStrategy()
+                    versioningStrategy.tag = None
+                    versioningStrategy.none = TemporalCoreWorkerVersioningNone(build_id: emptyRef)
+
+                    // Create simple maximum poller behavior
+                    // Must be created inside withUnsafePointer to keep it alive
+                    let simpleMaximum = TemporalCorePollerBehaviorSimpleMaximum(simple_maximum: 2)
+                    return try withUnsafePointer(to: simpleMaximum) { simpleMaxPtr in
+                        let pollerBehavior = TemporalCorePollerBehavior(
+                            simple_maximum: simpleMaxPtr,
+                            autoscaling: nil
+                        )
+
+                        var opts = TemporalCoreWorkerOptions(
+                            namespace_: namespaceRef,
+                            task_queue: taskQueueRef,
+                            versioning_strategy: versioningStrategy,
+                            identity_override: emptyRef,
+                            max_cached_workflows: 1,
+                            tuner: tuner,
+                            task_types: TemporalCoreWorkerTaskTypes(
+                                enable_workflows: true,
+                                enable_local_activities: false,
+                                enable_remote_activities: false,
+                                enable_nexus: false
+                            ),
+                            sticky_queue_schedule_to_start_timeout_millis: 10_000,
+                            max_heartbeat_throttle_interval_millis: 60_000,
+                            default_heartbeat_throttle_interval_millis: 30_000,
+                            max_activities_per_second: 0,
+                            max_task_queue_activities_per_second: 0,
+                            graceful_shutdown_period_millis: 0,
+                            workflow_task_poller_behavior: pollerBehavior,
+                            nonsticky_to_sticky_poll_ratio: 0.2,
+                            activity_task_poller_behavior: pollerBehavior,
+                            nexus_task_poller_behavior: pollerBehavior,
+                            nondeterminism_as_workflow_fail: true,
+                            nondeterminism_as_workflow_fail_for_types: .init(),
+                            plugins: .init()
+                        )
+
+                        return try body(&opts)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowHandle+Operations.swift
+++ b/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowHandle+Operations.swift
@@ -90,6 +90,33 @@ extension UntypedWorkflowHandle {
         )
     }
 
+    /// Fetches the complete execution history for this workflow.
+    ///
+    /// - Parameters:
+    ///   - waitNewEvent: Whether to wait for new events if none are immediately available.
+    ///   - eventFilterType: The type of events to include in the response.
+    ///   - skipArchival: Whether to skip archived history events for performance.
+    ///   - callOptions: Optional gRPC call options for customizing the behavior of the underlying request.
+    /// - Returns: An array of history events representing the workflow's execution timeline.
+    /// - Throws: An error if the history cannot be retrieved or the workflow doesn't exist.
+    public func fetchHistory(
+        waitNewEvent: Bool = false,
+        eventFilterType: Api.Enums.V1.HistoryEventFilterType = .allEvent,
+        skipArchival: Bool = false,
+        callOptions: CallOptions? = nil
+    ) async throws -> WorkflowHistory {
+        return try await WorkflowHistory(
+            events:
+                self
+                .fetchHistoryEvents(
+                    waitNewEvent: waitNewEvent,
+                    eventFilterType: eventFilterType,
+                    skipArchival: skipArchival,
+                    callOptions: callOptions
+                )
+        )
+    }
+
     // MARK: Signals
 
     /// Sends a signal to the workflow execution with typed input data.

--- a/Sources/Temporal/Client/Handles/Workflow/WorkflowHandle+Operations.swift
+++ b/Sources/Temporal/Client/Handles/Workflow/WorkflowHandle+Operations.swift
@@ -71,6 +71,24 @@ extension WorkflowHandle {
         )
     }
 
+    /// Fetches the complete execution history for this workflow.
+    ///
+    /// - Parameters:
+    ///   - waitNewEvent: Whether to wait for new events if none are immediately available.
+    ///   - eventFilterType: The type of events to include in the response.
+    ///   - skipArchival: Whether to skip archived history events for performance.
+    ///   - callOptions: Optional gRPC call options for customizing the behavior of the underlying request.
+    /// - Returns: An array of history events representing the workflow's execution timeline.
+    /// - Throws: An error if the history cannot be retrieved or the workflow doesn't exist.
+    public func fetchHistory(
+        waitNewEvent: Bool = false,
+        eventFilterType: Api.Enums.V1.HistoryEventFilterType = .allEvent,
+        skipArchival: Bool = false,
+        callOptions: CallOptions? = nil
+    ) async throws -> WorkflowHistory {
+        try await self.untypedHandle.fetchHistory(callOptions: callOptions)
+    }
+
     // MARK: Signals
 
     /// Sends a signal to the workflow execution with typed input data.

--- a/Sources/Temporal/Errors/WorkflowNondeterminismError.swift
+++ b/Sources/Temporal/Errors/WorkflowNondeterminismError.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Error thrown when workflowdoes something potentially non-deterministic such as making an illegal call.
+public struct WorkflowNondeterminismError: TemporalError {
+    /// The error message describing the non-determinism.
+    public var message: String
+
+    /// The cause of the error, if any.
+    public var cause: (any Error)?
+
+    /// The stack trace at the point of failure.
+    public var stackTrace: String
+
+    /// Creates a new non-determinism error.
+    ///
+    /// - Parameters:
+    ///   - message: The error message describing the non-determinism.
+    ///   - cause: The underlying cause, if any.
+    ///   - stackTrace: The stack trace at the point of failure.
+    public init(
+        message: String,
+        cause: (any Error)? = nil,
+        stackTrace: String = ""
+    ) {
+        self.message = message
+        self.cause = cause
+        self.stackTrace = stackTrace
+    }
+}

--- a/Sources/Temporal/Replayer/WorkflowHistory.swift
+++ b/Sources/Temporal/Replayer/WorkflowHistory.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+public import Foundation
+internal import SwiftProtobuf
+
+/// Represents a workflow's execution history for replay purposes.
+public struct WorkflowHistory: Sendable {
+    /// The workflow ID this history belongs to.
+    public let id: String
+
+    /// The history events for the workflow execution.
+    public let events: [Api.History.V1.HistoryEvent]
+
+    /// Creates a new workflow history.
+    ///
+    /// - Parameters:
+    ///   - events: The history events for the workflow execution.
+    public init(events: [Api.History.V1.HistoryEvent]) throws {
+        self.events = events
+        guard case let .workflowExecutionStartedEventAttributes(workflowExecutionsStartedEventAttributes) = events.first?.attributes else {
+            throw ArgumentError(message: "First event not a start event")
+        }
+        self.id = workflowExecutionsStartedEventAttributes.workflowID
+    }
+
+    /// Creates a workflow history by parsing JSON data.
+    ///
+    /// This method handles JSON in the format produced by:
+    /// - Temporal CLI: `temporal workflow show --output=json`
+    /// - Temporal UI: Exported history download
+    /// - SDK's own ``toJSON()`` method
+    ///
+    /// - Parameters:
+    ///   - workflowID: The workflow ID.
+    ///   - jsonData: The JSON data containing the history.
+    /// - Returns: A ``WorkflowHistory`` instance parsed from the JSON.
+    /// - Throws: ``ArgumentError`` if the JSON cannot be parsed or is invalid.
+    public static func fromJSON(
+        workflowID: String,
+        jsonData: Data
+    ) throws -> WorkflowHistory {
+        // Parse using protobuf JSON decoder with ignoreUnknownFields to handle
+        // CLI/UI exports that may contain extra fields
+        var decodingOptions = JSONDecodingOptions()
+        decodingOptions.ignoreUnknownFields = true
+
+        let protoHistory: Api.History.V1.History
+        do {
+            protoHistory = try Api.History.V1.History(
+                jsonUTF8Data: jsonData,
+                options: decodingOptions
+            )
+        } catch {
+            throw ArgumentError(
+                message: "Failed to parse history JSON as protobuf",
+                cause: error
+            )
+        }
+
+        return try WorkflowHistory(
+            events: Array(protoHistory.events)
+        )
+    }
+
+    /// Converts this history to JSON.
+    ///
+    /// - Returns: A JSON string representation of the history.
+    /// - Throws: An error if serialization fails.
+    public func toJSON() throws -> Data {
+        let history = Api.History.V1.History.with {
+            $0.events = self.events
+        }
+        return try history.jsonUTF8Data()
+    }
+}

--- a/Sources/Temporal/Replayer/WorkflowHistoryRunner.swift
+++ b/Sources/Temporal/Replayer/WorkflowHistoryRunner.swift
@@ -1,0 +1,283 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+internal import SwiftProtobuf
+
+import struct Foundation.Data
+
+/// Internal runner for workflow history replay.
+package final class WorkflowHistoryRunner: Sendable {
+    /// The bridge replayer instance.
+    private let bridgeReplayer: BridgeReplayer
+
+    /// The configuration for the replayer.
+    private let configuration: WorkflowReplayer.Configuration
+
+    /// The runtime used for the replayer.
+    private let runtime: BridgeRuntime
+
+    init(configuration: WorkflowReplayer.Configuration) throws {
+        self.configuration = configuration
+        self.runtime = try BridgeRuntime()
+        self.bridgeReplayer = try BridgeReplayer(
+            runtime: self.runtime,
+            namespace: configuration.namespace,
+            taskQueue: configuration.taskQueue
+        )
+    }
+
+    /// Replays a single workflow history..
+    func replayWorkflow(
+        history: WorkflowHistory,
+        throwOnReplayFailure: Bool
+    ) async throws -> WorkflowReplayResult {
+        // Serialize the history to protobuf bytes
+        let historyData = try Api.History.V1.History
+            .with { $0.events = history.events }
+            .serializedData()
+
+        var logger = self.configuration.logger
+        logger[metadataKey: LoggingKeys.workflowID] = "\(history.id)"
+
+        // Create a result box to capture the replay result
+        let resultBox = ReplayResultBox()
+
+        // Create the replay bridge worker
+        let replayBridgeWorker = ReplayBridgeWorker(
+            bridgeReplayer: self.bridgeReplayer,
+            resultBox: resultBox,
+            history: history,
+            throwOnReplayFailure: throwOnReplayFailure
+        )
+
+        // Create the workflow worker with replay bridge
+        let workflowWorker = try WorkflowWorker(
+            worker: replayBridgeWorker,
+            taskQueue: self.configuration.taskQueue,
+            namespace: self.configuration.namespace,
+            dataConverter: self.configuration.dataConverter,
+            workflows: self.configuration.workflows,
+            interceptors: self.configuration.interceptors,
+            logger: logger
+        )
+
+        // Run replay following the pattern from TemporalWorker
+        let result = try await self.runReplayWorker(
+            replayBridgeWorker: replayBridgeWorker,
+            workflowWorker: workflowWorker,
+            resultBox: resultBox,
+            history: history,
+            historyData: historyData
+        )
+
+        guard let failure = result.replayFailure, throwOnReplayFailure else {
+            return result
+        }
+        throw failure
+    }
+
+    /// Runs the replay worker with proper cancellation handling.
+    private func runReplayWorker(
+        replayBridgeWorker: ReplayBridgeWorker,
+        workflowWorker: WorkflowWorker<ReplayBridgeWorker>,
+        resultBox: ReplayResultBox,
+        history: WorkflowHistory,
+        historyData: Data
+    ) async throws -> WorkflowReplayResult {
+        await withTaskCancellationHandler {
+            // Block cancellation from propagating inwards, similar to TemporalWorker
+            await Task {
+                await withTaskGroup(of: Void.self) { group in
+                    // Start the worker running in the background
+                    group.addTask {
+                        do {
+                            self.configuration.logger.debug("Starting replay workflow worker")
+                            try await workflowWorker.run()
+                        } catch {
+                            // Worker encountered an error - this triggers shutdown
+                            self.configuration.logger.debug(
+                                "Replay worker encountered error",
+                                metadata: [
+                                    LoggingKeys.errorType: "\(type(of: error))",
+                                    LoggingKeys.errorMessage: "\(error)",
+                                ]
+                            )
+                        }
+                    }
+
+                    // Push the history and wait for RemoveFromCache
+                    let result = await withCheckedContinuation { continuation in
+                        // Store the continuation in the result box
+                        resultBox.setContinuation(continuation)
+
+                        // Push the history to the replayer
+                        do {
+                            try self.bridgeReplayer.pushHistory(
+                                workflowID: history.id,
+                                history: historyData
+                            )
+                        } catch {
+                            fatalError("Failed to push history to replayer")
+                        }
+                    }
+
+                    // Got the result from replay completion
+                    // Now initiate shutdown and clean up
+                    self.configuration.logger.debug("Replay complete, initiating shutdown")
+                    replayBridgeWorker.initiateShutdown()
+
+                    // Cancel remaining tasks
+                    group.cancelAll()
+
+                    // Wait for worker to finish cleaning up
+                    _ = await group.next()
+                    return result
+                }
+            }.value
+        } onCancel: {
+            // Handle cancellation by initiating shutdown
+            self.configuration.logger.debug("Replay cancelled, initiating shutdown")
+            replayBridgeWorker.initiateShutdown()
+        }
+    }
+}
+
+/// A box for capturing the replay result and managing the continuation.
+private final class ReplayResultBox: @unchecked Sendable {
+    private var continuation: CheckedContinuation<WorkflowReplayResult, Never>?
+    private var history: WorkflowHistory?
+    private var throwOnReplayFailure: Bool = false
+
+    func setContinuation(_ continuation: CheckedContinuation<WorkflowReplayResult, Never>) {
+        self.continuation = continuation
+    }
+
+    func setHistory(_ history: WorkflowHistory, throwOnReplayFailure: Bool) {
+        self.history = history
+        self.throwOnReplayFailure = throwOnReplayFailure
+    }
+
+    func resumeWithResult(failure: (any Error)?) {
+        guard let continuation = self.continuation,
+            let history = self.history
+        else {
+            return
+        }
+
+        self.continuation = nil
+
+        let result = WorkflowReplayResult(history: history, replayFailure: failure)
+        continuation.resume(returning: result)
+    }
+}
+
+/// A bridge worker implementation for replay that wraps the BridgeReplayer.
+package final class ReplayBridgeWorker: BridgeWorkerProtocol {
+    private let bridgeReplayer: BridgeReplayer
+    private let resultBox: ReplayResultBox
+    private let history: WorkflowHistory
+    private let throwOnReplayFailure: Bool
+
+    fileprivate init(
+        bridgeReplayer: BridgeReplayer,
+        resultBox: ReplayResultBox,
+        history: WorkflowHistory,
+        throwOnReplayFailure: Bool
+    ) {
+        self.bridgeReplayer = bridgeReplayer
+        self.resultBox = resultBox
+        self.history = history
+        self.throwOnReplayFailure = throwOnReplayFailure
+
+        // Store history in result box for later use
+        resultBox.setHistory(history, throwOnReplayFailure: throwOnReplayFailure)
+    }
+
+    package init(
+        client: borrowing BridgeClient,
+        configuration: TemporalWorker.Configuration,
+        hasActivities: Bool,
+        hasWorkflows: Bool
+    ) throws {
+        fatalError("ReplayBridgeWorker should not be created with BridgeClient")
+    }
+
+    package func initiateShutdown() {
+        bridgeReplayer.initiateShutdown()
+    }
+
+    package func finalizeShutdown() async throws {
+        try await bridgeReplayer.finalizeShutdown()
+    }
+
+    package func pollWorkflowActivation() async throws -> Coresdk.WorkflowActivation.WorkflowActivation {
+        let activation = try await bridgeReplayer.pollWorkflowActivation()
+
+        // Check for RemoveFromCache and capture the eviction reason
+        for job in activation.jobs {
+            if case .removeFromCache(let removeFromCache) = job.variant {
+                // Capture any failure from the eviction reason
+                let failure = self.failureFromEvictionReason(
+                    reason: removeFromCache.reason,
+                    message: removeFromCache.message
+                )
+
+                // Resume the continuation with the result
+                self.resultBox.resumeWithResult(failure: failure)
+            }
+        }
+
+        return activation
+    }
+
+    package func completeWorkflowActivation(
+        completion: Coresdk.WorkflowCompletion.WorkflowActivationCompletion
+    ) async throws {
+        try await bridgeReplayer.completeWorkflowActivation(completion: completion)
+    }
+
+    package func pollActivityTask() async throws -> Coresdk.ActivityTask.ActivityTask {
+        throw InvalidOperationError(message: "Activities are not supported during replay")
+    }
+
+    package func completeActivityTask(_ completion: Coresdk.ActivityTaskCompletion) async throws {
+        throw InvalidOperationError(message: "Activities are not supported during replay")
+    }
+
+    package func recordActivityHeartbeat(_ heartbeat: Coresdk.ActivityHeartbeat) throws {
+        throw InvalidOperationError(message: "Activities are not supported during replay")
+    }
+
+    /// Converts an eviction reason to an appropriate error.
+    private func failureFromEvictionReason(
+        reason: Coresdk.WorkflowActivation.RemoveFromCache.EvictionReason,
+        message: String
+    ) -> (any Error)? {
+        switch reason {
+        case .nondeterminism:
+            return WorkflowNondeterminismError(message: message)
+        case .cacheFull, .langRequested, .workflowExecutionEnding:
+            // Normal completion - no failure
+            return nil
+        case .langFail, .fatal, .unhandledCommand:
+            return InvalidOperationError(message: "\(reason): \(message)")
+        case .unspecified, .cacheMiss, .taskNotFound, .paginationOrHistoryFetch:
+            // Unexpected reasons - treat as errors
+            return InvalidOperationError(message: "\(reason): \(message)")
+        case .UNRECOGNIZED(let code):
+            return InvalidOperationError(message: "Unrecognized eviction reason (\(code)): \(message)")
+        }
+    }
+}

--- a/Sources/Temporal/Replayer/WorkflowReplayResult.swift
+++ b/Sources/Temporal/Replayer/WorkflowReplayResult.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// The result of replaying a workflow from history.
+public struct WorkflowReplayResult: Sendable {
+    /// The history that was replayed.
+    public var history: WorkflowHistory
+
+    /// The replay failure, if any occurred.
+    ///
+    /// This property is `nil` for successful replays. When a replay fails, this
+    /// will contain one of the following error types:
+    ///
+    /// - ``WorkflowNondeterminismError``: The workflow code has changed in a way
+    ///   that is incompatible with the recorded history
+    /// - ``InvalidOperationError``: An unexpected error occurred during replay
+    ///
+    /// Note: Normal workflow failures (e.g., ``ApplicationError`` thrown by the
+    /// workflow) are not captured here as they represent valid workflow behavior
+    /// that was correctly replayed.
+    public var replayFailure: (any Error)?
+
+    /// Creates a new replay result.
+    ///
+    /// - Parameters:
+    ///   - history: The history that was replayed.
+    ///   - replayFailure: The replay failure, if any occurred.
+    public init(history: WorkflowHistory, replayFailure: (any Error)? = nil) {
+        self.history = history
+        self.replayFailure = replayFailure
+    }
+}

--- a/Sources/Temporal/Replayer/WorkflowReplayer+Configuration.swift
+++ b/Sources/Temporal/Replayer/WorkflowReplayer+Configuration.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+public import Logging
+
+extension WorkflowReplayer {
+    /// Configuration options for a ``WorkflowReplayer``.
+    public struct Configuration: Sendable {
+        /// The workflow types registered for replay.
+        public var workflows: [any WorkflowDefinition.Type]
+
+        /// The namespace used for replay context.
+        public var namespace: String
+
+        /// The task queue used for replay context.
+        public var taskQueue: String
+
+        /// The data converter used for serializing and deserializing payloads.
+        public var dataConverter: DataConverter
+
+        /// The interceptors to apply during replay.
+        public var interceptors: [any WorkerInterceptor]
+
+        /// A logger for diagnostic output during replay.
+        public var logger: Logger
+
+        /// Creates a new replayer configuration.
+        ///
+        /// - Parameters:
+        ///   - workflows: The workflow types to register for replay. At least one workflow
+        ///     must be registered before creating a replayer.
+        ///   - namespace: The namespace for replay context. Defaults to `"ReplayNamespace"`.
+        ///   - taskQueue: The task queue for replay context. Defaults to `"ReplayTaskQueue"`.
+        ///   - dataConverter: The data converter for payload serialization. Defaults to
+        ///     ``DataConverter/default``.
+        ///   - interceptors: The interceptors to apply during replay. Defaults to an empty
+        ///     array (no interceptors).
+        ///   - logger: The logger for diagnostic output. Defaults to a logger with label
+        ///     `"WorkflowReplayer"`.
+        public init(
+            workflows: [any WorkflowDefinition.Type] = [],
+            namespace: String = "ReplayNamespace",
+            taskQueue: String = "ReplayTaskQueue",
+            dataConverter: DataConverter = .default,
+            interceptors: [any WorkerInterceptor] = [],
+            logger: Logger = Logger(label: "WorkflowReplayer")
+        ) {
+            self.workflows = workflows
+            self.namespace = namespace
+            self.taskQueue = taskQueue
+            self.dataConverter = dataConverter
+            self.interceptors = interceptors
+            self.logger = logger
+        }
+    }
+}

--- a/Sources/Temporal/Replayer/WorkflowReplayer.swift
+++ b/Sources/Temporal/Replayer/WorkflowReplayer.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Replays workflow histories to verify workflow code compatibility.
+///
+/// ``WorkflowReplayer`` is used for testing workflow code changes against recorded
+/// execution histories. It helps detect non-deterministic changes before they cause
+/// production failures by running workflow code against historical events without
+/// connecting to a Temporal server.
+///
+/// ## Usage
+///
+/// Create a replayer with the workflow types you want to test:
+///
+/// ```swift
+/// var config = WorkflowReplayer.Configuration()
+/// config.workflows.append(MyWorkflow.self)
+/// config.workflows.append(AnotherWorkflow.self)
+///
+/// let replayer = WorkflowReplayer(configuration: config)
+///
+/// let history = try WorkflowHistory.fromJSON(
+///     workflowID: "my-workflow-123",
+///     json: jsonString
+/// )
+///
+/// let result = try await replayer.replayWorkflow(history: history)
+/// print("Replay succeeded: \(result.succeeded)")
+/// ```
+public final class WorkflowReplayer: Sendable {
+    /// The configuration for this replayer.
+    private let configuration: Configuration
+
+    /// Creates a new workflow replayer with the given configuration.
+    ///
+    /// At least one workflow must be registered in the configuration.
+    ///
+    /// - Parameter configuration: The configuration specifying which workflows to replay
+    ///   and how to process them.
+    public init(configuration: Configuration) {
+        precondition(
+            !configuration.workflows.isEmpty,
+            "At least one workflow must be registered with the replayer"
+        )
+        self.configuration = configuration
+    }
+
+    /// Replays a single workflow history.
+    ///
+    /// - Parameters:
+    ///   - history: The workflow history to replay.
+    ///   - throwOnReplayFailure: If `true` (the default), throws an error when replay
+    ///     fails due to non-determinism or other issues. If `false`, returns a result
+    ///     with the failure information.
+    /// - Returns: A ``WorkflowReplayResult`` containing the replay outcome.
+    /// - Throws: ``WorkflowNondeterminismError`` if the workflow code is incompatible
+    ///   with the history and `throwOnReplayFailure` is `true`. Other errors may be
+    ///   thrown for infrastructure failures.
+    public func replayWorkflow(
+        history: WorkflowHistory,
+        throwOnReplayFailure: Bool = true
+    ) async throws -> WorkflowReplayResult {
+        let runner = try WorkflowHistoryRunner(configuration: self.configuration)
+        return try await runner.replayWorkflow(
+            history: history,
+            throwOnReplayFailure: throwOnReplayFailure
+        )
+    }
+
+    /// Replays multiple workflow histories.
+    ///
+    /// - Parameters:
+    ///   - histories: The workflow histories to replay.
+    ///   - throwOnReplayFailure: If `true` (the default), throws on the first replay
+    ///     failure. If `false`, continues replaying all histories and returns results
+    ///     for each.
+    /// - Returns: An array of ``WorkflowReplayResult`` containing the outcome for each
+    ///   history, in the same order as the input.
+    /// - Throws: ``WorkflowNondeterminismError`` if any workflow code is incompatible
+    ///   with its history and `throwOnReplayFailure` is `true`.
+    public func replayWorkflows(
+        histories: [WorkflowHistory],
+        throwOnReplayFailure: Bool = true
+    ) async throws -> [WorkflowReplayResult] {
+        var results: [WorkflowReplayResult] = []
+        results.reserveCapacity(histories.count)
+
+        for history in histories {
+            let result = try await self.replayWorkflow(
+                history: history,
+                throwOnReplayFailure: throwOnReplayFailure
+            )
+            results.append(result)
+        }
+
+        return results
+    }
+}

--- a/Sources/Temporal/Worker/Workflow/WorkflowWorker.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowWorker.swift
@@ -254,17 +254,23 @@ package final class WorkflowWorker<BridgeWorker: BridgeWorkerProtocol>: Workflow
             let (activationsStream, activationsContinuation) = AsyncStream<Coresdk.WorkflowActivation.WorkflowActivation>.makeStream()
             runningWorkflows[runID] = activationsContinuation
             taskGroup.addTask {
-                self.logger.trace("Running workflow instance")
+                logger.trace("Running workflow instance")
                 do {
                     try await workflowInstance.run(
                         workflowType: workflowType,
                         activations: activationsStream
                     )
-                    self.logger.trace("Workflow instance finished")
+                    logger.trace("Workflow instance finished")
                 } catch {
                     // TODO: We should probably log an error here and let it all tear down
                     // since this can only happen if we failed to send a completion to the worker
-                    self.logger.error("Workflow instance failed to send a completion")
+                    logger.info(
+                        "Workflow instance failed to send a completion",
+                        metadata: [
+                            LoggingKeys.errorType: "\(type(of: error))",
+                            LoggingKeys.errorMessage: "\(error)",
+                        ]
+                    )
                 }
             }
             return activationsContinuation

--- a/Tests/TemporalTests/Worker/Histories/replayer-test.complete.json
+++ b/Tests/TemporalTests/Worker/Histories/replayer-test.complete.json
@@ -1,0 +1,216 @@
+{
+    "events": [
+        {
+            "eventId": "1",
+            "eventTime": "2026-02-16T14:18:03.073125Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+            "taskId": "1048587",
+            "workflowExecutionStartedEventAttributes": {
+                "workflowType": {
+                    "name": "SayHelloWorkflow"
+                },
+                "taskQueue": {
+                    "name": "BA0C76B8-F38B-4303-B785-1ED6FE488A4A",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "input": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "eyJuYW1lIjoiVGVtcG9yYWwiLCJzaG91bGRXYWl0IjpmYWxzZSwic2hvdWxkRXJyb3IiOmZhbHNlLCJzaG91bGRDYXVzZU5vbkRldGVybWluaXNtIjpmYWxzZX0="
+                        }
+                    ]
+                },
+                "workflowTaskTimeout": "10s",
+                "originalExecutionRunId": "019c66d0-c1c1-71e8-b0f3-3e572576cf6c",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)",
+                "firstExecutionRunId": "019c66d0-c1c1-71e8-b0f3-3e572576cf6c",
+                "attempt": 1,
+                "firstWorkflowTaskBackoff": "0s",
+                "workflowId": "replayer-test-simple-2F1AA4EC-5C82-4E8D-819E-5BFE6FD7312E"
+            }
+        },
+        {
+            "eventId": "2",
+            "eventTime": "2026-02-16T14:18:03.073197Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+            "taskId": "1048588",
+            "workflowTaskScheduledEventAttributes": {
+                "taskQueue": {
+                    "name": "BA0C76B8-F38B-4303-B785-1ED6FE488A4A",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "startToCloseTimeout": "10s",
+                "attempt": 1
+            }
+        },
+        {
+            "eventId": "3",
+            "eventTime": "2026-02-16T14:18:05.078125Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+            "taskId": "1048593",
+            "workflowTaskStartedEventAttributes": {
+                "scheduledEventId": "2",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-4E2A9",
+                "requestId": "46727192-9224-438f-b357-2ea0013b798b",
+                "historySizeBytes": "499"
+            }
+        },
+        {
+            "eventId": "4",
+            "eventTime": "2026-02-16T14:18:05.098268Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+            "taskId": "1048597",
+            "workflowTaskCompletedEventAttributes": {
+                "scheduledEventId": "2",
+                "startedEventId": "3",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-4E2A9",
+                "workerVersion": {},
+                "sdkMetadata": {
+                    "coreUsedFlags": [
+                        1,
+                        2,
+                        3
+                    ],
+                    "sdkName": "swift-temporal",
+                    "sdkVersion": "16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)"
+                },
+                "meteringMetadata": {}
+            }
+        },
+        {
+            "eventId": "5",
+            "eventTime": "2026-02-16T14:18:05.098338Z",
+            "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+            "taskId": "1048598",
+            "activityTaskScheduledEventAttributes": {
+                "activityId": "0",
+                "activityType": {
+                    "name": "ReplayActivity"
+                },
+                "taskQueue": {
+                    "name": "BA0C76B8-F38B-4303-B785-1ED6FE488A4A",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "header": {},
+                "input": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "IlRlbXBvcmFsIg=="
+                        }
+                    ]
+                },
+                "scheduleToCloseTimeout": "60s",
+                "scheduleToStartTimeout": "60s",
+                "startToCloseTimeout": "60s",
+                "heartbeatTimeout": "0s",
+                "workflowTaskCompletedEventId": "4",
+                "retryPolicy": {
+                    "initialInterval": "1s",
+                    "backoffCoefficient": 2,
+                    "maximumInterval": "100s"
+                },
+                "useWorkflowBuildId": true
+            }
+        },
+        {
+            "eventId": "6",
+            "eventTime": "2026-02-16T14:18:05.099677Z",
+            "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+            "taskId": "1048605",
+            "activityTaskStartedEventAttributes": {
+                "scheduledEventId": "5",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-4E2A9",
+                "requestId": "7897b9c0-9721-48a5-a2f3-395cbbd7598f",
+                "attempt": 1,
+                "workerVersion": {}
+            }
+        },
+        {
+            "eventId": "7",
+            "eventTime": "2026-02-16T14:18:05.111432Z",
+            "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+            "taskId": "1048606",
+            "activityTaskCompletedEventAttributes": {
+                "result": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "IkhlbGxvLCBUZW1wb3JhbCEi"
+                        }
+                    ]
+                },
+                "scheduledEventId": "5",
+                "startedEventId": "6",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-4E2A9"
+            }
+        },
+        {
+            "eventId": "8",
+            "eventTime": "2026-02-16T14:18:05.111435Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+            "taskId": "1048607",
+            "workflowTaskScheduledEventAttributes": {
+                "taskQueue": {
+                    "name": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-4E2A9-15b710ea9caf42e38a84622619ceff4f",
+                    "kind": "TASK_QUEUE_KIND_STICKY",
+                    "normalName": "BA0C76B8-F38B-4303-B785-1ED6FE488A4A"
+                },
+                "startToCloseTimeout": "10s",
+                "attempt": 1
+            }
+        },
+        {
+            "eventId": "9",
+            "eventTime": "2026-02-16T14:18:05.112191Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+            "taskId": "1048611",
+            "workflowTaskStartedEventAttributes": {
+                "scheduledEventId": "8",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-4E2A9",
+                "requestId": "0ddbcfe6-9aa8-426c-a414-5829b78c9941",
+                "historySizeBytes": "1477"
+            }
+        },
+        {
+            "eventId": "10",
+            "eventTime": "2026-02-16T14:18:05.118549Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+            "taskId": "1048615",
+            "workflowTaskCompletedEventAttributes": {
+                "scheduledEventId": "8",
+                "startedEventId": "9",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-4E2A9",
+                "workerVersion": {},
+                "sdkMetadata": {},
+                "meteringMetadata": {}
+            }
+        },
+        {
+            "eventId": "11",
+            "eventTime": "2026-02-16T14:18:05.118581Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+            "taskId": "1048616",
+            "workflowExecutionCompletedEventAttributes": {
+                "result": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "IkhlbGxvLCBUZW1wb3JhbCEi"
+                        }
+                    ]
+                },
+                "workflowTaskCompletedEventId": "10"
+            }
+        }
+    ]
+}

--- a/Tests/TemporalTests/Worker/Histories/replayer-test.nondeterministic.json
+++ b/Tests/TemporalTests/Worker/Histories/replayer-test.nondeterministic.json
@@ -1,0 +1,216 @@
+{
+    "events": [
+        {
+            "eventId": "1",
+            "eventTime": "2026-02-16T14:27:04.925844Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+            "taskId": "1048587",
+            "workflowExecutionStartedEventAttributes": {
+                "workflowType": {
+                    "name": "SayHelloWorkflow"
+                },
+                "taskQueue": {
+                    "name": "86186999-3E6A-45A0-932A-B35ED0811A8C",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "input": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "eyJuYW1lIjoiVGVtcG9yYWwiLCJzaG91bGRFcnJvciI6ZmFsc2UsInNob3VsZENhdXNlTm9uRGV0ZXJtaW5pc20iOnRydWUsInNob3VsZFdhaXQiOmZhbHNlfQ=="
+                        }
+                    ]
+                },
+                "workflowTaskTimeout": "10s",
+                "originalExecutionRunId": "019c66d9-065d-7ce0-8dd0-610dcb6d6fbf",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)",
+                "firstExecutionRunId": "019c66d9-065d-7ce0-8dd0-610dcb6d6fbf",
+                "attempt": 1,
+                "firstWorkflowTaskBackoff": "0s",
+                "workflowId": "replayer-test-nondet-928BA36D-99FA-4DED-850D-19BC06DB1053"
+            }
+        },
+        {
+            "eventId": "2",
+            "eventTime": "2026-02-16T14:27:04.925883Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+            "taskId": "1048588",
+            "workflowTaskScheduledEventAttributes": {
+                "taskQueue": {
+                    "name": "86186999-3E6A-45A0-932A-B35ED0811A8C",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "startToCloseTimeout": "10s",
+                "attempt": 1
+            }
+        },
+        {
+            "eventId": "3",
+            "eventTime": "2026-02-16T14:27:06.930151Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+            "taskId": "1048593",
+            "workflowTaskStartedEventAttributes": {
+                "scheduledEventId": "2",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-59AED",
+                "requestId": "fbab8612-7489-475c-9fbf-3bc6cae940cf",
+                "historySizeBytes": "500"
+            }
+        },
+        {
+            "eventId": "4",
+            "eventTime": "2026-02-16T14:27:06.946488Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+            "taskId": "1048597",
+            "workflowTaskCompletedEventAttributes": {
+                "scheduledEventId": "2",
+                "startedEventId": "3",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-59AED",
+                "workerVersion": {},
+                "sdkMetadata": {
+                    "coreUsedFlags": [
+                        3,
+                        1,
+                        2
+                    ],
+                    "sdkName": "swift-temporal",
+                    "sdkVersion": "16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)"
+                },
+                "meteringMetadata": {}
+            }
+        },
+        {
+            "eventId": "5",
+            "eventTime": "2026-02-16T14:27:06.946554Z",
+            "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+            "taskId": "1048598",
+            "activityTaskScheduledEventAttributes": {
+                "activityId": "0",
+                "activityType": {
+                    "name": "ReplayActivity"
+                },
+                "taskQueue": {
+                    "name": "86186999-3E6A-45A0-932A-B35ED0811A8C",
+                    "kind": "TASK_QUEUE_KIND_NORMAL"
+                },
+                "header": {},
+                "input": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "IlRlbXBvcmFsIg=="
+                        }
+                    ]
+                },
+                "scheduleToCloseTimeout": "60s",
+                "scheduleToStartTimeout": "60s",
+                "startToCloseTimeout": "60s",
+                "heartbeatTimeout": "0s",
+                "workflowTaskCompletedEventId": "4",
+                "retryPolicy": {
+                    "initialInterval": "1s",
+                    "backoffCoefficient": 2,
+                    "maximumInterval": "100s"
+                },
+                "useWorkflowBuildId": true
+            }
+        },
+        {
+            "eventId": "6",
+            "eventTime": "2026-02-16T14:27:06.947905Z",
+            "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+            "taskId": "1048605",
+            "activityTaskStartedEventAttributes": {
+                "scheduledEventId": "5",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-59AED",
+                "requestId": "a00ce1d5-c608-441d-aa64-adc291833b92",
+                "attempt": 1,
+                "workerVersion": {}
+            }
+        },
+        {
+            "eventId": "7",
+            "eventTime": "2026-02-16T14:27:06.958947Z",
+            "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+            "taskId": "1048606",
+            "activityTaskCompletedEventAttributes": {
+                "result": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "IkhlbGxvLCBUZW1wb3JhbCEi"
+                        }
+                    ]
+                },
+                "scheduledEventId": "5",
+                "startedEventId": "6",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-59AED"
+            }
+        },
+        {
+            "eventId": "8",
+            "eventTime": "2026-02-16T14:27:06.958950Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+            "taskId": "1048607",
+            "workflowTaskScheduledEventAttributes": {
+                "taskQueue": {
+                    "name": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-59AED-a50759748aef486fb1b7f6a04df653a5",
+                    "kind": "TASK_QUEUE_KIND_STICKY",
+                    "normalName": "86186999-3E6A-45A0-932A-B35ED0811A8C"
+                },
+                "startToCloseTimeout": "10s",
+                "attempt": 1
+            }
+        },
+        {
+            "eventId": "9",
+            "eventTime": "2026-02-16T14:27:06.959867Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+            "taskId": "1048611",
+            "workflowTaskStartedEventAttributes": {
+                "scheduledEventId": "8",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-59AED",
+                "requestId": "ffb2b90b-4012-41d1-8e52-28cf8f7bb206",
+                "historySizeBytes": "1484"
+            }
+        },
+        {
+            "eventId": "10",
+            "eventTime": "2026-02-16T14:27:06.965147Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+            "taskId": "1048615",
+            "workflowTaskCompletedEventAttributes": {
+                "scheduledEventId": "8",
+                "startedEventId": "9",
+                "identity": "swift-temporal-16305efac88dbe2144cac1f3124e5c8a123fff08 (modified)-59AED",
+                "workerVersion": {},
+                "sdkMetadata": {},
+                "meteringMetadata": {}
+            }
+        },
+        {
+            "eventId": "11",
+            "eventTime": "2026-02-16T14:27:06.965177Z",
+            "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+            "taskId": "1048616",
+            "workflowExecutionCompletedEventAttributes": {
+                "result": {
+                    "payloads": [
+                        {
+                            "metadata": {
+                                "encoding": "anNvbi9wbGFpbg=="
+                            },
+                            "data": "IkhlbGxvLCBUZW1wb3JhbCEi"
+                        }
+                    ]
+                },
+                "workflowTaskCompletedEventId": "10"
+            }
+        }
+    ]
+}

--- a/Tests/TemporalTests/Worker/WorkflowReplayerTests.swift
+++ b/Tests/TemporalTests/Worker/WorkflowReplayerTests.swift
@@ -1,0 +1,423 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import Temporal
+import TemporalTestKit
+import Testing
+
+// MARK: - Test Suite
+
+extension TestServerDependentTests {
+    @Suite(.tags(.workflowTests))
+    struct WorkflowReplayerTests {
+        struct ReplayParams: Codable, Sendable {
+            let name: String
+            var shouldWait: Bool = false
+            var shouldError: Bool = false
+            var shouldCauseNonDeterminism: Bool = false
+        }
+
+        struct ReplayActivity: ActivityDefinition {
+            static let name: String? = "ReplayActivity"
+
+            func run(input name: String) async throws -> String {
+                "Hello, \(name)!"
+            }
+        }
+
+        @Workflow
+        final class SayHelloWorkflow {
+            private var waiting = false
+            private var finish = false
+
+            func run(input params: ReplayParams) async throws -> String {
+                let result = try await Workflow.executeActivity(
+                    ReplayActivity.self,
+                    options: .init(scheduleToCloseTimeout: .seconds(60)),
+                    input: params.name
+                )
+
+                // Wait if requested
+                if params.shouldWait {
+                    waiting = true
+                    try await Workflow.condition { self.finish }
+                    waiting = false
+                }
+
+                // Throw if requested
+                if params.shouldError {
+                    throw ApplicationError(message: "Intentional error")
+                }
+
+                // Cause non-determinism if requested and we're replaying
+                // This simulates a code change that adds an extra timer
+                if params.shouldCauseNonDeterminism && Workflow.isReplaying {
+                    try await Workflow.sleep(for: .milliseconds(1))
+                }
+
+                return result
+            }
+
+            @WorkflowSignal
+            func finish(input: Void) async {
+                finish = true
+            }
+
+            @WorkflowQuery
+            func waiting(input: Void) -> Bool {
+                waiting
+            }
+        }
+
+        // MARK: - Simple Replay Tests
+
+        @Test
+        func replaySimpleWorkflowSucceeds() async throws {
+            try await withTestWorkerAndClient(
+                activities: [ReplayActivity()],
+                workflows: [SayHelloWorkflow.self]
+            ) { taskQueue, client in
+                let params = ReplayParams(name: "Temporal")
+                let workflowID = "replayer-test-simple-\(UUID().uuidString)"
+                let handle = try await client.startWorkflow(
+                    type: SayHelloWorkflow.self,
+                    options: .init(id: workflowID, taskQueue: taskQueue),
+                    input: params
+                )
+                let result = try await handle.result()
+                #expect(result == "Hello, Temporal!")
+
+                let history = try await handle.fetchHistory()
+
+                var config = WorkflowReplayer.Configuration()
+                config.workflows.append(SayHelloWorkflow.self)
+                let replayer = WorkflowReplayer(configuration: config)
+
+                let replayResult = try await replayer.replayWorkflow(history: history)
+                #expect(replayResult.replayFailure == nil)
+            }
+        }
+
+        @Test
+        func replayFailedWorkflowSucceeds() async throws {
+            try await withTestWorkerAndClient(
+                activities: [ReplayActivity()],
+                workflows: [SayHelloWorkflow.self]
+            ) { taskQueue, client in
+                let params = ReplayParams(name: "Temporal", shouldError: true)
+                let workflowID = "replayer-test-failed-\(UUID().uuidString)"
+                let handle = try await client.startWorkflow(
+                    type: SayHelloWorkflow.self,
+                    options: .init(id: workflowID, taskQueue: taskQueue),
+                    input: params
+                )
+
+                await #expect(throws: WorkflowFailedError.self) {
+                    try await handle.result()
+                }
+
+                let history = try await handle.fetchHistory()
+
+                var config = WorkflowReplayer.Configuration()
+                config.workflows.append(SayHelloWorkflow.self)
+                let replayer = WorkflowReplayer(configuration: config)
+
+                let replayResult = try await replayer.replayWorkflow(history: history)
+                #expect(replayResult.replayFailure == nil)
+            }
+        }
+
+        // MARK: - Non-determinism Detection Tests
+
+        @Test
+        func replayNondeterministicWorkflowFails() async throws {
+            try await withTestWorkerAndClient(
+                activities: [ReplayActivity()],
+                workflows: [SayHelloWorkflow.self]
+            ) { taskQueue, client in
+                // Run workflow WITH non-determinism flag set
+                // During initial execution, isReplaying is false, so no extra timer
+                let params = ReplayParams(name: "Temporal", shouldCauseNonDeterminism: true)
+                let workflowID = "replayer-test-nondet-\(UUID().uuidString)"
+                let handle = try await client.startWorkflow(
+                    type: SayHelloWorkflow.self,
+                    options: .init(id: workflowID, taskQueue: taskQueue),
+                    input: params
+                )
+                _ = try await handle.result()
+
+                let history = try await handle.fetchHistory()
+
+                // Replay the same workflow with same params
+                // Now isReplaying is true, so the extra timer WILL be added
+                // This causes non-determinism with the captured history
+                var config = WorkflowReplayer.Configuration()
+                config.workflows.append(SayHelloWorkflow.self)
+                let replayer = WorkflowReplayer(configuration: config)
+
+                await #expect(throws: WorkflowNondeterminismError.self) {
+                    try await replayer.replayWorkflow(history: history)
+                }
+            }
+        }
+
+        @Test
+        func replayNondeterministicWithoutThrowingReturnsFailure() async throws {
+            try await withTestWorkerAndClient(
+                activities: [ReplayActivity()],
+                workflows: [SayHelloWorkflow.self]
+            ) { taskQueue, client in
+                // Run workflow WITH non-determinism flag set
+                let params = ReplayParams(name: "Temporal", shouldCauseNonDeterminism: true)
+                let workflowID = "replayer-test-nondet-nothrow-\(UUID().uuidString)"
+                let handle = try await client.startWorkflow(
+                    type: SayHelloWorkflow.self,
+                    options: .init(id: workflowID, taskQueue: taskQueue),
+                    input: params
+                )
+                _ = try await handle.result()
+
+                let history = try await handle.fetchHistory()
+
+                var config = WorkflowReplayer.Configuration()
+                config.workflows.append(SayHelloWorkflow.self)
+                let replayer = WorkflowReplayer(configuration: config)
+
+                let replayResult = try await replayer.replayWorkflow(
+                    history: history,
+                    throwOnReplayFailure: false
+                )
+
+                #expect(replayResult.replayFailure != nil)
+                #expect(replayResult.replayFailure is WorkflowNondeterminismError)
+            }
+        }
+
+        // MARK: - JSON History Tests
+
+        @Test
+        func replayFromInvalidJSONThrowsError() async throws {
+            var config = WorkflowReplayer.Configuration()
+            config.workflows.append(SayHelloWorkflow.self)
+            let replayer = WorkflowReplayer(configuration: config)
+
+            await #expect(throws: (any Error).self) {
+                _ = try await replayer.replayWorkflow(
+                    history: .fromJSON(
+                        workflowID: "test",
+                        jsonData: Data("not valid json".utf8)
+                    )
+                )
+            }
+        }
+
+        @Test
+        func replayIncompleteWorkflowSucceeds() async throws {
+            try await withTestWorkerAndClient(
+                activities: [ReplayActivity()],
+                workflows: [SayHelloWorkflow.self]
+            ) { taskQueue, client in
+                // Start workflow with shouldWait flag - it will wait on a signal
+                let params = ReplayParams(name: "Temporal", shouldWait: true)
+                let workflowID = "replayer-test-incomplete-\(UUID().uuidString)"
+                let handle = try await client.startWorkflow(
+                    type: SayHelloWorkflow.self,
+                    options: .init(id: workflowID, taskQueue: taskQueue),
+                    input: params
+                )
+
+                // Wait until workflow reaches waiting state
+                while true {
+                    let waiting = try await handle.query(
+                        queryType: SayHelloWorkflow.Waiting.self
+                    )
+                    if waiting {
+                        break
+                    } else {
+                        try await Task.sleep(for: .seconds(0.1))
+                    }
+                }
+
+                // Fetch incomplete history and replay it
+                let history = try await handle.fetchHistory()
+
+                var config = WorkflowReplayer.Configuration()
+                config.workflows.append(SayHelloWorkflow.self)
+                let replayer = WorkflowReplayer(configuration: config)
+
+                let replayResult = try await replayer.replayWorkflow(history: history)
+                #expect(replayResult.replayFailure == nil)
+            }
+        }
+
+        @Test
+        func replayFromCompleteJSONFileSucceeds() async throws {
+            let testBundle = Bundle.module
+            guard
+                let jsonURL = testBundle.url(
+                    forResource: "replayer-test.complete",
+                    withExtension: "json",
+                    subdirectory: "Histories"
+                )
+            else {
+                Issue.record("Failed to find replayer-test.complete.json in test bundle")
+                return
+            }
+
+            let jsonData = try Data(contentsOf: jsonURL)
+
+            var config = WorkflowReplayer.Configuration()
+            config.workflows.append(SayHelloWorkflow.self)
+            let replayer = WorkflowReplayer(configuration: config)
+
+            let result = try await replayer.replayWorkflow(
+                history: .fromJSON(
+                    workflowID: "test-workflow-id",
+                    jsonData: jsonData,
+                )
+            )
+
+            #expect(result.replayFailure == nil)
+        }
+
+        @Test
+        func replayFromNondeterministicJSONFileFails() async throws {
+            let testBundle = Bundle.module
+            guard
+                let jsonURL = testBundle.url(
+                    forResource: "replayer-test.nondeterministic",
+                    withExtension: "json",
+                    subdirectory: "Histories"
+                )
+            else {
+                Issue.record("Failed to find replayer-test.nondeterministic.json in test bundle")
+                return
+            }
+
+            let jsonData = try Data(contentsOf: jsonURL)
+
+            var config = WorkflowReplayer.Configuration()
+            config.workflows.append(SayHelloWorkflow.self)
+            let replayer = WorkflowReplayer(configuration: config)
+
+            // Test that it throws when throwOnReplayFailure is true
+            await #expect(throws: WorkflowNondeterminismError.self) {
+                _ =
+                    try await replayer
+                    .replayWorkflow(
+                        history: .fromJSON(
+                            workflowID: "test-workflow-id",
+                            jsonData: jsonData,
+                        )
+                    )
+            }
+
+            // Test that it returns failure when throwOnReplayFailure is false
+            let result = try await replayer.replayWorkflow(
+                history: .fromJSON(
+                    workflowID: "test-workflow-id",
+                    jsonData: jsonData,
+                ),
+                throwOnReplayFailure: false
+            )
+
+            #expect(result.replayFailure != nil)
+            #expect(result.replayFailure is WorkflowNondeterminismError)
+        }
+
+        // MARK: - Multiple Workflow Tests
+
+        @Test
+        func replayMultipleWorkflowsCollectsAllResults() async throws {
+            try await withTestWorkerAndClient(
+                activities: [ReplayActivity()],
+                workflows: [SayHelloWorkflow.self]
+            ) { taskQueue, client in
+                let params1 = ReplayParams(name: "First")
+                let params2 = ReplayParams(name: "Second")
+
+                let handle1 = try await client.startWorkflow(
+                    type: SayHelloWorkflow.self,
+                    options: .init(
+                        id: "replayer-multi-1-\(UUID().uuidString)",
+                        taskQueue: taskQueue
+                    ),
+                    input: params1
+                )
+                let handle2 = try await client.startWorkflow(
+                    type: SayHelloWorkflow.self,
+                    options: .init(
+                        id: "replayer-multi-2-\(UUID().uuidString)",
+                        taskQueue: taskQueue
+                    ),
+                    input: params2
+                )
+
+                _ = try await handle1.result()
+                _ = try await handle2.result()
+
+                let history1 = try await handle1.fetchHistory()
+                let history2 = try await handle2.fetchHistory()
+
+                var config = WorkflowReplayer.Configuration()
+                config.workflows.append(SayHelloWorkflow.self)
+                let replayer = WorkflowReplayer(configuration: config)
+
+                let results = try await replayer.replayWorkflows(
+                    histories: [history1, history2],
+                    throwOnReplayFailure: false
+                )
+
+                #expect(results.count == 2)
+            }
+        }
+
+        @Test
+        func replayMultipleWorkflowsThrowsOnFirstFailure() async throws {
+            try await withTestWorkerAndClient(
+                activities: [ReplayActivity()],
+                workflows: [SayHelloWorkflow.self]
+            ) { taskQueue, client in
+                // Run workflow with non-determinism flag
+                let params = ReplayParams(name: "Test", shouldCauseNonDeterminism: true)
+
+                let handle = try await client.startWorkflow(
+                    type: SayHelloWorkflow.self,
+                    options: .init(
+                        id: "replayer-multi-fail-\(UUID().uuidString)",
+                        taskQueue: taskQueue
+                    ),
+                    input: params
+                )
+
+                _ = try await handle.result()
+                let history = try await handle.fetchHistory()
+
+                var config = WorkflowReplayer.Configuration()
+                config.workflows.append(SayHelloWorkflow.self)
+                let replayer = WorkflowReplayer(configuration: config)
+
+                // Replay should detect non-determinism and throw on first failure
+                await #expect(throws: WorkflowNondeterminismError.self) {
+                    _ = try await replayer.replayWorkflows(
+                        histories: [history, history],
+                        throwOnReplayFailure: true
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `WorkflowReplayer` for replaying workflow histories against current code to detect nondeterminism errors. Includes WorkflowHistory type with JSON import/export compatible with Temporal CLI/UI, single and batch replay methods, and WorkflowReplayResult with failure reporting.