### PR TITLE
Add worker tuner with fixed-size and resource-based slot suppliers

### DIFF
--- a/Sources/Temporal/Bridge/BridgeWorker.swift
+++ b/Sources/Temporal/Bridge/BridgeWorker.swift
@@ -49,15 +49,13 @@ package final class BridgeWorker: BridgeWorkerProtocol {
         // –– Workflows ––
         workflowTaskPollerBehavior: TemporalWorker.Configuration.PollerBehavior,
         maxCachedWorkflows: UInt32,
-        maxConcurrentWorkflowTasks: UInt,
+        tuner: WorkerTuner,
         nonstickyToStickyPollRatio: Float,
         stickyQueueScheduleToStartTimeoutMs: UInt64,
         nondeterminismAsWorkflowFail: Bool,
         nondeterminismAsWorkflowFailForTypes: [String],
         // –– Activities ––
         activityTaskPollerBehavior: TemporalWorker.Configuration.PollerBehavior,
-        maxConcurrentActivities: UInt,
-        maxConcurrentLocalActivities: UInt,
         maxActivitiesPerSecond: Double,
         maxTaskQueueActivitiesPerSecond: Double,
         // –– Heartbeat throttling ––
@@ -67,13 +65,10 @@ package final class BridgeWorker: BridgeWorkerProtocol {
         nexusTaskPollerBehavior: TemporalWorker.Configuration.PollerBehavior,
         gracefulShutdownPeriodMs: UInt64
     ) throws {
-        var tuner = TemporalCoreTunerHolder()
-        tuner.workflow_slot_supplier.tag = FixedSize
-        tuner.workflow_slot_supplier.fixed_size.num_slots = maxConcurrentWorkflowTasks
-        tuner.activity_slot_supplier.tag = FixedSize
-        tuner.activity_slot_supplier.fixed_size.num_slots = maxConcurrentActivities
-        tuner.local_activity_slot_supplier.tag = FixedSize
-        tuner.local_activity_slot_supplier.fixed_size.num_slots = maxConcurrentLocalActivities
+        var bridgeTuner = TemporalCoreTunerHolder()
+        bridgeTuner.workflow_slot_supplier = .init(tuner.workflowSlotSupplier)
+        bridgeTuner.activity_slot_supplier = .init(tuner.activitySlotSupplier)
+        bridgeTuner.local_activity_slot_supplier = .init(tuner.localActivitySlotSupplier)
 
         self.worker = try Self.withWorkerOptions(
             namespace: namespace,
@@ -82,7 +77,7 @@ package final class BridgeWorker: BridgeWorkerProtocol {
             hasActivities: hasActivities,
             hasWorkflows: hasWorkflows,
             versioningStrategy: versioningStrategy,
-            tuner: tuner,
+            tuner: bridgeTuner,
             maxCachedWorkflows: maxCachedWorkflows,
             stickyQueueTimeoutMs: stickyQueueScheduleToStartTimeoutMs,
             maxHeartbeatThrottleIntervalMs: maxHeartbeatThrottleIntervalMs,
@@ -131,14 +126,12 @@ package final class BridgeWorker: BridgeWorkerProtocol {
             hasWorkflows: hasWorkflows,
             workflowTaskPollerBehavior: configuration.workflowTaskPollerBehavior,
             maxCachedWorkflows: UInt32(configuration.maxCachedWorkflows),
-            maxConcurrentWorkflowTasks: UInt(configuration.maxConcurrentWorkflowTasks),
+            tuner: configuration.tuner,
             nonstickyToStickyPollRatio: Float(configuration.nonstickyToStickyPollRatio),
             stickyQueueScheduleToStartTimeoutMs: configuration.stickyQueueScheduleToStartTimeout.milliseconds,
             nondeterminismAsWorkflowFail: true,
             nondeterminismAsWorkflowFailForTypes: [],
             activityTaskPollerBehavior: configuration.activityTaskPollerBehavior,
-            maxConcurrentActivities: UInt(configuration.maxConcurrentActivities),
-            maxConcurrentLocalActivities: UInt(configuration.maxConcurrentLocalActivities),
             maxActivitiesPerSecond: configuration.maxActivitiesPerSecond,
             maxTaskQueueActivitiesPerSecond: configuration.maxTaskQueueActivitiesPerSecond,
             defaultHeartbeatThrottleIntervalMs: configuration.defaultHeartbeatThrottleInterval.milliseconds,

--- a/Sources/Temporal/Bridge/Helpers/SlotSupplier+Bridge.swift
+++ b/Sources/Temporal/Bridge/Helpers/SlotSupplier+Bridge.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Bridge
+
+extension TemporalCoreSlotSupplier {
+    init(_ slotSupplier: SlotSupplier) {
+        var supplier = TemporalCoreSlotSupplier()
+        switch slotSupplier.kind {
+        case .fixedSize(let fixedSize):
+            supplier.tag = FixedSize
+            supplier.fixed_size.num_slots = UInt(fixedSize.maximumSlots)
+        case .resourceBased(let options, let tunerOptions):
+            supplier.tag = ResourceBased
+            supplier.resource_based.minimum_slots = UInt(options.minimumSlots)
+            supplier.resource_based.maximum_slots = UInt(options.maximumSlots)
+            supplier.resource_based.ramp_throttle_ms = options.rampThrottle.milliseconds
+            supplier.resource_based.tuner_options.target_memory_usage = tunerOptions.targetMemoryUsage
+            supplier.resource_based.tuner_options.target_cpu_usage = tunerOptions.targetCpuUsage
+        }
+        self = supplier
+    }
+}

--- a/Sources/Temporal/Statics/ConfigKeys+Worker.swift
+++ b/Sources/Temporal/Statics/ConfigKeys+Worker.swift
@@ -34,4 +34,26 @@ extension ConfigKey {
 
     /// The optional worker heartbeat interval in milliseconds of the ``TemporalWorker``.
     static let workerHeartbeatIntervalMs: ConfigKey = ["worker", "heartbeatintervalms"]
+
+    // MARK: - Tuner
+
+    /// The optional slot supplier type for workflow tasks (`"fixed"` or `"resource-based"`).
+    static let workerTunerWorkflowType: ConfigKey = ["worker", "tuner", "workflow", "type"]
+    /// The optional maximum slots for fixed-size workflow task supplier.
+    static let workerTunerWorkflowMaxSlots: ConfigKey = ["worker", "tuner", "workflow", "maxslots"]
+
+    /// The optional slot supplier type for activity tasks (`"fixed"` or `"resource-based"`).
+    static let workerTunerActivityType: ConfigKey = ["worker", "tuner", "activity", "type"]
+    /// The optional maximum slots for fixed-size activity task supplier.
+    static let workerTunerActivityMaxSlots: ConfigKey = ["worker", "tuner", "activity", "maxslots"]
+
+    /// The optional slot supplier type for local activity tasks (`"fixed"` or `"resource-based"`).
+    static let workerTunerLocalActivityType: ConfigKey = ["worker", "tuner", "localactivity", "type"]
+    /// The optional maximum slots for fixed-size local activity task supplier.
+    static let workerTunerLocalActivityMaxSlots: ConfigKey = ["worker", "tuner", "localactivity", "maxslots"]
+
+    /// The optional target memory usage for resource-based slot suppliers (0.0--1.0).
+    static let workerTunerTargetMemoryUsage: ConfigKey = ["worker", "tuner", "targetmemoryusage"]
+    /// The optional target CPU usage for resource-based slot suppliers (0.0--1.0).
+    static let workerTunerTargetCpuUsage: ConfigKey = ["worker", "tuner", "targetcpuusage"]
 }

--- a/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
+++ b/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
@@ -47,8 +47,10 @@ extension TemporalWorker {
     /// Adjust operational settings after initialization:
     ///
     /// ```swift
-    /// config.maxConcurrentWorkflowTasks = 50
-    /// config.maxConcurrentActivities = 200
+    /// config.tuner = WorkerTuner(
+    ///     workflowSlotSupplier: .fixedSize(.init(maximumSlots: 50)),
+    ///     activitySlotSupplier: .fixedSize(.init(maximumSlots: 200))
+    /// )
     /// config.gracefulShutdownPeriod = .seconds(30)
     /// ```
     public struct Configuration: Sendable {
@@ -301,13 +303,17 @@ extension TemporalWorker {
         /// - Important: Ensure that you only configure either an API key or mTLS.
         public var apiKey: String?
 
+        /// Controls how task processing slots are allocated for workflow, activity,
+        /// and local activity tasks.
+        ///
+        /// By default, all three slot suppliers use fixed-size with 100 slots each.
+        public var tuner: WorkerTuner = WorkerTuner()
+
         // –– Workflows ––
         /// Polling behavior for workflows (default max `5`).
         public var workflowTaskPollerBehavior: PollerBehavior = .simpleMaximum(maximum: 5)
         /// Maximum number of workflow instances to cache in memory (default `1000`).
         public var maxCachedWorkflows: Int = 1_000
-        /// Maximum concurrent workflow tasks the worker will execute (default `100`).
-        public var maxConcurrentWorkflowTasks: Int = 100
         /// Ratio of non-sticky to sticky workflow task polls (0.0–1.0, default `0.2`).
         public var nonstickyToStickyPollRatio: Double = 0.2
         /// Timeout for a sticky workflow task from schedule to start before falling back (default `10 sec`).
@@ -316,10 +322,6 @@ extension TemporalWorker {
         // –– Activities ––
         /// Polling behavior for activities (default max `5`).
         public var activityTaskPollerBehavior: PollerBehavior = .simpleMaximum(maximum: 5)
-        /// Maximum concurrent remote activities (default `100`).
-        public var maxConcurrentActivities: Int = 100
-        /// Maximum concurrent local activities (default `100`).
-        public var maxConcurrentLocalActivities: Int = 100
         /// Global throttle for activity start rate (units/sec, default `100_000`).
         public var maxActivitiesPerSecond: Double = 100_000
 
@@ -421,6 +423,20 @@ extension TemporalWorker {
         /// - `worker.heartbeatintervalms`: The worker heartbeat interval in milliseconds (defaults to 0,
         /// which disables worker heartbeats).
         ///
+        /// ## Tuner configuration keys
+        ///
+        /// The following keys configure the worker tuner. If no tuner keys are present,
+        /// the default ``WorkerTuner`` is used (fixed-size with 100 slots for each task type).
+        ///
+        /// - `worker.tuner.workflow.type`: Slot supplier type -- `"fixed"` or `"resource-based"`.
+        /// - `worker.tuner.workflow.maxslots`: Maximum slots for workflow tasks (fixed-size only).
+        /// - `worker.tuner.activity.type`: Slot supplier type -- `"fixed"` or `"resource-based"`.
+        /// - `worker.tuner.activity.maxslots`: Maximum slots for activity tasks (fixed-size only).
+        /// - `worker.tuner.localactivity.type`: Slot supplier type -- `"fixed"` or `"resource-based"`.
+        /// - `worker.tuner.localactivity.maxslots`: Maximum slots for local activity tasks (fixed-size only).
+        /// - `worker.tuner.targetmemoryusage`: Target memory usage for resource-based suppliers (0.0--1.0).
+        /// - `worker.tuner.targetcpuusage`: Target CPU usage for resource-based suppliers (0.0--1.0).
+        ///
         /// - Parameters:
         ///   - configReader: The configuration reader containing the required configuration values.
         ///   - dataConverter: The converter for encoding and decoding payloads. Defaults to the
@@ -453,6 +469,57 @@ extension TemporalWorker {
             // Set optional configuration values that have defaults
             if let heartbeatIntervalMs = snapshot.int(forKey: .workerHeartbeatIntervalMs) {
                 self.workerHeartbeatInterval = .milliseconds(heartbeatIntervalMs)
+            }
+
+            // Read tuner configuration
+            let workflowType = snapshot.string(forKey: .workerTunerWorkflowType)
+            let activityType = snapshot.string(forKey: .workerTunerActivityType)
+            let localActivityType = snapshot.string(forKey: .workerTunerLocalActivityType)
+
+            // Only override the default tuner if at least one tuner key is present
+            if workflowType != nil || activityType != nil || localActivityType != nil {
+                let targetMemoryUsage = snapshot.double(forKey: .workerTunerTargetMemoryUsage) ?? 0.8
+                let targetCpuUsage = snapshot.double(forKey: .workerTunerTargetCpuUsage) ?? 0.9
+                let tunerOptions = ResourceBasedTunerOptions(
+                    targetMemoryUsage: targetMemoryUsage,
+                    targetCpuUsage: targetCpuUsage
+                )
+
+                self.tuner = WorkerTuner(
+                    workflowSlotSupplier: Self.slotSupplier(
+                        type: workflowType,
+                        maxSlots: snapshot.int(forKey: .workerTunerWorkflowMaxSlots),
+                        tunerOptions: tunerOptions
+                    ),
+                    activitySlotSupplier: Self.slotSupplier(
+                        type: activityType,
+                        maxSlots: snapshot.int(forKey: .workerTunerActivityMaxSlots),
+                        tunerOptions: tunerOptions
+                    ),
+                    localActivitySlotSupplier: Self.slotSupplier(
+                        type: localActivityType,
+                        maxSlots: snapshot.int(forKey: .workerTunerLocalActivityMaxSlots),
+                        tunerOptions: tunerOptions
+                    )
+                )
+            }
+        }
+
+        /// Builds a ``SlotSupplier`` from configuration values.
+        private static func slotSupplier(
+            type: String?,
+            maxSlots: Int?,
+            tunerOptions: ResourceBasedTunerOptions
+        ) -> SlotSupplier {
+            switch type {
+            case "resource-based":
+                return .resourceBased(
+                    .init(),
+                    tunerOptions: tunerOptions
+                )
+            default:
+                // Default to fixed-size
+                return .fixedSize(.init(maximumSlots: maxSlots ?? 100))
             }
         }
     }

--- a/Sources/Temporal/Worker/Tuning/FixedSizeSlotSupplierOptions.swift
+++ b/Sources/Temporal/Worker/Tuning/FixedSizeSlotSupplierOptions.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Per-supplier options for a fixed slot supplier.
+///
+/// The worker will never execute more than ``maximumSlots`` tasks of this type
+/// concurrently. The slot count does not change during the worker's lifetime.
+public struct FixedSizeSlotSupplierOptions: Sendable {
+    /// The maximum number of concurrent task executions.
+    public var maximumSlots: Int
+
+    /// Creates a fixed-size slot supplier.
+    ///
+    /// - Parameter maximumSlots: The maximum number of concurrent task executions. Defaults to `100`.
+    public init(maximumSlots: Int = 100) {
+        self.maximumSlots = maximumSlots
+    }
+}

--- a/Sources/Temporal/Worker/Tuning/ResourceBasedSlotSupplierOptions.swift
+++ b/Sources/Temporal/Worker/Tuning/ResourceBasedSlotSupplierOptions.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Per-supplier options for a resource-based slot supplier.
+///
+/// These options control the slot allocation behavior of an individual resource-based slot
+/// supplier. Each supplier can have different slot limits and ramp throttle settings, while
+/// sharing the same ``ResourceBasedTunerOptions`` for system resource targets.
+public struct ResourceBasedSlotSupplierOptions: Sendable {
+    /// Minimum number of slots that will be issued regardless of resource usage.
+    ///
+    /// The supplier will always maintain at least this many slots, even if resource
+    /// usage is above the target thresholds.
+    public var minimumSlots: Int
+
+    /// Maximum number of slots that can ever be issued.
+    ///
+    /// The supplier will never allocate more than this many slots, even if resource
+    /// usage is well below the target thresholds.
+    public var maximumSlots: Int
+
+    /// Minimum time to wait between issuing new slots after the minimum has been reached.
+    ///
+    /// This throttle exists because the resource impact of a task cannot be determined
+    /// ahead of time. The system waits to observe resource usage before issuing additional
+    /// slots.
+    public var rampThrottle: Duration
+
+    /// Creates per-supplier options for a resource-based slot supplier.
+    ///
+    /// - Parameters:
+    ///   - minimumSlots: Minimum number of slots that will always be available. Defaults to `5`.
+    ///   - maximumSlots: Maximum number of slots that can be issued. Defaults to `100`.
+    ///   - rampThrottle: Minimum time between issuing new slots after reaching the minimum. Defaults to 50 milliseconds.
+    public init(
+        minimumSlots: Int = 5,
+        maximumSlots: Int = 100,
+        rampThrottle: Duration = .milliseconds(50)
+    ) {
+        self.minimumSlots = minimumSlots
+        self.maximumSlots = maximumSlots
+        self.rampThrottle = rampThrottle
+    }
+}

--- a/Sources/Temporal/Worker/Tuning/ResourceBasedTunerOptions.swift
+++ b/Sources/Temporal/Worker/Tuning/ResourceBasedTunerOptions.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Options for target system resource usage, shared across all resource-based slot suppliers.
+///
+/// These options control the system-wide resource targets that all resource-based slot suppliers
+/// in a ``WorkerTuner`` share. Each supplier individually scales its slot count to keep the
+/// system within these target thresholds.
+///
+/// - Important: It is not recommended to set ``targetMemoryUsage`` higher than 0.8,
+///   since how much memory a task may use is not predictable and you want to avoid
+///   out-of-memory errors.
+public struct ResourceBasedTunerOptions: Sendable {
+    /// Target system memory usage as a fraction between 0.0 and 1.0.
+    ///
+    /// The supplier will try to keep system memory usage at or below this level by
+    /// adjusting the number of available slots.
+    ///
+    /// - Important: It is not recommended to set this higher than 0.8, since how much
+    ///   memory a task may use is not predictable and you want to avoid out-of-memory
+    ///   errors.
+    public var targetMemoryUsage: Double
+
+    /// Target system CPU usage as a fraction between 0.0 and 1.0.
+    ///
+    /// The supplier will try to keep system CPU usage at or below this level by
+    /// adjusting the number of available slots. This can be set to 1.0 if desired,
+    /// but it is recommended to leave some headroom for other processes.
+    public var targetCpuUsage: Double
+
+    /// Creates resource-based tuner options.
+    ///
+    /// - Parameters:
+    ///   - targetMemoryUsage: Target system memory usage as a fraction (0.0--1.0). Defaults to `0.8`.
+    ///   - targetCpuUsage: Target system CPU usage as a fraction (0.0--1.0). Defaults to `0.9`.
+    public init(
+        targetMemoryUsage: Double = 0.8,
+        targetCpuUsage: Double = 0.9
+    ) {
+        precondition(
+            0 <= targetMemoryUsage && targetMemoryUsage <= 1.0,
+            "Target memory usage out of range"
+        )
+        precondition(
+            0 <= targetCpuUsage && targetCpuUsage <= 1.0,
+            "Target CPU usage out of range"
+        )
+        self.targetMemoryUsage = targetMemoryUsage
+        self.targetCpuUsage = targetCpuUsage
+    }
+}

--- a/Sources/Temporal/Worker/Tuning/SlotSupplier.swift
+++ b/Sources/Temporal/Worker/Tuning/SlotSupplier.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Determines how slots are allocated for workflow, activity, or local activity task processing.
+///
+/// Each slot represents one concurrent task execution. The slot supplier controls
+/// how many tasks can run in parallel and how that number is determined.
+public struct SlotSupplier: Sendable {
+    package enum Kind: Sendable {
+        case fixedSize(FixedSizeSlotSupplierOptions)
+        case resourceBased(options: ResourceBasedSlotSupplierOptions, tunerOptions: ResourceBasedTunerOptions)
+    }
+
+    package let kind: Kind
+
+    private init(_ kind: Kind) {
+        self.kind = kind
+    }
+
+    /// Fixed number of slots available for task processing.
+    ///
+    /// The worker will never execute more than the supplier's ``FixedSizeSlotSupplierOptions/maximumSlots``
+    /// tasks of this type concurrently.
+    ///
+    /// - Parameter options: The fixed-size slot supplier configuration.
+    /// - Returns: A slot supplier with fixed concurrency.
+    public static func fixedSize(_ options: FixedSizeSlotSupplierOptions) -> SlotSupplier {
+        .init(.fixedSize(options))
+    }
+
+    /// Dynamically adjusts the number of slots based on system resource usage.
+    ///
+    /// The worker monitors CPU and memory usage and scales the number of available slots
+    /// up or down to stay within the configured resource targets.
+    ///
+    /// - Parameters:
+    ///   - options: Per-supplier slot configuration (min/max slots, ramp throttle).
+    ///   - tunerOptions: System-wide resource targets (memory, CPU) shared across all resource-based suppliers.
+    /// - Returns: A slot supplier with resource-based concurrency.
+    public static func resourceBased(
+        _ options: ResourceBasedSlotSupplierOptions = .init(),
+        tunerOptions: ResourceBasedTunerOptions
+    ) -> SlotSupplier {
+        .init(.resourceBased(options: options, tunerOptions: tunerOptions))
+    }
+}

--- a/Sources/Temporal/Worker/Tuning/WorkerTuner.swift
+++ b/Sources/Temporal/Worker/Tuning/WorkerTuner.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Controls how task processing slots are allocated across workflow, activity, and local activity workers.
+///
+/// A ``WorkerTuner`` groups together separate ``SlotSupplier`` instances for each task type,
+/// allowing fine-grained control over concurrency. You can mix different supplier strategies --
+/// for example, using a fixed-size supplier for workflows and a resource-based supplier for activities.
+///
+/// ## Fixed-size tuner
+///
+/// Use fixed slot counts for predictable concurrency limits:
+///
+/// ```swift
+/// let tuner = WorkerTuner(
+///     workflowSlotSupplier: .fixedSize(.init(maximumSlots: 100)),
+///     activitySlotSupplier: .fixedSize(.init(maximumSlots: 200)),
+///     localActivitySlotSupplier: .fixedSize(.init(maximumSlots: 100))
+/// )
+/// ```
+///
+/// ## Resource-based tuner
+///
+/// Use the ``resourceBased(targetMemoryUsage:targetCpuUsage:workflowOptions:activityOptions:localActivityOptions:)``
+/// factory to create a tuner that dynamically scales all slot types based on system resource usage:
+///
+/// ```swift
+/// let tuner = WorkerTuner.resourceBased(
+///     targetMemoryUsage: 0.8,
+///     targetCpuUsage: 0.9,
+///     workflowOptions: .init(minimumSlots: 2, maximumSlots: 50),
+///     activityOptions: .init(minimumSlots: 10, maximumSlots: 200)
+/// )
+/// ```
+///
+/// ## Applying a tuner
+///
+/// Set the tuner on the worker configuration:
+///
+/// ```swift
+/// var config = TemporalWorker.Configuration(...)
+/// config.tuner = tuner
+/// ```
+public struct WorkerTuner: Sendable {
+    /// Slot supplier for workflow task processing.
+    public var workflowSlotSupplier: SlotSupplier
+
+    /// Slot supplier for activity task processing.
+    public var activitySlotSupplier: SlotSupplier
+
+    /// Slot supplier for local activity task processing.
+    public var localActivitySlotSupplier: SlotSupplier
+
+    /// Creates a worker tuner with the specified slot suppliers.
+    ///
+    /// - Parameters:
+    ///   - workflowSlotSupplier: Slot supplier for workflow tasks. Defaults to fixed-size with 100 slots.
+    ///   - activitySlotSupplier: Slot supplier for activity tasks. Defaults to fixed-size with 100 slots.
+    ///   - localActivitySlotSupplier: Slot supplier for local activity tasks. Defaults to fixed-size with 100 slots.
+    public init(
+        workflowSlotSupplier: SlotSupplier = .fixedSize(.init()),
+        activitySlotSupplier: SlotSupplier = .fixedSize(.init()),
+        localActivitySlotSupplier: SlotSupplier = .fixedSize(.init())
+    ) {
+        self.workflowSlotSupplier = workflowSlotSupplier
+        self.activitySlotSupplier = activitySlotSupplier
+        self.localActivitySlotSupplier = localActivitySlotSupplier
+    }
+
+    /// Creates a resource-based tuner that dynamically scales all slot types based on
+    /// system CPU and memory usage.
+    ///
+    /// All three slot suppliers (workflow, activity, and local activity) share the same
+    /// resource targets but can have individual slot configuration options.
+    ///
+    /// - Parameters:
+    ///   - targetMemoryUsage: Target system memory usage as a fraction (0.0--1.0). Defaults to `0.8`.
+    ///   - targetCpuUsage: Target system CPU usage as a fraction (0.0--1.0). Defaults to `0.9`.
+    ///   - workflowOptions: Per-supplier slot options for workflow tasks. Defaults to standard options.
+    ///   - activityOptions: Per-supplier slot options for activity tasks. Defaults to standard options.
+    ///   - localActivityOptions: Per-supplier slot options for local activity tasks. Defaults to standard options.
+    /// - Returns: A tuner with resource-based slot suppliers for all task types.
+    public static func resourceBased(
+        targetMemoryUsage: Double = 0.8,
+        targetCpuUsage: Double = 0.9,
+        workflowOptions: ResourceBasedSlotSupplierOptions = .init(),
+        activityOptions: ResourceBasedSlotSupplierOptions = .init(),
+        localActivityOptions: ResourceBasedSlotSupplierOptions = .init()
+    ) -> WorkerTuner {
+        let tunerOptions = ResourceBasedTunerOptions(
+            targetMemoryUsage: targetMemoryUsage,
+            targetCpuUsage: targetCpuUsage
+        )
+        return WorkerTuner(
+            workflowSlotSupplier: .resourceBased(workflowOptions, tunerOptions: tunerOptions),
+            activitySlotSupplier: .resourceBased(activityOptions, tunerOptions: tunerOptions),
+            localActivitySlotSupplier: .resourceBased(localActivityOptions, tunerOptions: tunerOptions)
+        )
+    }
+}

--- a/Sources/TemporalTestKit/TemporalTestServer.swift
+++ b/Sources/TemporalTestKit/TemporalTestServer.swift
@@ -350,33 +350,28 @@ public struct TemporalTestServer: Sendable {
     /// plaintext transport to the test server. The worker runs concurrently while your `body` closure
     /// executes; once the closure finishes (or throws), the worker task is cancelled and torn down.
     ///
-    /// The worker can be customized with namespace, task queue, interceptors, activities, workflows,
-    /// logging, and heartbeat throttling. By default, a fresh random task queue is used so tests
-    /// remain isolated.
-    ///
     /// ## Usage
     ///
     /// ```swift
     /// let testServer = TemporalTestServer.testServer!
-    /// let result = try await testServer.withConnectedWorker(
+    /// var config = TemporalWorker.Configuration(
     ///     namespace: "default",
+    ///     taskQueue: UUID().uuidString,
+    ///     instrumentation: .init(serverHostname: "localhost")
+    /// )
+    /// let result = try await testServer.withConnectedWorker(
+    ///     configuration: config,
     ///     activities: [MyActivity()],
     ///     workflows: [MyWorkflow.self]
     /// ) { worker in
     ///     // Interact with the system under test while the worker is running.
-    ///     // For example, start a workflow from a connected client (e.g. via `withConnectedClient()`),
-    ///     // then await its result.
     /// }
     ///
     /// #expect(result == "...")
     /// ```
     ///
     /// - Parameters:
-    ///   - namespace: Temporal namespace to register the worker with. Defaults to `"default"`.
-    ///   - taskQueue: Task queue the worker will poll. Defaults to a fresh random UUID to avoid collisions between tests.
-    ///   - workerBuildID: Optional Build ID for worker versioning. (Defaults to an empty string.)
-    ///   - maxHeartbeatThrottleInterval: Maximum server-side heartbeat throttle interval used by the worker. Defaults to 60 seconds.
-    ///   - interceptors: Worker interceptors to install for testing/tracing.
+    ///   - configuration: Worker configuration including namespace, task queue, interceptors, and tuning parameters.
     ///   - activities: Activity implementations to register on the worker.
     ///   - workflows: Workflow types to register on the worker.
     ///   - logger: Logger used by the worker. Defaults to a stdout `Logger` at `.info`.
@@ -386,11 +381,7 @@ public struct TemporalTestServer: Sendable {
     /// - Note: The worker is run concurrently in a `TaskGroup`. The group is cancelled after the first task
     ///   (typically your `body`) completes. The transport uses plaintext HTTP/2 and is intended for test environments only.
     public func withConnectedWorker<Result: Sendable>(
-        namespace: String = "default",
-        taskQueue: String = UUID().uuidString,
-        workerBuildID: String = "",
-        maxHeartbeatThrottleInterval: Duration = .seconds(60),
-        interceptors: [any WorkerInterceptor] = [],
+        configuration: TemporalWorker.Configuration,
         activities: [any ActivityDefinition] = [],
         workflows: [any WorkflowDefinition.Type] = [],
         logger: Logger = {
@@ -401,11 +392,7 @@ public struct TemporalTestServer: Sendable {
         _ body: sending @escaping @isolated(any) (TemporalWorker) async throws -> sending Result
     ) async throws -> sending Result {
         try await self.withConnectedWorker(
-            namespace: namespace,
-            taskQueue: taskQueue,
-            workerBuildID: workerBuildID,
-            maxHeartbeatThrottleInterval: maxHeartbeatThrottleInterval,
-            interceptors: interceptors,
+            configuration: configuration,
             activities: activities,
             workflows: workflows,
             workerType: TemporalWorker.self,
@@ -417,11 +404,7 @@ public struct TemporalTestServer: Sendable {
 
     /// Creates a connected Temporal worker for test scenarios including a specific worker type.
     package func withConnectedWorker<Result: Sendable, Worker: TemporalWorkerProtocol>(
-        namespace: String = "default",
-        taskQueue: String = UUID().uuidString,
-        workerBuildID: String = "",
-        maxHeartbeatThrottleInterval: Duration = .seconds(60),
-        interceptors: [any WorkerInterceptor] = [],
+        configuration: TemporalWorker.Configuration,
         activities: [any ActivityDefinition] = [],
         workflows: [any WorkflowDefinition.Type] = [],
         workerType: Worker.Type = Worker.self,
@@ -437,18 +420,8 @@ public struct TemporalTestServer: Sendable {
 
             let (host, port) = self.hostAndPort()
 
-            var workerConfiguration = TemporalWorker.Configuration(
-                namespace: namespace,
-                taskQueue: taskQueue,
-                instrumentation: .init(serverHostname: host),
-                clientIdentity: nil,  // defaults to the SDK name and version followed by a unique ID
-                dataConverter: .default
-            )
-            workerConfiguration.interceptors = interceptors
-            workerConfiguration.maxHeartbeatThrottleInterval = maxHeartbeatThrottleInterval
-
             let worker = Worker(
-                for: workerConfiguration,
+                for: configuration,
                 transport: try .http2NIOPosix(
                     target: .dns(host: host, port: port),
                     transportSecurity: .plaintext,  // plaintext transport for testing

--- a/Tests/TemporalTests/TestHelpers/WorkerTestHelper.swift
+++ b/Tests/TemporalTests/TestHelpers/WorkerTestHelper.swift
@@ -61,6 +61,40 @@ func withTestClient<Result: Sendable>(
 }
 
 func withTestWorkerAndClient<Result: Sendable, Worker: TemporalWorkerProtocol>(
+    configuration: TemporalWorker.Configuration,
+    clientInterceptors: [any ClientInterceptor] = [],
+    activities: [any ActivityDefinition] = [],
+    workflows: [any WorkflowDefinition.Type] = [],
+    workerType: Worker.Type = TemporalWorker.self,
+    clientLogger: Logger = {
+        var logger = Logger(label: "TestClient", factory: { StreamLogHandler.standardOutput(label: $0) })
+        logger.logLevel = .info
+        return logger
+    }(),
+    workerLogger: Logger = {
+        var logger = Logger(label: "TestWorker", factory: { StreamLogHandler.standardOutput(label: $0) })
+        logger.logLevel = .info
+        return logger
+    }(),
+    _ body: sending @escaping @isolated(any) (String, TemporalClient) async throws -> sending Result
+) async throws -> Result {
+    try await TemporalTestServer.testServer!.withConnectedWorker(
+        configuration: configuration,
+        activities: activities,
+        workflows: workflows,
+        workerType: workerType,
+        logger: workerLogger
+    ) { worker in
+        try await TemporalTestServer.testServer!.withConnectedClient(
+            logger: clientLogger,
+            interceptors: clientInterceptors
+        ) { client, _, _ in
+            try await body(configuration.taskQueue, client)
+        }
+    }
+}
+
+func withTestWorkerAndClient<Result: Sendable, Worker: TemporalWorkerProtocol>(
     namespace: String = "default",
     taskQueue: String = UUID().uuidString,
     workerBuildID: String = "",
@@ -82,22 +116,58 @@ func withTestWorkerAndClient<Result: Sendable, Worker: TemporalWorkerProtocol>(
     }(),
     _ body: sending @escaping @isolated(any) (String, TemporalClient) async throws -> sending Result
 ) async throws -> Result {
-    try await TemporalTestServer.testServer!.withConnectedWorker(
+    let (host, _) = TemporalTestServer.testServer!.hostAndPort()
+    var config = TemporalWorker.Configuration(
         namespace: namespace,
         taskQueue: taskQueue,
-        workerBuildID: workerBuildID,
-        maxHeartbeatThrottleInterval: maxHeartbeatThrottleInterval,
-        interceptors: interceptors,
+        instrumentation: .init(serverHostname: host),
+        clientIdentity: nil,
+        dataConverter: .default
+    )
+    config.interceptors = interceptors
+    config.maxHeartbeatThrottleInterval = maxHeartbeatThrottleInterval
+    return try await withTestWorkerAndClient(
+        configuration: config,
+        clientInterceptors: clientInterceptors,
+        activities: activities,
+        workflows: workflows,
+        workerType: workerType,
+        clientLogger: clientLogger,
+        workerLogger: workerLogger,
+        body
+    )
+}
+
+func withTimeSkippingTestWorkerAndClient<Result: Sendable, Worker: TemporalWorkerProtocol>(
+    configuration: TemporalWorker.Configuration,
+    clientInterceptors: [any ClientInterceptor] = [],
+    activities: [any ActivityDefinition] = [],
+    workflows: [any WorkflowDefinition.Type] = [],
+    workerType: Worker.Type = TemporalWorker.self,
+    clientLogger: Logger = {
+        var logger = Logger(label: "TestClient", factory: { StreamLogHandler.standardOutput(label: $0) })
+        logger.logLevel = .info
+        return logger
+    }(),
+    workerLogger: Logger = {
+        var logger = Logger(label: "TestWorker", factory: { StreamLogHandler.standardOutput(label: $0) })
+        logger.logLevel = .info
+        return logger
+    }(),
+    _ body: sending @escaping @isolated(any) (String, TemporalClient) async throws -> sending Result
+) async throws -> Result {
+    try await TemporalTestServer.timeSkippingTestServer!.withConnectedWorker(
+        configuration: configuration,
         activities: activities,
         workflows: workflows,
         workerType: workerType,
         logger: workerLogger
     ) { worker in
-        try await TemporalTestServer.testServer!.withConnectedClient(
+        try await TemporalTestServer.timeSkippingTestServer!.withConnectedClient(
             logger: clientLogger,
             interceptors: clientInterceptors
         ) { client, _, _ in
-            try await body(taskQueue, client)
+            try await body(configuration.taskQueue, client)
         }
     }
 }
@@ -124,24 +194,26 @@ func withTimeSkippingTestWorkerAndClient<Result: Sendable, Worker: TemporalWorke
     }(),
     _ body: sending @escaping @isolated(any) (String, TemporalClient) async throws -> sending Result
 ) async throws -> Result {
-    try await TemporalTestServer.timeSkippingTestServer!.withConnectedWorker(
+    let (host, _) = TemporalTestServer.timeSkippingTestServer!.hostAndPort()
+    var config = TemporalWorker.Configuration(
         namespace: namespace,
         taskQueue: taskQueue,
-        workerBuildID: workerBuildID,
-        maxHeartbeatThrottleInterval: maxHeartbeatThrottleInterval,
-        interceptors: interceptors,
+        instrumentation: .init(serverHostname: host),
+        clientIdentity: nil,
+        dataConverter: .default
+    )
+    config.interceptors = interceptors
+    config.maxHeartbeatThrottleInterval = maxHeartbeatThrottleInterval
+    return try await withTimeSkippingTestWorkerAndClient(
+        configuration: config,
+        clientInterceptors: clientInterceptors,
         activities: activities,
         workflows: workflows,
         workerType: workerType,
-        logger: workerLogger
-    ) { worker in
-        try await TemporalTestServer.timeSkippingTestServer!.withConnectedClient(
-            logger: clientLogger,
-            interceptors: clientInterceptors
-        ) { client, _, _ in
-            try await body(taskQueue, client)
-        }
-    }
+        clientLogger: clientLogger,
+        workerLogger: workerLogger,
+        body
+    )
 }
 
 func executeWorkflow<Workflow: WorkflowDefinition>(

--- a/Tests/TemporalTests/Worker/Tuning/WorkerTunerTests.swift
+++ b/Tests/TemporalTests/Worker/Tuning/WorkerTunerTests.swift
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Temporal
+import TemporalTestKit
+import Testing
+
+extension TestServerDependentTests {
+    @Suite(.tags(.workflowTests))
+    struct WorkerTunerTests {
+        @Workflow
+        final class SimpleWorkflow {
+            func run(input: String) async -> String {
+                return "Hello, \(input)!"
+            }
+        }
+
+        @Test
+        func fixedSizeTunerExecutesWorkflow() async throws {
+            let taskQueue = "tq-\(UUID().uuidString)"
+            let id = "wf-\(UUID().uuidString)"
+
+            try await withTestWorkerAndClient(
+                taskQueue: taskQueue,
+                workflows: [SimpleWorkflow.self]
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: SimpleWorkflow.self,
+                    options: WorkflowOptions(id: id, taskQueue: taskQueue),
+                    input: "Tuner"
+                )
+                let result = try await handle.result()
+                #expect(result == "Hello, Tuner!")
+            }
+        }
+
+        @Test
+        func resourceBasedTunerExecutesWorkflow() async throws {
+            let taskQueue = "tq-\(UUID().uuidString)"
+            let id = "wf-\(UUID().uuidString)"
+
+            let (host, _) = TemporalTestServer.testServer!.hostAndPort()
+
+            var config = TemporalWorker.Configuration(
+                namespace: "default",
+                taskQueue: taskQueue,
+                instrumentation: .init(serverHostname: host)
+            )
+            config.tuner = .resourceBased(
+                targetMemoryUsage: 0.8,
+                targetCpuUsage: 0.9
+            )
+
+            try await withTestWorkerAndClient(
+                configuration: config,
+                workflows: [SimpleWorkflow.self]
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: SimpleWorkflow.self,
+                    options: WorkflowOptions(id: id, taskQueue: taskQueue),
+                    input: "ResourceBased"
+                )
+                let result = try await handle.result()
+                #expect(result == "Hello, ResourceBased!")
+            }
+        }
+
+        @Test
+        func explicitFixedSizeTunerExecutesWorkflow() async throws {
+            let taskQueue = "tq-\(UUID().uuidString)"
+            let id = "wf-\(UUID().uuidString)"
+
+            let (host, _) = TemporalTestServer.testServer!.hostAndPort()
+
+            var config = TemporalWorker.Configuration(
+                namespace: "default",
+                taskQueue: taskQueue,
+                instrumentation: .init(serverHostname: host)
+            )
+            config.tuner = WorkerTuner(
+                workflowSlotSupplier: .fixedSize(.init(maximumSlots: 50)),
+                activitySlotSupplier: .fixedSize(.init(maximumSlots: 200)),
+                localActivitySlotSupplier: .fixedSize(.init(maximumSlots: 75))
+            )
+
+            try await withTestWorkerAndClient(
+                configuration: config,
+                workflows: [SimpleWorkflow.self]
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: SimpleWorkflow.self,
+                    options: WorkflowOptions(id: id, taskQueue: taskQueue),
+                    input: "FixedSize"
+                )
+                let result = try await handle.result()
+                #expect(result == "Hello, FixedSize!")
+            }
+        }
+    }
+}

--- a/Tests/TemporalTests/Worker/WorkerConfigurationTests.swift
+++ b/Tests/TemporalTests/Worker/WorkerConfigurationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Temporal SDK open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
 // Licensed under MIT License
 //
 // See LICENSE.txt for license information
@@ -120,5 +120,395 @@ struct WorkerConfigurationTests {
         )
 
         #expect(config.workerHeartbeatInterval == .milliseconds(heartbeatIntervalMs))
+    }
+
+    // MARK: - Worker Tuner
+
+    @Test
+    func tunerDefaultsToFixedSize() {
+        let config = TemporalWorker.Configuration(
+            namespace: "test",
+            taskQueue: "test-queue",
+            instrumentation: .init(serverHostname: "localhost")
+        )
+
+        guard case .fixedSize(let wfSupplier) = config.tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected fixedSize workflow slot supplier")
+            return
+        }
+        #expect(wfSupplier.maximumSlots == 100)
+
+        guard case .fixedSize(let actSupplier) = config.tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize activity slot supplier")
+            return
+        }
+        #expect(actSupplier.maximumSlots == 100)
+
+        guard case .fixedSize(let laSupplier) = config.tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize local activity slot supplier")
+            return
+        }
+        #expect(laSupplier.maximumSlots == 100)
+    }
+
+    @Test
+    func tunerCanBeSetWithFixedSizeSuppliers() {
+        var config = TemporalWorker.Configuration(
+            namespace: "test",
+            taskQueue: "test-queue",
+            instrumentation: .init(serverHostname: "localhost")
+        )
+
+        config.tuner = WorkerTuner(
+            workflowSlotSupplier: .fixedSize(.init(maximumSlots: 50)),
+            activitySlotSupplier: .fixedSize(.init(maximumSlots: 200)),
+            localActivitySlotSupplier: .fixedSize(.init(maximumSlots: 75))
+        )
+
+        let tuner = config.tuner
+
+        guard case .fixedSize(let wfSupplier) = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected fixedSize workflow slot supplier")
+            return
+        }
+        #expect(wfSupplier.maximumSlots == 50)
+
+        guard case .fixedSize(let actSupplier) = tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize activity slot supplier")
+            return
+        }
+        #expect(actSupplier.maximumSlots == 200)
+
+        guard case .fixedSize(let laSupplier) = tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize local activity slot supplier")
+            return
+        }
+        #expect(laSupplier.maximumSlots == 75)
+    }
+
+    @Test
+    func tunerCanBeSetWithResourceBasedSuppliers() {
+        var config = TemporalWorker.Configuration(
+            namespace: "test",
+            taskQueue: "test-queue",
+            instrumentation: .init(serverHostname: "localhost")
+        )
+
+        let options = ResourceBasedSlotSupplierOptions(
+            minimumSlots: 10,
+            maximumSlots: 500,
+            rampThrottle: .milliseconds(100)
+        )
+        let tunerOptions = ResourceBasedTunerOptions(
+            targetMemoryUsage: 0.8,
+            targetCpuUsage: 0.9
+        )
+
+        config.tuner = WorkerTuner(
+            workflowSlotSupplier: .resourceBased(options, tunerOptions: tunerOptions),
+            activitySlotSupplier: .resourceBased(options, tunerOptions: tunerOptions),
+            localActivitySlotSupplier: .resourceBased(options, tunerOptions: tunerOptions)
+        )
+
+        let tuner = config.tuner
+
+        guard case .resourceBased(let wfOptions, _) = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected resourceBased workflow slot supplier")
+            return
+        }
+        #expect(wfOptions.minimumSlots == 10)
+        #expect(wfOptions.maximumSlots == 500)
+        #expect(wfOptions.rampThrottle == .milliseconds(100))
+    }
+
+    @Test
+    func resourceBasedTunerFactoryMethod() {
+        let tuner = WorkerTuner.resourceBased(
+            targetMemoryUsage: 0.75,
+            targetCpuUsage: 0.85
+        )
+
+        guard case .resourceBased = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected resourceBased workflow slot supplier")
+            return
+        }
+
+        guard case .resourceBased = tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected resourceBased activity slot supplier")
+            return
+        }
+
+        guard case .resourceBased(_, let laTunerOptions) = tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected resourceBased local activity slot supplier")
+            return
+        }
+
+        #expect(laTunerOptions.targetMemoryUsage == 0.75)
+        #expect(laTunerOptions.targetCpuUsage == 0.85)
+    }
+
+    @Test
+    func resourceBasedSlotSupplierOptionsDefaults() {
+        let options = ResourceBasedSlotSupplierOptions()
+
+        #expect(options.minimumSlots == 5)
+        #expect(options.maximumSlots == 100)
+        #expect(options.rampThrottle == .milliseconds(50))
+    }
+
+    @Test
+    func fixedSizeSlotSupplierDefaults() {
+        let options = FixedSizeSlotSupplierOptions()
+
+        #expect(options.maximumSlots == 100)
+    }
+
+    @Test
+    func workerTunerDefaults() {
+        let tuner = WorkerTuner()
+
+        guard case .fixedSize(let wfSupplier) = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected fixedSize workflow slot supplier")
+            return
+        }
+        #expect(wfSupplier.maximumSlots == 100)
+
+        guard case .fixedSize(let actSupplier) = tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize activity slot supplier")
+            return
+        }
+        #expect(actSupplier.maximumSlots == 100)
+
+        guard case .fixedSize(let laSupplier) = tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize local activity slot supplier")
+            return
+        }
+        #expect(laSupplier.maximumSlots == 100)
+    }
+
+    @Test
+    func tunerWithMixedSuppliers() {
+        var config = TemporalWorker.Configuration(
+            namespace: "test",
+            taskQueue: "test-queue",
+            instrumentation: .init(serverHostname: "localhost")
+        )
+
+        let tunerOptions = ResourceBasedTunerOptions()
+
+        config.tuner = WorkerTuner(
+            workflowSlotSupplier: .fixedSize(.init(maximumSlots: 50)),
+            activitySlotSupplier: .resourceBased(.init(), tunerOptions: tunerOptions),
+            localActivitySlotSupplier: .fixedSize(.init(maximumSlots: 100))
+        )
+
+        let tuner = config.tuner
+
+        guard case .fixedSize(let wfSupplier) = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected fixedSize workflow slot supplier")
+            return
+        }
+        #expect(wfSupplier.maximumSlots == 50)
+
+        guard case .resourceBased(_, let actTunerOptions) = tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected resourceBased activity slot supplier")
+            return
+        }
+        #expect(actTunerOptions.targetMemoryUsage == 0.8)
+
+        guard case .fixedSize(let laSupplier) = tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize local activity slot supplier")
+            return
+        }
+        #expect(laSupplier.maximumSlots == 100)
+    }
+
+    // MARK: - Tuner from ConfigReader
+
+    @Test
+    func tunerFromConfigReaderFixedSize() async throws {
+        let container = ConfigReader(
+            provider: InMemoryProvider(
+                values: [
+                    ["temporal", "worker", "namespace"]: .init(stringLiteral: "test"),
+                    ["temporal", "worker", "taskqueue"]: .init(stringLiteral: "test-queue"),
+                    ["temporal", "worker", "buildid"]: .init(stringLiteral: "build-1"),
+                    ["temporal", "worker", "client", "instrumentation", "serverhostname"]: .init(
+                        stringLiteral: "localhost"
+                    ),
+                    ["temporal", "worker", "client", "identity"]: .init(stringLiteral: "test-identity"),
+                    ["temporal", "worker", "tuner", "workflow", "type"]: .init(stringLiteral: "fixed"),
+                    ["temporal", "worker", "tuner", "workflow", "maxslots"]: .init(integerLiteral: 50),
+                    ["temporal", "worker", "tuner", "activity", "type"]: .init(stringLiteral: "fixed"),
+                    ["temporal", "worker", "tuner", "activity", "maxslots"]: .init(integerLiteral: 200),
+                    ["temporal", "worker", "tuner", "localactivity", "type"]: .init(stringLiteral: "fixed"),
+                    ["temporal", "worker", "tuner", "localactivity", "maxslots"]: .init(integerLiteral: 75),
+                ]
+            )
+        )
+
+        let config = try TemporalWorker.Configuration(
+            configReader: container.scoped(to: "temporal")
+        )
+
+        let tuner = config.tuner
+
+        guard case .fixedSize(let wfSupplier) = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected fixedSize workflow slot supplier")
+            return
+        }
+        #expect(wfSupplier.maximumSlots == 50)
+
+        guard case .fixedSize(let actSupplier) = tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize activity slot supplier")
+            return
+        }
+        #expect(actSupplier.maximumSlots == 200)
+
+        guard case .fixedSize(let laSupplier) = tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize local activity slot supplier")
+            return
+        }
+        #expect(laSupplier.maximumSlots == 75)
+    }
+
+    @Test
+    func tunerFromConfigReaderResourceBased() async throws {
+        let container = ConfigReader(
+            provider: InMemoryProvider(
+                values: [
+                    ["temporal", "worker", "namespace"]: .init(stringLiteral: "test"),
+                    ["temporal", "worker", "taskqueue"]: .init(stringLiteral: "test-queue"),
+                    ["temporal", "worker", "buildid"]: .init(stringLiteral: "build-1"),
+                    ["temporal", "worker", "client", "instrumentation", "serverhostname"]: .init(
+                        stringLiteral: "localhost"
+                    ),
+                    ["temporal", "worker", "client", "identity"]: .init(stringLiteral: "test-identity"),
+                    ["temporal", "worker", "tuner", "workflow", "type"]: .init(stringLiteral: "resource-based"),
+                    ["temporal", "worker", "tuner", "activity", "type"]: .init(stringLiteral: "resource-based"),
+                    ["temporal", "worker", "tuner", "localactivity", "type"]: .init(stringLiteral: "resource-based"),
+                    ["temporal", "worker", "tuner", "targetmemoryusage"]: .init(floatLiteral: 0.75),
+                    ["temporal", "worker", "tuner", "targetcpuusage"]: .init(floatLiteral: 0.85),
+                ]
+            )
+        )
+
+        let config = try TemporalWorker.Configuration(
+            configReader: container.scoped(to: "temporal")
+        )
+
+        let tuner = config.tuner
+
+        guard case .resourceBased = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected resourceBased workflow slot supplier")
+            return
+        }
+
+        guard case .resourceBased = tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected resourceBased activity slot supplier")
+            return
+        }
+
+        guard case .resourceBased = tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected resourceBased local activity slot supplier")
+            return
+        }
+
+        if case .resourceBased(_, let tunerOptions) = tuner.workflowSlotSupplier.kind {
+            #expect(tunerOptions.targetMemoryUsage == 0.75)
+            #expect(tunerOptions.targetCpuUsage == 0.85)
+        } else {
+            Issue.record("Expected resource-based supplier")
+        }
+    }
+
+    @Test
+    func tunerFromConfigReaderNoTunerKeysDefaultsToFixedSize() async throws {
+        let container = ConfigReader(
+            provider: InMemoryProvider(
+                values: [
+                    ["temporal", "worker", "namespace"]: .init(stringLiteral: "test"),
+                    ["temporal", "worker", "taskqueue"]: .init(stringLiteral: "test-queue"),
+                    ["temporal", "worker", "buildid"]: .init(stringLiteral: "build-1"),
+                    ["temporal", "worker", "client", "instrumentation", "serverhostname"]: .init(
+                        stringLiteral: "localhost"
+                    ),
+                    ["temporal", "worker", "client", "identity"]: .init(stringLiteral: "test-identity"),
+                ]
+            )
+        )
+
+        let config = try TemporalWorker.Configuration(
+            configReader: container.scoped(to: "temporal")
+        )
+
+        // Default tuner should be fixed-size with 100 slots for all task types
+        let tuner = config.tuner
+
+        guard case .fixedSize(let wfSupplier) = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected fixedSize workflow slot supplier")
+            return
+        }
+        #expect(wfSupplier.maximumSlots == 100)
+
+        guard case .fixedSize(let actSupplier) = tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize activity slot supplier")
+            return
+        }
+        #expect(actSupplier.maximumSlots == 100)
+
+        guard case .fixedSize(let laSupplier) = tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize local activity slot supplier")
+            return
+        }
+        #expect(laSupplier.maximumSlots == 100)
+    }
+
+    @Test
+    func tunerFromConfigReaderMixed() async throws {
+        let container = ConfigReader(
+            provider: InMemoryProvider(
+                values: [
+                    ["temporal", "worker", "namespace"]: .init(stringLiteral: "test"),
+                    ["temporal", "worker", "taskqueue"]: .init(stringLiteral: "test-queue"),
+                    ["temporal", "worker", "buildid"]: .init(stringLiteral: "build-1"),
+                    ["temporal", "worker", "client", "instrumentation", "serverhostname"]: .init(
+                        stringLiteral: "localhost"
+                    ),
+                    ["temporal", "worker", "client", "identity"]: .init(stringLiteral: "test-identity"),
+                    ["temporal", "worker", "tuner", "workflow", "type"]: .init(stringLiteral: "fixed"),
+                    ["temporal", "worker", "tuner", "workflow", "maxslots"]: .init(integerLiteral: 50),
+                    ["temporal", "worker", "tuner", "activity", "type"]: .init(stringLiteral: "resource-based"),
+                    ["temporal", "worker", "tuner", "targetmemoryusage"]: .init(floatLiteral: 0.7),
+                    ["temporal", "worker", "tuner", "targetcpuusage"]: .init(floatLiteral: 0.8),
+                ]
+            )
+        )
+
+        let config = try TemporalWorker.Configuration(
+            configReader: container.scoped(to: "temporal")
+        )
+
+        let tuner = config.tuner
+
+        guard case .fixedSize(let wfSupplier) = tuner.workflowSlotSupplier.kind else {
+            Issue.record("Expected fixedSize workflow slot supplier")
+            return
+        }
+        #expect(wfSupplier.maximumSlots == 50)
+
+        guard case .resourceBased(_, let actTunerOptions) = tuner.activitySlotSupplier.kind else {
+            Issue.record("Expected resourceBased activity slot supplier")
+            return
+        }
+        #expect(actTunerOptions.targetMemoryUsage == 0.7)
+        #expect(actTunerOptions.targetCpuUsage == 0.8)
+
+        // localactivity type not set, defaults to fixed with default slots
+        guard case .fixedSize(let laSupplier) = tuner.localActivitySlotSupplier.kind else {
+            Issue.record("Expected fixedSize local activity slot supplier (default)")
+            return
+        }
+        #expect(laSupplier.maximumSlots == 100)
     }
 }


### PR DESCRIPTION
Adds `WorkerTuner` and `SlotSupplier` types for configuring how task processing slots are allocated. Supports fixed-size and resource-based (CPU/memory-aware) slot suppliers. Existing `maxConcurrent*` configuration options are removed.