### PR TITLE
Add dynamic activity support

### DIFF
--- a/Sources/Temporal/Macros/ActivityMacro.swift
+++ b/Sources/Temporal/Macros/ActivityMacro.swift
@@ -28,9 +28,29 @@
 /// }
 /// ```
 ///
-/// - Parameter name: The name of the activity. If not provided, defaults to the function name.
+/// ## Dynamic Activities
+///
+/// Mark an activity as dynamic to create a catch-all handler for unregistered activity types:
+///
+/// ```swift
+/// struct MyDynamicActivity {
+///     @Activity(dynamic: true)
+///     func handle(input: [TemporalRawValue]) async throws -> TemporalRawValue {
+///         let activityType = ActivityExecutionContext.current!.info.activityType
+///         // Handle based on activity type...
+///     }
+/// }
+/// ```
+///
+/// - Parameters:
+///   - name: The name of the activity. If not provided, defaults to the function name.
+///   - dynamic: Whether this activity is dynamic. A dynamic activity cannot have a custom name.
 @attached(peer)
-public macro Activity(name: String? = nil) = #externalMacro(module: "TemporalMacros", type: "ActivityMacro")
+public macro Activity(name: String? = nil, dynamic: Bool = false) =
+    #externalMacro(
+        module: "TemporalMacros",
+        type: "ActivityMacro"
+    )
 
 /// Generates an extension conforming to ``ActivityContainer`` for a type containing activity functions.
 ///

--- a/Sources/Temporal/Worker/Activities/ActivityDefinition.swift
+++ b/Sources/Temporal/Worker/Activities/ActivityDefinition.swift
@@ -57,6 +57,22 @@ public protocol ActivityDefinition: Sendable {
     /// Defaults to the string representation of the conforming type.
     static var name: String { get }
 
+    /// Whether this activity is a dynamic activity that handles unregistered activity types.
+    ///
+    /// Dynamic activities act as catch-all handlers for activity types that are not explicitly registered
+    /// with the worker. When the worker receives a task for an unregistered activity type and a dynamic
+    /// activity is registered, the task is routed to the dynamic activity instead of failing.
+    ///
+    /// Dynamic activities must use `[TemporalRawValue]` as their ``Input`` type to receive
+    /// the raw arguments. The activity type name is available via
+    /// ``ActivityExecutionContext/info``'s ``ActivityExecutionContext/Info-swift.struct/activityType``.
+    ///
+    /// A worker can have at most one dynamic activity registered. Dynamic activities cannot have
+    /// a custom name -- the name is ignored when ``isDynamic`` returns `true`.
+    ///
+    /// Default is `false`.
+    static var isDynamic: Bool { get }
+
     /// Executes the activity with the provided input.
     ///
     /// This method contains the core logic of the activity and will be invoked by the Temporal worker
@@ -71,5 +87,9 @@ public protocol ActivityDefinition: Sendable {
 extension ActivityDefinition {
     public static var name: String {
         String(describing: self)
+    }
+
+    public static var isDynamic: Bool {
+        false
     }
 }

--- a/Sources/Temporal/Worker/Activities/ActivityWorker.swift
+++ b/Sources/Temporal/Worker/Activities/ActivityWorker.swift
@@ -63,9 +63,8 @@ package final class ActivityWorker<BridgeWorker: BridgeWorkerProtocol>: Activity
     private let worker: BridgeWorker
     /// A dictionary of registered activity implementations indexed by their type names.
     ///
-    /// Activities are stored with their registered names as keys. A `nil` key indicates support for dynamic
-    /// activities (not yet implemented).
-    // TODO: Add support for dynamic activities.
+    /// Activities are stored with their registered names as keys. A `nil` key indicates a dynamic
+    /// activity that handles unregistered activity types.
     private let activities: [String?: any ActivityDefinition]
     /// The name of the task queue from which this worker polls for activity tasks.
     private let taskQueue: String
@@ -81,6 +80,12 @@ package final class ActivityWorker<BridgeWorker: BridgeWorkerProtocol>: Activity
 
     /// The interceptor implementation chain for processing activity inbound calls.
     private let implementation: Implementation
+
+    /// The reserved name prefix for internal/system activity types.
+    ///
+    /// Activity names starting with this prefix are reserved for Temporal internal use.
+    /// Registration of activities with names starting with this prefix will cause an error.
+    private static var reservedNamePrefix: String { "__temporal_" }
 
     /// Creates an activity worker with the specified configuration and dependencies.
     ///
@@ -103,10 +108,21 @@ package final class ActivityWorker<BridgeWorker: BridgeWorkerProtocol>: Activity
         logger: Logger
     ) throws {
         self.worker = worker
+
+        // Validate reserved name prefix and build the activities dictionary
+        for activity in activities {
+            let name = Self.getName(for: activity)
+            if let name, name.hasPrefix(Self.reservedNamePrefix) {
+                throw TemporalSDKError(
+                    "Activity name \"\(name)\" cannot start with reserved prefix \"\(Self.reservedNamePrefix)\""
+                )
+            }
+        }
+
         self.activities = try Dictionary(
             activities.map { (Self.getName(for: $0), $0) },
             uniquingKeysWith: { first, second in
-                let activityName = Self.getName(for: first) ?? "unknown"
+                let activityName = Self.getName(for: first) ?? "dynamic"
                 logger.info("Duplicate activity registration", metadata: [LoggingKeys.activityName: "\(activityName)"])
                 throw TemporalSDKError("Duplicate activity: \(activityName)")
             }
@@ -187,7 +203,8 @@ package final class ActivityWorker<BridgeWorker: BridgeWorkerProtocol>: Activity
         case .start(let activityTaskStart):
             logger.debug("Starting activity")
 
-            guard let activity = self.activities[activityTaskStart.activityType] else {
+            // Look up the activity by name, falling back to the dynamic activity (nil key)
+            guard let activity = self.activities[activityTaskStart.activityType] ?? self.activities[nil] else {
                 logger.debug("No activity registered for type")
                 try await self.sendActivityCompletionForUnknownActivity(
                     taskToken: activityTask.taskToken,
@@ -301,6 +318,21 @@ package final class ActivityWorker<BridgeWorker: BridgeWorkerProtocol>: Activity
                                     let input: A.Input
                                     if A.Input.self == Void.self {
                                         input = () as! A.Input
+                                    } else if A.isDynamic, A.Input.self == [TemporalRawValue].self {
+                                        // Dynamic activities receive just the raw payloads.
+                                        // The activity type name is available via
+                                        // ActivityExecutionContext.current.info.activityType.
+                                        var rawArgs = [TemporalRawValue]()
+                                        for payload in activityTaskStart.input {
+                                            if let payloadCodec = self.dataConverter.payloadCodec {
+                                                rawArgs.append(
+                                                    TemporalRawValue(try await payloadCodec.decode(payload: payload))
+                                                )
+                                            } else {
+                                                rawArgs.append(TemporalRawValue(payload))
+                                            }
+                                        }
+                                        input = rawArgs as! A.Input
                                     } else {
                                         input = try await self.dataConverter.convertPayloads(
                                             activityTaskStart.input,
@@ -484,11 +516,17 @@ package final class ActivityWorker<BridgeWorker: BridgeWorkerProtocol>: Activity
 
     /// Extracts the activity name from an activity definition for registration purposes.
     ///
+    /// For dynamic activities (where ``ActivityDefinition/isDynamic`` returns `true`), this
+    /// method returns `nil` to register the activity under the dynamic key.
+    ///
     /// - Parameter activity: The activity definition to get the name from.
-    /// - Returns: The activity name used for server registration and routing.
+    /// - Returns: The activity name used for server registration and routing, or `nil` for dynamic activities.
     private static func getName<Activity: ActivityDefinition>(
         for activity: Activity
     ) -> String? {
+        if Activity.isDynamic {
+            return nil
+        }
         return Activity.name
     }
 }

--- a/Sources/TemporalMacros/ActivityContainerMacro.swift
+++ b/Sources/TemporalMacros/ActivityContainerMacro.swift
@@ -17,7 +17,8 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 private struct ActivityInfo {
-    var name: String
+    var name: String?
+    var isDynamic: Bool
     var parentMethodName: String
     var parentTypeName: String
     var isStatic: Bool
@@ -27,9 +28,16 @@ private struct ActivityInfo {
     var structDefinition: DeclSyntax {
         let closureType: String = "@Sendable (\(inputType)) async throws -> \(resultType)"
 
+        let nameDecl: String
+        if isDynamic {
+            nameDecl = "static var isDynamic: Bool { true }"
+        } else {
+            nameDecl = "static var name: String { \"\(name!)\" }"
+        }
+
         return """
             struct \(raw: parentMethodName.capitalizingFirst()): ActivityDefinition {
-                static var name: String { "\(raw: name)" }
+                \(raw: nameDecl)
                 var _run: \(raw: closureType)
                 init(run: @escaping \(raw: closureType)) { self._run = run }
                 func run(input: \(raw: inputType == "" ? "Void" : inputType)) async throws -> \(raw: resultType) {
@@ -76,11 +84,18 @@ public struct ActivityContainerMacro: ExtensionMacro {
             }
 
             let methodName = functionDecl.name.trimmedDescription
-            let activityName = activityAttribute.stringValueForArgument(named: "name") ?? methodName.capitalizingFirst()
+            let isDynamic = activityAttribute.boolValueForArgument(named: "dynamic") ?? false
+            let activityName: String?
+            if isDynamic {
+                activityName = nil
+            } else {
+                activityName = activityAttribute.stringValueForArgument(named: "name") ?? methodName.capitalizingFirst()
+            }
 
             activities.append(
                 ActivityInfo(
                     name: activityName,
+                    isDynamic: isDynamic,
                     parentMethodName: methodName,
                     parentTypeName: type.trimmedDescription,
                     isStatic: functionDecl.modifiers.contains { $0.trimmedDescription == "static" },

--- a/Sources/TemporalMacros/ActivityMacro.swift
+++ b/Sources/TemporalMacros/ActivityMacro.swift
@@ -40,6 +40,15 @@ public struct ActivityMacro: PeerMacro {
             throw MacroError(message: "Activity macro can not be applied to a member function with multiple parameters")
         }
 
+        let isDynamic = node.boolValueForArgument(named: "dynamic") ?? false
+        let hasCustomName = node.stringValueForArgument(named: "name") != nil
+
+        if isDynamic && hasCustomName {
+            throw MacroError(
+                message: "A dynamic activity cannot have a custom name. Dynamic activities handle all unregistered activity types."
+            )
+        }
+
         return []
     }
 }

--- a/Sources/TemporalMacros/AttributeSyntax+Utilities.swift
+++ b/Sources/TemporalMacros/AttributeSyntax+Utilities.swift
@@ -27,4 +27,10 @@ extension AttributeSyntax {
         guard case let .stringSegment(value) = stringLiteral.segments.first else { return nil }
         return value.trimmed.content.text
     }
+    func boolValueForArgument(named name: String) -> Bool? {
+        guard case let .argumentList(arguments) = arguments else { return nil }
+        guard let element = arguments.first(where: { $0.label?.text == name }) else { return nil }
+        guard let boolLiteral = element.expression.as(BooleanLiteralExprSyntax.self) else { return nil }
+        return boolLiteral.literal.tokenKind == .keyword(.true)
+    }
 }

--- a/Tests/TemporalMacrosTests/ActivityMacrosTests.swift
+++ b/Tests/TemporalMacrosTests/ActivityMacrosTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
@@ -339,5 +340,61 @@ struct ActivityMacrosTests {
 
         #expect(expectedOutput == actualOutput)
         #expect(diagnostics.isEmpty)
+    }
+
+    @Test
+    func dynamicActivity() throws {
+        let (expectedOutput, _) = try parse(
+            """
+            struct Foo {
+                static func handle(input: [TemporalRawValue]) -> TemporalRawValue { fatalError() }
+            }
+
+            extension Foo: ActivityContainer {
+                struct Activities {
+                    struct Handle: ActivityDefinition {
+                        static var isDynamic: Bool { true }
+                        var _run: @Sendable ([TemporalRawValue]) async throws -> TemporalRawValue
+                        init(run: @escaping @Sendable ([TemporalRawValue]) async throws -> TemporalRawValue) { self._run = run }
+                        func run(input: [TemporalRawValue]) async throws -> TemporalRawValue { return try await self._run(input) }
+                    }
+                    var handle: Handle { return .init(run: Foo.handle) }
+                }
+                var activities: Activities { return .init() }
+                var allActivities: [any ActivityDefinition] { return [self.activities.handle] }
+            }
+            """
+        )
+        let (actualOutput, diagnostics) = try parse(
+            """
+            @ActivityContainer
+            struct Foo {
+                @Activity(dynamic: true)
+                static func handle(input: [TemporalRawValue]) -> TemporalRawValue { fatalError() }
+            }
+            """
+        )
+
+        #expect(expectedOutput == actualOutput)
+        #expect(diagnostics.isEmpty)
+    }
+
+    @Test
+    func dynamicActivityWithCustomNameProducesError() throws {
+        let (_, diagnostics) = try parse(
+            """
+            @ActivityContainer
+            struct Foo {
+                @Activity(name: "CustomName", dynamic: true)
+                static func handle(input: [TemporalRawValue]) -> TemporalRawValue { fatalError() }
+            }
+            """
+        )
+
+        #expect(diagnostics.count == 1)
+        #expect(
+            diagnostics.first?.message
+                == "A dynamic activity cannot have a custom name. Dynamic activities handle all unregistered activity types."
+        )
     }
 }

--- a/Tests/TemporalTests/Worker/Activities/ActivityWorkerTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityWorkerTests.swift
@@ -318,6 +318,25 @@ private struct UniqueActivity: ActivityDefinition {
     func run(input: Void) async throws {}
 }
 
+private struct TestDynamicActivity: ActivityDefinition {
+    typealias Input = [TemporalRawValue]
+    typealias Output = String
+
+    static var isDynamic: Bool { true }
+
+    func run(input: [TemporalRawValue]) async throws -> String {
+        let activityType = ActivityExecutionContext.current!.info.activityType
+        return "handled:\(activityType):args=\(input.count)"
+    }
+}
+
+private struct ReservedNameActivity: ActivityDefinition {
+    typealias Input = Void
+    typealias Output = Void
+    static var name: String { "__temporal_reserved" }
+    func run(input: Void) async throws {}
+}
+
 @Suite()
 struct ActivityWorkerTests {
     private let bridgeWorker = MockBridgeWorker()
@@ -946,6 +965,155 @@ struct ActivityWorkerTests {
         // Verify no logs were recorded
         logHandler.entries.withLock { entries in
             #expect(entries.isEmpty)
+        }
+    }
+
+    @Test
+    static func dynamicActivityHandlesUnregisteredType() async throws {
+        let test = ActivityWorkerTests(activities: [TestDynamicActivity()])
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await test.activityWorker.run()
+            }
+
+            test.bridgeWorker.activityTaskContinuation.yield(
+                .with {
+                    $0.taskToken = Data([1])
+                    $0.start.activityType = "SomeUnregisteredActivity"
+                    $0.start.activityID = "ActivityID1"
+                    $0.start.attempt = 1
+                    $0.start.workflowType = "WorkflowType"
+                    $0.start.workflowExecution = .with {
+                        $0.runID = "RunID"
+                        $0.workflowID = "WorkflowID1"
+                    }
+                    $0.start.input = [
+                        .with {
+                            $0.data = Data(#""hello""#.utf8)
+                            $0.metadata = ["encoding": Data("json/plain".utf8)]
+                        }
+                    ]
+                }
+            )
+
+            var activityTaskCompletionIterator = test.bridgeWorker.activityTaskCompletionStream.makeAsyncIterator()
+            let completion = try await activityTaskCompletionIterator.next()
+            #expect(completion!.taskToken == Data([1]))
+            // The dynamic activity returns "handled:<activityType>:args=<count>"
+            let resultString = String(data: completion!.result.completed.result.data, encoding: .utf8)
+            #expect(resultString == #""handled:SomeUnregisteredActivity:args=1""#)
+            group.cancelAll()
+        }
+    }
+
+    @Test
+    static func dynamicActivityReceivesCorrectNameAndArgs() async throws {
+        let test = ActivityWorkerTests(activities: [TestDynamicActivity()])
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await test.activityWorker.run()
+            }
+
+            test.bridgeWorker.activityTaskContinuation.yield(
+                .with {
+                    $0.taskToken = Data([1])
+                    $0.start.activityType = "CustomType"
+                    $0.start.activityID = "ActivityID1"
+                    $0.start.attempt = 1
+                    $0.start.workflowType = "WorkflowType"
+                    $0.start.workflowExecution = .with {
+                        $0.runID = "RunID"
+                        $0.workflowID = "WorkflowID1"
+                    }
+                    $0.start.input = [
+                        .with {
+                            $0.data = Data(#""arg1""#.utf8)
+                            $0.metadata = ["encoding": Data("json/plain".utf8)]
+                        },
+                        .with {
+                            $0.data = Data(#""arg2""#.utf8)
+                            $0.metadata = ["encoding": Data("json/plain".utf8)]
+                        },
+                    ]
+                }
+            )
+
+            var activityTaskCompletionIterator = test.bridgeWorker.activityTaskCompletionStream.makeAsyncIterator()
+            let completion = try await activityTaskCompletionIterator.next()
+            #expect(completion!.taskToken == Data([1]))
+            let resultString = String(data: completion!.result.completed.result.data, encoding: .utf8)
+            #expect(resultString == #""handled:CustomType:args=2""#)
+            group.cancelAll()
+        }
+    }
+
+    @Test
+    static func registeredActivityTakesPrecedenceOverDynamic() async throws {
+        let test = ActivityWorkerTests(activities: [VoidActivity(), TestDynamicActivity()])
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await test.activityWorker.run()
+            }
+
+            // Send a task for the registered VoidActivity
+            test.bridgeWorker.activityTaskContinuation.yield(
+                .with {
+                    $0.taskToken = Data([1])
+                    $0.start.activityType = "VoidActivity"
+                    $0.start.activityID = "ActivityID1"
+                    $0.start.attempt = 1
+                    $0.start.workflowType = "WorkflowType"
+                    $0.start.workflowExecution = .with {
+                        $0.runID = "RunID"
+                        $0.workflowID = "WorkflowID1"
+                    }
+                }
+            )
+
+            var activityTaskCompletionIterator = test.bridgeWorker.activityTaskCompletionStream.makeAsyncIterator()
+            let completion = try await activityTaskCompletionIterator.next()
+            // VoidActivity returns empty result (not the dynamic activity's string)
+            let expectedCompletion = Coresdk.ActivityTaskCompletion.with {
+                $0.taskToken = Data([1])
+                $0.result.completed.result = .init()
+            }
+            #expect(completion == expectedCompletion)
+            group.cancelAll()
+        }
+    }
+
+    @Test
+    func reservedNamePrefixThrowsError() async throws {
+        let bridgeWorker = MockBridgeWorker()
+
+        #expect(throws: (any Error).self) {
+            let _ = try ActivityWorker(
+                worker: bridgeWorker,
+                activities: [ReservedNameActivity()],
+                taskQueue: "test-queue",
+                dataConverter: .default,
+                interceptors: [],
+                logger: .init(label: "TestLogger")
+            )
+        }
+    }
+
+    @Test
+    func duplicateDynamicActivitiesThrowsError() async throws {
+        let bridgeWorker = MockBridgeWorker()
+
+        #expect(throws: (any Error).self) {
+            let _ = try ActivityWorker(
+                worker: bridgeWorker,
+                activities: [TestDynamicActivity(), TestDynamicActivity()],
+                taskQueue: "test-queue",
+                dataConverter: .default,
+                interceptors: [],
+                logger: .init(label: "TestLogger")
+            )
         }
     }
 }

--- a/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowActivityTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowActivityTests.swift
@@ -208,6 +208,48 @@ extension TestServerDependentTests {
                 activities: [InfiniteActivity()],
             )
         }
+
+        // MARK: - Dynamic Activity Tests
+
+        struct DynamicActivity: ActivityDefinition {
+            static var isDynamic: Bool { true }
+
+            func run(input: [TemporalRawValue]) async throws -> String {
+                let activityType = ActivityExecutionContext.current!.info.activityType
+                // Decode the first raw argument to demonstrate deserialization works.
+                // Using DefaultPayloadConverter directly since the activity context
+                // does not yet expose a public payload converter (planned in Section 20).
+                let converter = DefaultPayloadConverter()
+                let decodedArg: String =
+                    input.isEmpty
+                    ? "<none>"
+                    : try converter.convertPayload(input[0].payload, as: String.self)
+                return "dynamic:\(activityType):\(decodedArg)"
+            }
+        }
+
+        @Workflow
+        final class DynamicActivityWorkflow {
+            func run(input: String) async throws -> String {
+                try await Workflow.executeActivity(
+                    name: "SomeUnregisteredActivity",
+                    options: .init(startToCloseTimeout: .seconds(10)),
+                    input: input,
+                    outputType: String.self
+                )
+            }
+        }
+
+        @Test
+        func dynamicActivityHandlesUnregisteredWorkflowActivity() async throws {
+            let result = try await executeWorkflow(
+                DynamicActivityWorkflow.self,
+                input: "hello",
+                activities: [DynamicActivity()]
+            )
+
+            #expect(result == "dynamic:SomeUnregisteredActivity:hello")
+        }
     }
 }
 


### PR DESCRIPTION
Adds support for dynamic activities that handle unregistered activity types at runtime. Dynamic activities receive the activity type name and raw arguments, enabling plugin systems and generic handlers. This PR also adds reserved name prefix validation for activity registration. Furthermore, this PR expands the `@Activity` macro to support declaring dynamic activities.