### PR TITLE
Fix data conversion for cross-SDK compatibility

### DIFF
--- a/Sources/Temporal/Converters/BinaryProtobufPayloadConverter.swift
+++ b/Sources/Temporal/Converters/BinaryProtobufPayloadConverter.swift
@@ -29,7 +29,12 @@ public struct BinaryProtobufPayloadConverter: EncodingPayloadConverter {
             throw EncodingError()
         }
 
-        return createPayload(for: (try value.serializedBytes() as [UInt8]))
+        return createPayload(
+            for: (try value.serializedBytes() as [UInt8]),
+            additionalMetadata: [
+                Encodings.messageTypeKey: Data(type(of: value).protoMessageName.utf8)
+            ]
+        )
     }
 
     public func convertPayload<Value>(

--- a/Sources/Temporal/Converters/DataConverter.swift
+++ b/Sources/Temporal/Converters/DataConverter.swift
@@ -53,7 +53,15 @@ public struct DataConverter: Sendable {
         self.payloadCodec = payloadCodec
     }
 
-    package func convertValues<each Value>(
+    /// Converts a variadic list of optional values into an array of payloads.
+    ///
+    /// Each value is individually converted using the payload converter and optionally
+    /// encoded through the payload codec if one is configured.
+    ///
+    /// - Parameter values: A variadic list of optional values to convert.
+    /// - Returns: An array of payloads, one per input value.
+    /// - Throws: If any value cannot be converted by the payload converter or encoded by the payload codec.
+    public func convertValues<each Value>(
         _ values: repeat (each Value)?
     ) async throws -> [Api.Common.V1.Payload] {
         var payloads = [Api.Common.V1.Payload]()
@@ -63,7 +71,15 @@ public struct DataConverter: Sendable {
         return payloads
     }
 
-    package func convertValue<Value>(
+    /// Converts a single optional value into a payload.
+    ///
+    /// If the value is `Void`, an empty payload is returned. Otherwise, the value is converted
+    /// using the payload converter and optionally encoded through the payload codec.
+    ///
+    /// - Parameter value: The value to convert.
+    /// - Returns: The converted payload.
+    /// - Throws: If the value cannot be converted by the payload converter or encoded by the payload codec.
+    public func convertValue<Value>(
         _ value: Value?
     ) async throws -> Api.Common.V1.Payload {
         if value is Void {
@@ -80,7 +96,19 @@ public struct DataConverter: Sendable {
         return payload
     }
 
-    package func convertPayloads<each Value>(
+    /// Converts an array of payloads into a tuple of typed values.
+    ///
+    /// The number of payloads must match the number of requested value types. Each payload is
+    /// individually decoded, optionally through the payload codec first, and then through the
+    /// payload converter.
+    ///
+    /// - Parameters:
+    ///   - payloads: The array of payloads to convert.
+    ///   - valueTypes: The expected types to decode each payload into.
+    /// - Returns: A tuple of decoded values matching the requested types.
+    /// - Throws: If the number of payloads does not match the number of types, or if any payload
+    ///   cannot be decoded.
+    public func convertPayloads<each Value>(
         _ payloads: [Api.Common.V1.Payload],
         as valueTypes: repeat (each Value).Type
     ) async throws -> (repeat each Value) {
@@ -100,7 +128,19 @@ public struct DataConverter: Sendable {
         return try await (repeat self.convertPayload(payloads.removeFirst()) as each Value)
     }
 
-    package func convertPayload<Value>(
+    /// Converts a single payload into a typed value.
+    ///
+    /// If the requested type is `Void`, the payload is ignored and `Void` is returned.
+    /// Otherwise, the payload is optionally decoded through the payload codec first,
+    /// and then converted using the payload converter.
+    ///
+    /// - Parameters:
+    ///   - payload: The payload to convert.
+    ///   - valueType: The expected type to decode the payload into.
+    /// - Returns: The decoded value.
+    /// - Throws: If the payload cannot be decoded by the payload codec or converted by the
+    ///   payload converter.
+    public func convertPayload<Value>(
         _ payload: Api.Common.V1.Payload,
         as valueType: Value.Type = Value.self
     ) async throws -> Value {
@@ -117,7 +157,15 @@ public struct DataConverter: Sendable {
         return try self.payloadConverter.convertPayload(payload, as: Value.self)
     }
 
-    package func convertError(_ error: any Error) async -> Api.Failure.V1.Failure {
+    /// Converts a Swift error into a Temporal failure proto.
+    ///
+    /// The error is first converted using the failure converter, and then optionally encoded
+    /// through the payload codec. If codec encoding fails, a generic failure with the message
+    /// "Failed to encode failure" is returned.
+    ///
+    /// - Parameter error: The error to convert.
+    /// - Returns: The converted Temporal failure proto.
+    public func convertError(_ error: any Error) async -> Api.Failure.V1.Failure {
         let temporalFailure = self.failureConverter.convertError(
             error,
             payloadConverter: self.payloadConverter
@@ -138,7 +186,15 @@ public struct DataConverter: Sendable {
         return temporalFailure
     }
 
-    package func convertFailure(
+    /// Converts a Temporal failure proto back into a Swift error.
+    ///
+    /// The failure is optionally decoded through the payload codec first, and then converted
+    /// using the failure converter. If codec decoding fails, a ``BasicTemporalFailureError``
+    /// with the message "Failed to decode failure" is returned.
+    ///
+    /// - Parameter temporalFailure: The Temporal failure proto to convert.
+    /// - Returns: The converted Swift error.
+    public func convertFailure(
         _ temporalFailure: Api.Failure.V1.Failure
     ) async -> any Error {
         var temporalFailure = temporalFailure

--- a/Sources/Temporal/Converters/DefaultFailureConverter.swift
+++ b/Sources/Temporal/Converters/DefaultFailureConverter.swift
@@ -48,7 +48,7 @@ public struct DefaultFailureConverter: FailureConverter {
             // This is documented here: https://docs.temporal.io/dataconversion#failure-converter
             let attributes: [String: String] = [
                 "message": temporalFailure.message,
-                "stackTrace": temporalFailure.stackTrace,
+                "stack_trace": temporalFailure.stackTrace,
             ]
 
             // This string matches what the other SDKs do
@@ -82,7 +82,7 @@ public struct DefaultFailureConverter: FailureConverter {
                     temporalFailure.message = message
                 }
 
-                if let stackTrace = decodedAttributes["stackTrace"] {
+                if let stackTrace = decodedAttributes["stack_trace"] {
                     temporalFailure.stackTrace = stackTrace
                 }
 

--- a/Sources/Temporal/Converters/JSONProtobufPayloadConverter.swift
+++ b/Sources/Temporal/Converters/JSONProtobufPayloadConverter.swift
@@ -29,7 +29,12 @@ public struct JSONProtobufPayloadConverter: EncodingPayloadConverter {
             throw EncodingError()
         }
 
-        return createPayload(for: Array(try value.jsonString().utf8))
+        return createPayload(
+            for: Array(try value.jsonString().utf8),
+            additionalMetadata: [
+                Encodings.messageTypeKey: Data(type(of: value).protoMessageName.utf8)
+            ]
+        )
     }
 
     public func convertPayload<Value>(

--- a/Sources/Temporal/Statics/Encodings.swift
+++ b/Sources/Temporal/Statics/Encodings.swift
@@ -14,6 +14,7 @@
 
 enum Encodings {
     internal static let encodingKey = "encoding"
+    internal static let messageTypeKey = "messageType"
     internal static let binaryNil = "binary/null"
     internal static let binaryPlain = "binary/plain"
     internal static let jsonProtobuf = "json/protobuf"

--- a/Tests/TemporalTests/Converters/BinaryProtobufPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/BinaryProtobufPayloadConverterTests.swift
@@ -46,12 +46,35 @@ struct BinaryProtobufPayloadConverterTests {
 
         let payload = try payloadConverter.convertValue(testMessage)
         #expect(payload.data == Data([8, 1]))
-        #expect(payload.metadata == ["encoding": Data("binary/protobuf".utf8)])
+        #expect(
+            payload.metadata
+                == [
+                    "encoding": Data("binary/protobuf".utf8),
+                    "messageType": Data("TestMessage".utf8),
+                ]
+        )
 
         let convertedMessage = try payloadConverter.convertPayload(
             payload,
             as: TestMessage.self
         )
         #expect(convertedMessage.seconds == 1)
+    }
+
+    @Test
+    func convertProtoMessageWithMessageTypePresent() async throws {
+        let payloadConverter = BinaryProtobufPayloadConverter()
+        let testMessage = TestMessage.with {
+            $0.seconds = 42
+        }
+
+        let payload = try payloadConverter.convertValue(testMessage)
+
+        // Verify messageType metadata is set
+        #expect(payload.metadata["messageType"] == Data("TestMessage".utf8))
+
+        // Verify decoding still works when messageType is present
+        let decoded = try payloadConverter.convertPayload(payload, as: TestMessage.self)
+        #expect(decoded.seconds == 42)
     }
 }

--- a/Tests/TemporalTests/Converters/DefaultFailureConverterTests.swift
+++ b/Tests/TemporalTests/Converters/DefaultFailureConverterTests.swift
@@ -121,7 +121,7 @@ struct DefaultFailureConverterTests {
         #expect(failure.stackTrace == "")
         let expectedPayload = try jsonPayloadConverter.convertValue([
             "message": "Error description",
-            "stackTrace": "",
+            "stack_trace": "",
         ])
         #expect(failure.encodedAttributes == expectedPayload)
         #expect(failure.failureInfo == .applicationFailureInfo(.with { $0.type = "TestError" }))
@@ -133,7 +133,7 @@ struct DefaultFailureConverterTests {
         let jsonPayloadConverter = JSONPayloadConverter()
         let encodedAttributes = try jsonPayloadConverter.convertValue([
             "message": "Error description",
-            "stackTrace": "Some stack trace",
+            "stack_trace": "Some stack trace",
         ])
 
         let failure = Api.Failure.V1.Failure.with {
@@ -386,5 +386,62 @@ struct DefaultFailureConverterTests {
         #expect(decodedError.stackTrace == "Some stack trace")
         #expect(decodedError.type == .startToClose)
         #expect(decodedError.lastHeartbeatDetails == expectedDetails)
+    }
+
+    @Test
+    func encodeCommonAttributesUsesSnakeCaseKey() async throws {
+        let applicationError = ApplicationError(
+            message: "Test message",
+            stackTrace: "line1\nline2",
+            type: "TestError"
+        )
+        var failureConverter = DefaultFailureConverter()
+        failureConverter.encodeCommonAttributes = true
+        let jsonPayloadConverter = JSONPayloadConverter()
+
+        let failure = failureConverter.convertError(
+            applicationError,
+            payloadConverter: jsonPayloadConverter
+        )
+
+        #expect(failure.message == "Encoded failure")
+        #expect(failure.stackTrace == "")
+
+        // Decode the encoded attributes and verify the key is "stack_trace"
+        let decodedAttributes = try jsonPayloadConverter.convertPayload(
+            failure.encodedAttributes,
+            as: [String: String].self
+        )
+        #expect(decodedAttributes["stack_trace"] == "line1\nline2")
+        #expect(decodedAttributes["message"] == "Test message")
+    }
+
+    @Test
+    func encodeCommonAttributesRoundTrips() async throws {
+        let applicationError = ApplicationError(
+            message: "Round trip message",
+            stackTrace: "frame1\nframe2\nframe3",
+            type: "TestError",
+            isNonRetryable: true
+        )
+        var failureConverter = DefaultFailureConverter()
+        failureConverter.encodeCommonAttributes = true
+        let jsonPayloadConverter = JSONPayloadConverter()
+
+        let failure = failureConverter.convertError(
+            applicationError,
+            payloadConverter: jsonPayloadConverter
+        )
+
+        let error = failureConverter.convertFailure(
+            failure,
+            payloadConverter: jsonPayloadConverter
+        )
+
+        let convertedError = try #require(error as? ApplicationError)
+        #expect(convertedError.message == "Round trip message")
+        #expect(convertedError.stackTrace == "frame1\nframe2\nframe3")
+        #expect(convertedError.type == "TestError")
+        #expect(convertedError.isNonRetryable == true)
     }
 }

--- a/Tests/TemporalTests/Converters/DefaultPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/DefaultPayloadConverterTests.swift
@@ -106,7 +106,13 @@ struct DefaultPayloadConverterTests {
 
         let payload = try payloadConverter.convertValue(testMessage)
         #expect(payload.data == Data([123, 34, 115, 101, 99, 111, 110, 100, 115, 34, 58, 34, 49, 34, 125]))
-        #expect(payload.metadata == ["encoding": Data("json/protobuf".utf8)])
+        #expect(
+            payload.metadata
+                == [
+                    "encoding": Data("json/protobuf".utf8),
+                    "messageType": Data("TestMessage".utf8),
+                ]
+        )
 
         let convertedMessage = try payloadConverter.convertPayload(
             payload,

--- a/Tests/TemporalTests/Converters/JSONProtobufPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/JSONProtobufPayloadConverterTests.swift
@@ -48,12 +48,35 @@ struct JSONProtobufPayloadConverterTests {
         #expect(
             payload.data == Data([123, 34, 115, 101, 99, 111, 110, 100, 115, 34, 58, 34, 49, 34, 125])
         )
-        #expect(payload.metadata == ["encoding": Data("json/protobuf".utf8)])
+        #expect(
+            payload.metadata
+                == [
+                    "encoding": Data("json/protobuf".utf8),
+                    "messageType": Data("TestMessage".utf8),
+                ]
+        )
 
         let convertedMessage = try payloadConverter.convertPayload(
             payload,
             as: TestMessage.self
         )
         #expect(convertedMessage.seconds == 1)
+    }
+
+    @Test
+    func convertProtoMessageWithMessageTypePresent() async throws {
+        let payloadConverter = JSONProtobufPayloadConverter()
+        let testMessage = TestMessage.with {
+            $0.seconds = 42
+        }
+
+        let payload = try payloadConverter.convertValue(testMessage)
+
+        // Verify messageType metadata is set
+        #expect(payload.metadata["messageType"] == Data("TestMessage".utf8))
+
+        // Verify decoding still works when messageType is present
+        let decoded = try payloadConverter.convertPayload(payload, as: TestMessage.self)
+        #expect(decoded.seconds == 42)
     }
 }


### PR DESCRIPTION
Changes encoded failure attribute key from "stackTrace" to "stack_trace" for cross-language compatibility. Makes `DataConverter conversion methods public to match what other SDKs expose. Adds protobuf `messageType` metadata to binary and JSON protobuf payload converters.