### PR TITLE
Add missing `WorkflowOptions` fields

### DIFF
--- a/Sources/Temporal/API/ProtoConversions/Workflows/Priority+Proto.swift
+++ b/Sources/Temporal/API/ProtoConversions/Workflows/Priority+Proto.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+extension Api.Common.V1.Priority {
+    package init(_ priority: Priority) {
+        self.init()
+        self.priorityKey = Int32(priority.priorityKey ?? 0)
+        self.fairnessKey = priority.fairnessKey ?? ""
+        self.fairnessWeight = priority.fairnessWeight ?? 0
+    }
+}

--- a/Sources/Temporal/API/ProtoConversions/Workflows/VersioningOverride+Proto.swift
+++ b/Sources/Temporal/API/ProtoConversions/Workflows/VersioningOverride+Proto.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftProtobuf
+
+extension Api.Workflow.V1.VersioningOverride {
+    package init(_ override: VersioningOverride) {
+        self.init()
+        switch override.kind {
+        case .pinned(let deploymentVersion):
+            var pinnedOverride = PinnedOverride()
+            pinnedOverride.behavior = .pinned
+            pinnedOverride.version = .with {
+                $0.deploymentName = deploymentVersion.deploymentName
+                $0.buildID = deploymentVersion.buildId
+            }
+            self.override = .pinned(pinnedOverride)
+        case .autoUpgrade:
+            self.override = .autoUpgrade(true)
+        }
+    }
+}

--- a/Sources/Temporal/Client/WorkflowService/Model/Workflows/DeploymentVersion.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Workflows/DeploymentVersion.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Represents a version of a worker within a Worker Deployment.
+///
+/// The combination of ``deploymentName`` and ``buildId`` uniquely identifies a version
+/// within a namespace, because deployment names are unique within a namespace.
+public struct DeploymentVersion: Sendable {
+    /// Identifies the Worker Deployment this version is part of.
+    public var deploymentName: String
+
+    /// A unique identifier for this version within the Deployment it is a part of.
+    ///
+    /// Not necessarily unique within the namespace.
+    public var buildId: String
+
+    /// Creates a deployment version.
+    ///
+    /// - Parameters:
+    ///   - deploymentName: Identifies the Worker Deployment this version is part of.
+    ///   - buildId: A unique identifier for this version within the Deployment.
+    public init(deploymentName: String, buildId: String) {
+        self.deploymentName = deploymentName
+        self.buildId = buildId
+    }
+}

--- a/Sources/Temporal/Client/WorkflowService/Model/Workflows/Priority.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Workflows/Priority.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Priority contains metadata that controls relative ordering of task processing when tasks are
+/// backlogged in a queue.
+///
+/// Priority is used in activity and workflow task queues, which are typically where backlogs exist.
+/// Priority is attached to workflows and activities. Activities and child workflows inherit priority
+/// from the workflow that created them, but may override individual fields when they are started or
+/// modified.
+///
+/// For each field, a value of `nil` (or zero/empty string at the proto level) means to inherit the
+/// value from the calling workflow, or if there is no calling workflow, use the default value
+/// documented on the field.
+///
+/// The overall semantics of priority are:
+/// 1. First, consider ``priorityKey``: lower numbers go first (higher priority).
+/// 2. Then, consider fairness: the fairness mechanism attempts to dispatch tasks for a given
+///    ``fairnessKey`` in proportion to its ``fairnessWeight``.
+public struct Priority: Sendable {
+    /// The priority key, which is a positive integer from 1 to *n*, where smaller integers
+    /// correspond to higher priorities (tasks run sooner).
+    ///
+    /// In general, tasks in a queue are processed in close to priority order, although small
+    /// deviations are possible. The maximum priority value (minimum priority) is determined by
+    /// server configuration and defaults to 5.
+    ///
+    /// The default priority is `(min + max) / 2`. With the default max of 5 and min of 1, that
+    /// comes out to 3.
+    ///
+    /// A value of `nil` means inherit from the calling workflow or use the server default.
+    public var priorityKey: Int?
+
+    /// A short string used as a key for the fairness balancing mechanism.
+    ///
+    /// It may correspond to a tenant ID, or to a fixed string like `"high"` or `"low"`. The
+    /// default is the empty string.
+    ///
+    /// The fairness mechanism attempts to dispatch tasks for a given key in proportion to its
+    /// weight. For example, using a thousand distinct tenant IDs, each with a weight of 1.0 (the
+    /// default), will result in each tenant getting a roughly equal share of task dispatch
+    /// throughput.
+    ///
+    /// Fairness keys are limited to 64 bytes.
+    ///
+    /// A value of `nil` means inherit from the calling workflow (defaults to empty string).
+    public var fairnessKey: String?
+
+    /// The fairness weight, which can come from multiple sources for flexibility.
+    ///
+    /// From highest to lowest precedence:
+    /// 1. Weights for a small set of keys can be overridden in task queue configuration with an API.
+    /// 2. It can be attached to the workflow or activity in this field.
+    /// 3. The default weight of 1.0 will be used.
+    ///
+    /// Weight values are clamped to the range \[0.001, 1000\].
+    ///
+    /// A value of `nil` means inherit from the calling workflow or use the default weight of 1.0.
+    public var fairnessWeight: Float?
+
+    /// Creates a priority configuration.
+    ///
+    /// - Parameters:
+    ///   - priorityKey: The priority key (1 to *n*, lower = higher priority). `nil` means inherit.
+    ///   - fairnessKey: Short string used as a key for fairness balancing. `nil` means inherit.
+    ///   - fairnessWeight: Weight for fairness balancing, clamped to \[0.001, 1000\]. `nil` means
+    ///     inherit.
+    public init(priorityKey: Int? = nil, fairnessKey: String? = nil, fairnessWeight: Float? = nil) {
+        self.priorityKey = priorityKey
+        self.fairnessKey = fairnessKey
+        self.fairnessWeight = fairnessWeight
+    }
+
+    /// The default priority (all fields `nil` = inherit/use server defaults).
+    public static let `default` = Priority()
+}

--- a/Sources/Temporal/Client/WorkflowService/Model/Workflows/VersioningOverride.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Workflows/VersioningOverride.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Override for a workflow's versioning behavior.
+///
+/// Versioning overrides control how a workflow execution interacts with worker deployment versions.
+/// A workflow can either be pinned to a specific deployment version or set to auto-upgrade to the
+/// current deployment version on the next workflow task.
+public struct VersioningOverride: Sendable {
+    package enum Kind: Sendable {
+        case pinned(deploymentVersion: DeploymentVersion)
+        case autoUpgrade
+    }
+
+    package let kind: Kind
+
+    private init(_ kind: Kind) { self.kind = kind }
+
+    /// Pin the workflow to a specific deployment version.
+    ///
+    /// The workflow will remain on the specified version until the override is changed.
+    ///
+    /// - Parameter deploymentVersion: The deployment version to pin the workflow to.
+    /// - Returns: A versioning override that pins the workflow to the given version.
+    public static func pinned(deploymentVersion: DeploymentVersion) -> VersioningOverride {
+        .init(.pinned(deploymentVersion: deploymentVersion))
+    }
+
+    /// Auto-upgrade the workflow to the current deployment version on the next workflow task.
+    public static let autoUpgrade = VersioningOverride(.autoUpgrade)
+}

--- a/Sources/Temporal/Client/WorkflowService/Model/Workflows/WorkflowOptions.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Workflows/WorkflowOptions.swift
@@ -52,6 +52,78 @@ public struct WorkflowOptions: Sendable {
     /// than this duration, it will be terminated. If `nil`, no execution timeout is applied.
     public var executionTimeOut: Duration?
 
+    /// The maximum time for a single workflow run.
+    ///
+    /// Unlike ``executionTimeOut`` which spans retries and continue-as-new transitions, this timeout
+    /// applies only to an individual workflow run. If the workflow run exceeds this duration, it will
+    /// be terminated. If `nil`, no run timeout is applied.
+    public var runTimeout: Duration?
+
+    /// The maximum time for a single workflow task.
+    ///
+    /// A workflow task is the processing of a batch of events by the workflow code. If a workflow task
+    /// takes longer than this duration, it will be timed out and retried. If `nil`, the server default
+    /// (typically 10 seconds) is used.
+    public var taskTimeout: Duration?
+
+    /// The delay before the workflow starts executing.
+    ///
+    /// When set, the server will wait this duration before dispatching the first workflow task.
+    /// If the workflow receives a signal before the delay expires, a workflow task will be dispatched
+    /// immediately and the remaining delay will be ignored.
+    ///
+    /// - Note: Cannot be used with ``cronSchedule``.
+    public var startDelay: Duration?
+
+    /// The cron schedule expression for the workflow.
+    ///
+    /// When set, the workflow will be executed on the specified cron schedule. Uses standard cron
+    /// expression syntax (e.g. `"0 * * * *"` for every hour).
+    ///
+    /// - Note: Deprecated in favor of Temporal Schedules, but still supported for backward compatibility.
+    /// - Note: Cannot be used with ``startDelay``.
+    public var cronSchedule: String?
+
+    /// Whether to request eager workflow task dispatch.
+    ///
+    /// When `true`, the server is encouraged to dispatch the first workflow task to a local worker
+    /// running this same client. This can reduce the latency to start the workflow by avoiding
+    /// a round-trip through the task queue. Defaults to `false`.
+    public var requestEagerStart: Bool
+
+    /// A single-line fixed summary for this workflow execution that may appear in UI/CLI.
+    ///
+    /// This can be in single-line Temporal markdown format. The summary is set at workflow start
+    /// and cannot be changed during execution. The value is limited to 400 bytes.
+    ///
+    /// - Important: This setting is experimental.
+    public var staticSummary: String?
+
+    /// General fixed details for this workflow execution that may appear in UI/CLI.
+    ///
+    /// This can be in Temporal markdown format and can span multiple lines. The details are set at
+    /// workflow start and cannot be changed during execution. For details that can be updated
+    /// during the workflow's lifecycle, use `Workflow.currentDetails` within the workflow.
+    /// The value is limited to 20000 bytes.
+    ///
+    /// - Important: This setting is experimental.
+    public var staticDetails: String?
+
+    /// The priority for this workflow execution.
+    ///
+    /// Priority controls the relative ordering of task processing when tasks are backlogged in a queue.
+    /// Lower priority key values correspond to higher priorities (tasks run sooner). Activities and
+    /// child workflows inherit priority from the workflow that created them, but may override fields.
+    public var priority: Priority?
+
+    /// The versioning override for this workflow execution.
+    ///
+    /// When set, takes precedence over the versioning behavior sent by the SDK on workflow task
+    /// completion. The workflow can be pinned to a specific deployment version or set to auto-upgrade
+    /// to the current deployment version. To unset the override after the workflow is running, use
+    /// `UpdateWorkflowExecutionOptions`.
+    public var versioningOverride: VersioningOverride?
+
     /// Key-value metadata attached to the workflow for application-specific purposes.
     ///
     /// Memos provide a way to attach custom metadata to workflows that is accessible throughout
@@ -78,6 +150,15 @@ public struct WorkflowOptions: Sendable {
     ///   - taskQueue: The task queue to run the workflow on.
     ///   - retryPolicy: The workflow's retry policy. Defaults to `nil` (no retries).
     ///   - executionTimeOut: The total execution timeout of the workflow. Defaults to `nil` (no timeout).
+    ///   - runTimeout: The timeout for a single workflow run. Defaults to `nil` (no timeout).
+    ///   - taskTimeout: The timeout for a single workflow task. Defaults to `nil` (server default).
+    ///   - startDelay: The delay before the workflow starts executing. Defaults to `nil` (no delay).
+    ///   - cronSchedule: The cron schedule expression. Defaults to `nil` (no cron).
+    ///   - requestEagerStart: Whether to request eager workflow task dispatch. Defaults to `false`.
+    ///   - staticSummary: A fixed summary for the workflow. Defaults to `nil`.
+    ///   - staticDetails: Fixed details for the workflow. Defaults to `nil`.
+    ///   - priority: The workflow execution priority. Defaults to `nil`.
+    ///   - versioningOverride: The versioning override. Defaults to `nil`.
     ///   - searchAttributes: The search attributes for the workflow. Defaults to `nil`.
     ///   - idReusePolicy: The workflow ID reuse policy. Defaults to allowing duplicate IDs after completion.
     ///   - idConflictPolicy: The workflow ID conflict policy. Defaults to failing when conflicts occur.
@@ -87,6 +168,15 @@ public struct WorkflowOptions: Sendable {
         taskQueue: String,
         retryPolicy: RetryPolicy? = nil,
         executionTimeOut: Duration? = nil,
+        runTimeout: Duration? = nil,
+        taskTimeout: Duration? = nil,
+        startDelay: Duration? = nil,
+        cronSchedule: String? = nil,
+        requestEagerStart: Bool = false,
+        staticSummary: String? = nil,
+        staticDetails: String? = nil,
+        priority: Priority? = nil,
+        versioningOverride: VersioningOverride? = nil,
         searchAttributes: SearchAttributeCollection? = nil,
         idReusePolicy: Api.Enums.V1.WorkflowIdReusePolicy = .allowDuplicate,
         idConflictPolicy: Api.Enums.V1.WorkflowIdConflictPolicy = .fail,
@@ -98,17 +188,16 @@ public struct WorkflowOptions: Sendable {
         self.idReusePolicy = idReusePolicy
         self.idConflictPolicy = idConflictPolicy
         self.executionTimeOut = executionTimeOut
+        self.runTimeout = runTimeout
+        self.taskTimeout = taskTimeout
+        self.startDelay = startDelay
+        self.cronSchedule = cronSchedule
+        self.requestEagerStart = requestEagerStart
+        self.staticSummary = staticSummary
+        self.staticDetails = staticDetails
+        self.priority = priority
+        self.versioningOverride = versioningOverride
         self.searchAttributes = searchAttributes
         self.callOptions = callOptions
     }
-
-    //    CronSchedule
-    //    RequestEagerStart
-    //    RunTimeout
-    //    StartDelay
-    //    StartSignal
-    //    StartSignalArgs
-    //    StaticDetails
-    //    StaticSummary
-    //    TaskTimeout
 }

--- a/Sources/Temporal/Extensions/SignalWithStartWorkflowExecutionRequest+Proto.swift
+++ b/Sources/Temporal/Extensions/SignalWithStartWorkflowExecutionRequest+Proto.swift
@@ -58,6 +58,22 @@ extension Api.Workflowservice.V1.SignalWithStartWorkflowExecutionRequest {
             self.workflowExecutionTimeout = .init(duration: executionTimeOut)
         }
 
+        if let runTimeout = workflowOptions.runTimeout {
+            self.workflowRunTimeout = .init(duration: runTimeout)
+        }
+
+        if let taskTimeout = workflowOptions.taskTimeout {
+            self.workflowTaskTimeout = .init(duration: taskTimeout)
+        }
+
+        if let startDelay = workflowOptions.startDelay {
+            self.workflowStartDelay = .init(duration: startDelay)
+        }
+
+        if let cronSchedule = workflowOptions.cronSchedule {
+            self.cronSchedule = cronSchedule
+        }
+
         if let retryPolicy = workflowOptions.retryPolicy {
             self.retryPolicy = .init(retryPolicy: retryPolicy)
         }
@@ -74,6 +90,24 @@ extension Api.Workflowservice.V1.SignalWithStartWorkflowExecutionRequest {
 
         if let searchAttributes = workflowOptions.searchAttributes, !searchAttributes.isEmpty {
             self.searchAttributes = .init(searchAttributes)
+        }
+
+        if workflowOptions.staticSummary != nil || workflowOptions.staticDetails != nil {
+            self.userMetadata = .init()
+            if let staticSummary = workflowOptions.staticSummary {
+                self.userMetadata.summary = try await dataConverter.convertValue(staticSummary)
+            }
+            if let staticDetails = workflowOptions.staticDetails {
+                self.userMetadata.details = try await dataConverter.convertValue(staticDetails)
+            }
+        }
+
+        if let priority = workflowOptions.priority {
+            self.priority = .init(priority)
+        }
+
+        if let versioningOverride = workflowOptions.versioningOverride {
+            self.versioningOverride = .init(versioningOverride)
         }
 
         if !headers.isEmpty {

--- a/Sources/Temporal/Extensions/StartWorkflowExecutionRequest+Proto.swift
+++ b/Sources/Temporal/Extensions/StartWorkflowExecutionRequest+Proto.swift
@@ -34,6 +34,7 @@ extension Api.Workflowservice.V1.StartWorkflowExecutionRequest {
             $0.requestID = requestID
             $0.workflowIDReusePolicy = workflowOptions.idReusePolicy
             $0.workflowIDConflictPolicy = workflowOptions.idConflictPolicy
+            $0.requestEagerExecution = workflowOptions.requestEagerStart
             $0.input = .with {
                 $0.payloads = inputs
             }
@@ -41,6 +42,22 @@ extension Api.Workflowservice.V1.StartWorkflowExecutionRequest {
 
         if let executionTimeOut = workflowOptions.executionTimeOut {
             self.workflowExecutionTimeout = .init(duration: executionTimeOut)
+        }
+
+        if let runTimeout = workflowOptions.runTimeout {
+            self.workflowRunTimeout = .init(duration: runTimeout)
+        }
+
+        if let taskTimeout = workflowOptions.taskTimeout {
+            self.workflowTaskTimeout = .init(duration: taskTimeout)
+        }
+
+        if let startDelay = workflowOptions.startDelay {
+            self.workflowStartDelay = .init(duration: startDelay)
+        }
+
+        if let cronSchedule = workflowOptions.cronSchedule {
+            self.cronSchedule = cronSchedule
         }
 
         if let retryPolicy = workflowOptions.retryPolicy {
@@ -59,6 +76,24 @@ extension Api.Workflowservice.V1.StartWorkflowExecutionRequest {
 
         if let searchAttributes = workflowOptions.searchAttributes, !searchAttributes.isEmpty {
             self.searchAttributes = .init(searchAttributes)
+        }
+
+        if workflowOptions.staticSummary != nil || workflowOptions.staticDetails != nil {
+            self.userMetadata = .init()
+            if let staticSummary = workflowOptions.staticSummary {
+                self.userMetadata.summary = try await dataConverter.convertValue(staticSummary)
+            }
+            if let staticDetails = workflowOptions.staticDetails {
+                self.userMetadata.details = try await dataConverter.convertValue(staticDetails)
+            }
+        }
+
+        if let priority = workflowOptions.priority {
+            self.priority = .init(priority)
+        }
+
+        if let versioningOverride = workflowOptions.versioningOverride {
+            self.versioningOverride = .init(versioningOverride)
         }
 
         if !headers.isEmpty {

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowOptionsTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowOptionsTests.swift
@@ -23,9 +23,23 @@ struct WorkflowOptionsTests {
         "WorkflowOptions",
         arguments: [
             WorkflowOptions(id: UUID().uuidString, taskQueue: "test-queue"),
-            WorkflowOptions(id: UUID().uuidString, taskQueue: "test-queue", idReusePolicy: .allowDuplicateFailedOnly, idConflictPolicy: .useExisting),
-            WorkflowOptions(id: UUID().uuidString, taskQueue: "test-queue", idReusePolicy: .rejectDuplicate, idConflictPolicy: .terminateExisting),
-            WorkflowOptions(id: UUID().uuidString, taskQueue: "test-queue", executionTimeOut: .seconds(2)),
+            WorkflowOptions(
+                id: UUID().uuidString,
+                taskQueue: "test-queue",
+                idReusePolicy: .allowDuplicateFailedOnly,
+                idConflictPolicy: .useExisting
+            ),
+            WorkflowOptions(
+                id: UUID().uuidString,
+                taskQueue: "test-queue",
+                idReusePolicy: .rejectDuplicate,
+                idConflictPolicy: .terminateExisting
+            ),
+            WorkflowOptions(
+                id: UUID().uuidString,
+                taskQueue: "test-queue",
+                executionTimeOut: .seconds(2)
+            ),
             WorkflowOptions(
                 id: UUID().uuidString,
                 taskQueue: "test-queue",
@@ -66,7 +80,7 @@ struct WorkflowOptionsTests {
         #expect(request.workflowIDConflictPolicy == options.idConflictPolicy)
 
         if let timeout = options.executionTimeOut {
-            #expect(Duration(request.workflowExecutionTimeout) == timeout)
+            #expect(request.workflowExecutionTimeout.seconds == timeout.components.seconds)
         } else {
             #expect(!request.hasWorkflowExecutionTimeout)
         }
@@ -76,5 +90,279 @@ struct WorkflowOptionsTests {
         } else {
             #expect(!request.hasRetryPolicy)
         }
+    }
+
+    @Test("WorkflowOptions with runTimeout")
+    func testRunTimeout() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            runTimeout: .seconds(30)
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.hasWorkflowRunTimeout)
+        #expect(request.workflowRunTimeout.seconds == 30)
+    }
+
+    @Test("WorkflowOptions with taskTimeout")
+    func testTaskTimeout() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            taskTimeout: .seconds(10)
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.hasWorkflowTaskTimeout)
+        #expect(request.workflowTaskTimeout.seconds == 10)
+    }
+
+    @Test("WorkflowOptions with startDelay")
+    func testStartDelay() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            startDelay: .seconds(5)
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.hasWorkflowStartDelay)
+        #expect(request.workflowStartDelay.seconds == 5)
+    }
+
+    @Test("WorkflowOptions with cronSchedule")
+    func testCronSchedule() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            cronSchedule: "0 * * * *"
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.cronSchedule == "0 * * * *")
+    }
+
+    @Test("WorkflowOptions with requestEagerStart")
+    func testRequestEagerStart() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            requestEagerStart: true
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.requestEagerExecution == true)
+    }
+
+    @Test("WorkflowOptions requestEagerStart defaults to false")
+    func testRequestEagerStartDefault() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue"
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.requestEagerExecution == false)
+    }
+
+    @Test("WorkflowOptions with staticSummary and staticDetails")
+    func testStaticSummaryAndDetails() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            staticSummary: "My workflow summary",
+            staticDetails: "My workflow details\nwith multiple lines"
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.hasUserMetadata)
+        #expect(request.userMetadata.hasSummary)
+        #expect(request.userMetadata.hasDetails)
+    }
+
+    @Test("WorkflowOptions with priority")
+    func testPriority() async throws {
+        let priority = Priority(priorityKey: 1)
+
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            priority: priority
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.hasPriority)
+        #expect(request.priority.priorityKey == 1)
+    }
+
+    @Test("WorkflowOptions with versioningOverride")
+    func testVersioningOverride() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            versioningOverride: .autoUpgrade
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(request.hasVersioningOverride)
+        #expect(request.versioningOverride.autoUpgrade == true)
+    }
+
+    @Test("WorkflowOptions nil optional fields produce no proto fields")
+    func testNilOptionalFieldsProduceNoProtoFields() async throws {
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue"
+        )
+
+        let request = try await Api.Workflowservice.V1.StartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: []
+        )
+
+        #expect(!request.hasWorkflowRunTimeout)
+        #expect(!request.hasWorkflowTaskTimeout)
+        #expect(!request.hasWorkflowStartDelay)
+        #expect(request.cronSchedule.isEmpty)
+        #expect(!request.hasUserMetadata)
+        #expect(!request.hasPriority)
+        #expect(!request.hasVersioningOverride)
+    }
+
+    @Test("SignalWithStart proto conversion includes new fields")
+    func testSignalWithStartProtoConversion() async throws {
+        let priority = Priority(priorityKey: 2)
+
+        let options = WorkflowOptions(
+            id: UUID().uuidString,
+            taskQueue: "test-queue",
+            runTimeout: .seconds(60),
+            taskTimeout: .seconds(10),
+            startDelay: .seconds(5),
+            cronSchedule: "*/5 * * * *",
+            staticSummary: "Signal workflow",
+            priority: priority
+        )
+
+        let request = try await Api.Workflowservice.V1.SignalWithStartWorkflowExecutionRequest(
+            namespace: "default",
+            identity: "test-identity",
+            requestID: "test-request",
+            workflowTypeName: "TestWorkflow",
+            workflowOptions: options,
+            dataConverter: .default,
+            headers: [:],
+            inputs: [],
+            signalName: "test-signal",
+            signalInput: []
+        )
+
+        #expect(request.hasWorkflowRunTimeout)
+        #expect(request.workflowRunTimeout.seconds == 60)
+        #expect(request.hasWorkflowTaskTimeout)
+        #expect(request.workflowTaskTimeout.seconds == 10)
+        #expect(request.hasWorkflowStartDelay)
+        #expect(request.workflowStartDelay.seconds == 5)
+        #expect(request.cronSchedule == "*/5 * * * *")
+        #expect(request.hasUserMetadata)
+        #expect(request.hasPriority)
+        #expect(request.priority.priorityKey == 2)
     }
 }


### PR DESCRIPTION
Adds `runTimeout`, `taskTimeout`, `startDelay`, `cronSchedule`, `requestEagerStart`, `staticSummary`, `staticDetails`, `priority`, and `versioningOverride` to `WorkflowOptions`. Updates proto conversions for `StartWorkflowExecution` and `SignalWithStartWorkflowExecution`. This PR also introduces new `Priority` and `VersioningOverride` types to express these new options.