### PR TITLE
Add handler unfinished policy for signals and updates

### DIFF
--- a/Sources/Temporal/Macros/WorkflowMacro.swift
+++ b/Sources/Temporal/Macros/WorkflowMacro.swift
@@ -81,8 +81,11 @@ public macro Workflow(name: String? = nil) = #externalMacro(module: "TemporalMac
 ///
 /// - Parameter name: The name of the signal. If not provided, defaults to the function name.
 /// - Parameter description: An optional description of the signal's purpose.
+/// - Parameter unfinishedPolicy: The policy for handling unfinished instances of this handler when
+///   the workflow exits. Defaults to ``HandlerUnfinishedPolicy/warnAndAbandon``.
 @attached(peer, names: arbitrary)
-public macro WorkflowSignal(name: String? = nil, description: String? = nil) = #externalMacro(module: "TemporalMacros", type: "WorkflowSignalMacro")
+public macro WorkflowSignal(name: String? = nil, description: String? = nil, unfinishedPolicy: HandlerUnfinishedPolicy = .warnAndAbandon) =
+    #externalMacro(module: "TemporalMacros", type: "WorkflowSignalMacro")
 
 /// Defines a query handler for a workflow.
 ///
@@ -163,8 +166,11 @@ public macro WorkflowQuery(name: String? = nil, description: String? = nil) = #e
 ///
 /// - Parameter name: The name of the update. If not provided, defaults to the function name.
 /// - Parameter description: An optional description of the update's purpose.
+/// - Parameter unfinishedPolicy: The policy for handling unfinished instances of this handler when
+///   the workflow exits. Defaults to ``HandlerUnfinishedPolicy/warnAndAbandon``.
 @attached(peer, names: arbitrary)
-public macro WorkflowUpdate(name: String? = nil, description: String? = nil) = #externalMacro(module: "TemporalMacros", type: "WorkflowUpdateMacro")
+public macro WorkflowUpdate(name: String? = nil, description: String? = nil, unfinishedPolicy: HandlerUnfinishedPolicy = .warnAndAbandon) =
+    #externalMacro(module: "TemporalMacros", type: "WorkflowUpdateMacro")
 
 /// Makes workflow state sendable by ensuring it is modified on the workflow's executor.
 ///

--- a/Sources/Temporal/Statics/LoggingKeys.swift
+++ b/Sources/Temporal/Statics/LoggingKeys.swift
@@ -30,4 +30,6 @@ struct LoggingKeys {
     static let activityID = TemporalTracingKeys.activityID
     static let activityName = "temporal.activity.name"
     static let activityAttempt = "temporal.activity.attempt"
+    static let unfinishedSignalHandlers = "temporal.workflow.unfinished.signals"
+    static let unfinishedUpdateHandlers = "temporal.workflow.unfinished.updates"
 }

--- a/Sources/Temporal/Worker/Workflow/HandlerUnfinishedPolicy.swift
+++ b/Sources/Temporal/Worker/Workflow/HandlerUnfinishedPolicy.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Policy defining actions taken when a workflow exits while update or signal handlers are still
+/// running.
+///
+/// The workflow exit may be due to successful return, failure, cancellation, or continue-as-new.
+public struct HandlerUnfinishedPolicy: Sendable, Equatable {
+    package enum Kind: Sendable, Equatable {
+        case warnAndAbandon
+        case abandon
+    }
+
+    package let kind: Kind
+
+    private init(_ kind: Kind) {
+        self.kind = kind
+    }
+
+    /// Log a warning when the workflow exits with running handlers.
+    ///
+    /// This is the default policy. When the workflow completes while handlers are still running,
+    /// a warning will be logged to help identify potentially interrupted work.
+    public static let warnAndAbandon = HandlerUnfinishedPolicy(.warnAndAbandon)
+
+    /// Silently abandon running handlers when the workflow exits.
+    ///
+    /// Use this policy when it is expected and acceptable for the handler to be interrupted
+    /// by workflow completion.
+    public static let abandon = HandlerUnfinishedPolicy(.abandon)
+}

--- a/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
@@ -288,6 +288,10 @@ struct WorkflowInstance: Sendable {
                 )
             }
 
+            // Warn about unfinished handlers when the workflow completes and we are
+            // not replaying (to avoid duplicate warnings during replay).
+            self.warnUnfinishedHandlers()
+
             switch workflowResult {
             case .success(let output):
                 self.logger.trace("Workflow finished")
@@ -492,7 +496,11 @@ struct WorkflowInstance: Sendable {
                 return
             }
 
-            await self.runMessageHandler {
+            await self.runMessageHandler(
+                name: signal.name,
+                updateId: nil,
+                unfinishedPolicy: signal.unfinishedPolicy
+            ) {
                 await self.runSignal(
                     signal: signal,
                     workflow: workflow,
@@ -566,7 +574,11 @@ struct WorkflowInstance: Sendable {
         group.addTask(executorPreference: self.executor) {
             let workflow = workflow.wrapped
             if queryWorkflow.queryType == "__temporal_workflow_metadata" {
-                await self.runMessageHandler {
+                await self.runMessageHandler(
+                    name: queryWorkflow.queryType,
+                    updateId: nil,
+                    unfinishedPolicy: .abandon
+                ) {
                     do {
                         let metadata = workflowMetadata(type: Workflow.self, context: workflowContext)
                         // Use the default data converter as this query will be
@@ -607,7 +619,11 @@ struct WorkflowInstance: Sendable {
                 return
             }
 
-            await self.runMessageHandler {
+            await self.runMessageHandler(
+                name: query.name,
+                updateId: nil,
+                unfinishedPolicy: .abandon
+            ) {
                 await self.runQuery(
                     id: queryWorkflow.queryID,
                     query: query,
@@ -763,7 +779,11 @@ struct WorkflowInstance: Sendable {
                 return
             }
 
-            await self.runMessageHandler {
+            await self.runMessageHandler(
+                name: update.name,
+                updateId: updateWorkflow.protocolInstanceID,
+                unfinishedPolicy: update.unfinishedPolicy
+            ) {
                 await self.runUpdate(
                     id: updateWorkflow.protocolInstanceID,
                     runValidator: updateWorkflow.runValidator,
@@ -913,10 +933,70 @@ struct WorkflowInstance: Sendable {
 
     // MARK: Handlers
 
-    private func runMessageHandler(body: () async -> Void) async {
-        self.stateMachine.handlerStarted()
+    /// Logs a warning if there are still running handlers with the ``HandlerUnfinishedPolicy/warnAndAbandon`` policy
+    /// when the workflow's run method completes.
+    private func warnUnfinishedHandlers() {
+        let isReplaying = Self.$isOnWorkflowInstance.withValue(true) {
+            self.stateMachine.isReplaying()
+        }
+        guard !isReplaying else { return }
+
+        let warnEntries = Self.$isOnWorkflowInstance.withValue(true) {
+            self.stateMachine.unfinishedWarnHandlerEntries()
+        }
+        guard !warnEntries.isEmpty else { return }
+
+        // Separate signals (updateId == nil) from updates (updateId != nil)
+        let signalEntries = warnEntries.filter { $0.updateId == nil }
+        let updateEntries = warnEntries.filter { $0.updateId != nil }
+
+        // Build metadata
+        var metadata: Logger.Metadata = [:]
+
+        if !signalEntries.isEmpty {
+            var signalCounts: [String: Int] = [:]
+            for entry in signalEntries {
+                signalCounts[entry.name, default: 0] += 1
+            }
+            let signalParts =
+                signalCounts
+                .sorted(by: { $0.key < $1.key })
+                .map { "{\"name\":\"\($0.key)\",\"count\":\($0.value)}" }
+            metadata[LoggingKeys.unfinishedSignalHandlers] = "[\(signalParts.joined(separator: ","))]"
+        }
+
+        if !updateEntries.isEmpty {
+            let updateParts =
+                updateEntries
+                .sorted(by: { $0.name < $1.name })
+                .map { "{\"name\":\"\($0.name)\",\"id\":\"\($0.updateId ?? "")\"}" }
+            metadata[LoggingKeys.unfinishedUpdateHandlers] = "[\(updateParts.joined(separator: ","))]"
+        }
+
+        let message: Logger.Message =
+            """
+            Workflow finished while signal or update handlers are still running. \
+            This may have interrupted work that a handler was doing, and the client that sent the \
+            update may receive a 'workflow execution already completed' error. \
+            You can wait for all handlers to finish by using \
+            `try await Workflow.condition { Workflow.allHandlersFinished }`. \
+            Alternatively, to suppress this warning for a specific handler, set its unfinished \
+            policy to `.abandon`, for example: \
+            `@WorkflowSignal(unfinishedPolicy: .abandon)`.
+            """
+
+        self.logger.info(message, metadata: metadata)
+    }
+
+    private func runMessageHandler(
+        name: String,
+        updateId: String?,
+        unfinishedPolicy: HandlerUnfinishedPolicy,
+        body: () async -> Void
+    ) async {
+        self.stateMachine.handlerStarted(name: name, updateId: updateId, unfinishedPolicy: unfinishedPolicy)
         await body()
-        self.stateMachine.handlerFinished()
+        self.stateMachine.handlerFinished(name: name, updateId: updateId)
     }
 
     // MARK: Top level error handling

--- a/Sources/Temporal/Worker/Workflow/WorkflowSignalDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowSignalDefinition.swift
@@ -65,6 +65,13 @@ public protocol WorkflowSignalDefinition<Workflow>: Sendable {
     /// users understand the signal's functionality. Defaults to `nil`.
     static var description: String? { get }
 
+    /// The policy for handling unfinished instances of this handler when the workflow exits.
+    ///
+    /// This controls what happens when the workflow completes (successfully, with failure,
+    /// cancellation, or continue-as-new) while this signal handler is still running.
+    /// Defaults to ``HandlerUnfinishedPolicy/warnAndAbandon``.
+    static var unfinishedPolicy: HandlerUnfinishedPolicy { get }
+
     /// Executes the signal handler logic.
     ///
     /// This method is called when a signal is received by the workflow.
@@ -94,5 +101,13 @@ extension WorkflowSignalDefinition {
     /// Instance property providing access to the static description.
     var description: String? {
         Self.description
+    }
+
+    /// Default implementation returning ``HandlerUnfinishedPolicy/warnAndAbandon``.
+    public static var unfinishedPolicy: HandlerUnfinishedPolicy { .warnAndAbandon }
+
+    /// Instance property providing access to the static unfinished policy.
+    var unfinishedPolicy: HandlerUnfinishedPolicy {
+        Self.unfinishedPolicy
     }
 }

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachine.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachine.swift
@@ -18,6 +18,16 @@ import struct Foundation.Date
 import struct Foundation.UUID
 
 struct WorkflowStateMachine: ~Copyable {
+    /// An entry representing a currently running handler.
+    struct ActiveHandlerEntry: Sendable {
+        /// The name of the handler (signal or update name).
+        var name: String
+        /// The update ID if this is an update handler, `nil` for signals.
+        var updateId: String?
+        /// The unfinished policy for this handler.
+        var unfinishedPolicy: HandlerUnfinishedPolicy
+    }
+
     /// The state of the workflow.
     enum State: ~Copyable {
         /// The state when the workflow is actively running.
@@ -52,6 +62,9 @@ struct WorkflowStateMachine: ~Copyable {
 
             /// Number of current running and unfinished handlers.
             var numberOfActiveHandlers: Int
+
+            /// Descriptions of currently running handlers, used for warning on unfinished handlers.
+            var activeHandlerEntries: [ActiveHandlerEntry]
 
             /// Whether or not the activation is replaying past events.
             var isReplaying: Bool
@@ -138,6 +151,7 @@ struct WorkflowStateMachine: ~Copyable {
             nextExternalSignalSequenceNumber: 0,
             nextExternalCancelSequenceNumber: 0,
             numberOfActiveHandlers: 0,
+            activeHandlerEntries: [],
             isReplaying: false,
             now: .now,
             continueAsNewSuggested: false,
@@ -399,18 +413,32 @@ struct WorkflowStateMachine: ~Copyable {
         }
     }
 
-    mutating func handlerStarted() {
+    mutating func handlerStarted(name: String, updateId: String?, unfinishedPolicy: HandlerUnfinishedPolicy) {
         switch consume self.state {
         case .active(var active):
             active.numberOfActiveHandlers += 1
+            active.activeHandlerEntries.append(
+                ActiveHandlerEntry(name: name, updateId: updateId, unfinishedPolicy: unfinishedPolicy)
+            )
             self = .init(state: .active(active))
         }
     }
 
-    mutating func handlerFinished() {
+    mutating func handlerFinished(name: String, updateId: String?) {
         switch consume self.state {
         case .active(var active):
             active.numberOfActiveHandlers -= 1
+            if let updateId {
+                // For updates, match on updateId for precise identification
+                if let index = active.activeHandlerEntries.firstIndex(where: { $0.updateId == updateId }) {
+                    active.activeHandlerEntries.remove(at: index)
+                }
+            } else {
+                // For signals, match on name (first matching entry)
+                if let index = active.activeHandlerEntries.firstIndex(where: { $0.name == name && $0.updateId == nil }) {
+                    active.activeHandlerEntries.remove(at: index)
+                }
+            }
             self = .init(state: .active(active))
         }
     }
@@ -419,6 +447,15 @@ struct WorkflowStateMachine: ~Copyable {
         switch self.state {
         case .active(let active):
             return active.numberOfActiveHandlers == 0
+        }
+    }
+
+    /// Returns the active handler entries that have the ``HandlerUnfinishedPolicy/warnAndAbandon`` policy.
+    func unfinishedWarnHandlerEntries() -> [ActiveHandlerEntry] {
+        switch self.state {
+        case .active(let active):
+            return active.activeHandlerEntries
+                .filter { $0.unfinishedPolicy == .warnAndAbandon }
         }
     }
 

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
@@ -127,12 +127,12 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
         self.stateMachine.fireTimer(fireTimer)?.resume()
     }
 
-    func handlerStarted() {
-        self.stateMachine.handlerStarted()
+    func handlerStarted(name: String, updateId: String?, unfinishedPolicy: HandlerUnfinishedPolicy) {
+        self.stateMachine.handlerStarted(name: name, updateId: updateId, unfinishedPolicy: unfinishedPolicy)
     }
 
-    func handlerFinished() {
-        self.stateMachine.handlerFinished()
+    func handlerFinished(name: String, updateId: String?) {
+        self.stateMachine.handlerFinished(name: name, updateId: updateId)
     }
 
     func allHandlersFinished() -> Bool {
@@ -525,6 +525,10 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
 
     func isReplaying() -> Bool {
         return self.stateMachine.isReplaying()
+    }
+
+    func unfinishedWarnHandlerEntries() -> [WorkflowStateMachine.ActiveHandlerEntry] {
+        return self.stateMachine.unfinishedWarnHandlerEntries()
     }
 
     func now() -> Date {

--- a/Sources/Temporal/Worker/Workflow/WorkflowUpdateDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowUpdateDefinition.swift
@@ -75,6 +75,13 @@ public protocol WorkflowUpdateDefinition<Workflow>: Sendable {
     /// users understand the update's functionality. Defaults to `nil`.
     static var description: String? { get }
 
+    /// The policy for handling unfinished instances of this handler when the workflow exits.
+    ///
+    /// This controls what happens when the workflow completes (successfully, with failure,
+    /// cancellation, or continue-as-new) while this update handler is still running.
+    /// Defaults to ``HandlerUnfinishedPolicy/warnAndAbandon``.
+    static var unfinishedPolicy: HandlerUnfinishedPolicy { get }
+
     /// Validates the update input before execution.
     ///
     /// This method is called before the update is executed to validate the input data
@@ -115,6 +122,14 @@ extension WorkflowUpdateDefinition {
     /// Instance property providing access to the static description.
     var description: String? {
         Self.description
+    }
+
+    /// Default implementation returning ``HandlerUnfinishedPolicy/warnAndAbandon``.
+    public static var unfinishedPolicy: HandlerUnfinishedPolicy { .warnAndAbandon }
+
+    /// Instance property providing access to the static unfinished policy.
+    var unfinishedPolicy: HandlerUnfinishedPolicy {
+        Self.unfinishedPolicy
     }
 
     /// Default implementation that performs no validation.

--- a/Sources/TemporalMacros/AttributeSyntax+Utilities.swift
+++ b/Sources/TemporalMacros/AttributeSyntax+Utilities.swift
@@ -33,4 +33,11 @@ extension AttributeSyntax {
         guard let boolLiteral = element.expression.as(BooleanLiteralExprSyntax.self) else { return nil }
         return boolLiteral.literal.tokenKind == .keyword(.true)
     }
+
+    func memberAccessNameForArgument(named name: String) -> String? {
+        guard case let .argumentList(arguments) = arguments else { return nil }
+        guard let element = arguments.first(where: { $0.label?.text == name }) else { return nil }
+        guard let memberAccess = element.expression.as(MemberAccessExprSyntax.self) else { return nil }
+        return memberAccess.declName.baseName.text
+    }
 }

--- a/Sources/TemporalMacros/WorkflowSignalMacro.swift
+++ b/Sources/TemporalMacros/WorkflowSignalMacro.swift
@@ -65,11 +65,15 @@ public struct WorkflowSignalMacro: PeerMacro {
 
         var nameDecl: DeclSyntax?
         var descriptionDecl: DeclSyntax?
+        var unfinishedPolicyDecl: DeclSyntax?
         if let name = node.stringLiteralValueForArgument(named: "name") {
             nameDecl = "\(raw: rawAccessModifier)static var name: String { \(name) }"
         }
         if let description = node.stringLiteralValueForArgument(named: "description") {
             descriptionDecl = "\(raw: rawAccessModifier)static var description: String? { \(description) }"
+        }
+        if let policyName = node.memberAccessNameForArgument(named: "unfinishedPolicy") {
+            unfinishedPolicyDecl = "\(raw: rawAccessModifier)static var unfinishedPolicy: HandlerUnfinishedPolicy { .\(raw: policyName) }"
         }
 
         let signalName = functionDecl.name.text.capitalizingFirst()
@@ -78,7 +82,7 @@ public struct WorkflowSignalMacro: PeerMacro {
             \(raw: rawAccessModifier)struct \(raw: signalName): WorkflowSignalDefinition {
                 \(raw: rawAccessModifier)typealias Input = \(input.type)
                 \(raw: rawAccessModifier)typealias Workflow = \(parentClass.name)
-                
+
                 let _run: @Sendable (Workflow, Input) async throws -> Void
                 init(run: @Sendable @escaping (Workflow, Input) async throws -> Void) {
                     self._run = run
@@ -88,6 +92,7 @@ public struct WorkflowSignalMacro: PeerMacro {
                 }
                 \(nameDecl)
                 \(descriptionDecl)
+                \(unfinishedPolicyDecl)
             }
             """,
             """

--- a/Sources/TemporalMacros/WorkflowUpdateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowUpdateMacro.swift
@@ -57,11 +57,15 @@ public struct WorkflowUpdateMacro: PeerMacro {
 
         var nameDecl: DeclSyntax?
         var descriptionDecl: DeclSyntax?
+        var unfinishedPolicyDecl: DeclSyntax?
         if let name = node.stringLiteralValueForArgument(named: "name") {
             nameDecl = "\(raw: rawAccessModifier)static var name: String { \(name) }"
         }
         if let description = node.stringLiteralValueForArgument(named: "description") {
             descriptionDecl = "\(raw: rawAccessModifier)static var description: String? { \(description) }"
+        }
+        if let policyName = node.memberAccessNameForArgument(named: "unfinishedPolicy") {
+            unfinishedPolicyDecl = "\(raw: rawAccessModifier)static var unfinishedPolicy: HandlerUnfinishedPolicy { .\(raw: policyName) }"
         }
 
         let updateName = functionDecl.name.text.capitalizingFirst()
@@ -71,7 +75,7 @@ public struct WorkflowUpdateMacro: PeerMacro {
                 \(raw: rawAccessModifier)typealias Input = \(input.type)
                 \(raw: rawAccessModifier)typealias Output = \(raw: returnType)
                 \(raw: rawAccessModifier)typealias Workflow = \(parentClass.name)
-                
+
                 let _run: @Sendable (Workflow, Input) async throws -> Output
                 init(run: @Sendable @escaping (Workflow, Input) async throws -> Output) {
                     self._run = run
@@ -81,6 +85,7 @@ public struct WorkflowUpdateMacro: PeerMacro {
                 }
                 \(nameDecl)
                 \(descriptionDecl)
+                \(unfinishedPolicyDecl)
             }
             """,
             """

--- a/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
+++ b/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
@@ -60,8 +60,6 @@ struct WorkflowMacrosTests {
                     func run(workflow: Workflow, input: Input) async throws {
                         try await self._run(workflow, input)
                     }
-
-
                 }
 
                 static var fooSignal: FooSignal {
@@ -83,8 +81,6 @@ struct WorkflowMacrosTests {
                     func run(workflow: Workflow, input: Input) throws -> Output {
                         try self._run(workflow, input)
                     }
-
-
                 }
 
                 static var fooQuery: FooQuery {
@@ -106,8 +102,6 @@ struct WorkflowMacrosTests {
                     func run(workflow: Workflow, input: Input) async throws -> Output {
                         try await self._run(workflow, input)
                     }
-
-
                 }
 
                 static var fooUpdate: FooUpdate {
@@ -134,7 +128,8 @@ struct WorkflowMacrosTests {
             extension Foo: WorkflowDefinition {
                 \(modifier) static var name: String { "CustomName" }
             }
-            """
+            """,
+            removeWhitespace: true
         )
         let (actualOutput, _) = try parse(
             """
@@ -147,7 +142,8 @@ struct WorkflowMacrosTests {
                 @WorkflowUpdate
                 func fooUpdate(input: String) async throws -> Int {}
             }
-            """
+            """,
+            removeWhitespace: true
         )
         #expect(expectedOutput == actualOutput)
     }
@@ -628,6 +624,113 @@ struct WorkflowMacrosTests {
                 func run(input: Void) async throws {}
             }
             """
+        )
+        #expect(expectedOutput == actualOutput)
+    }
+
+    @Test
+    func signalWithUnfinishedPolicy() throws {
+        let (expectedOutput, _) = try parse(
+            """
+            final class FooWorkflow {
+                func foo(input: String) async throws {}
+
+                struct Foo: WorkflowSignalDefinition {
+                    typealias Input = String
+                    typealias Workflow = FooWorkflow
+
+                    let _run: @Sendable (Workflow, Input) async throws -> Void
+                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Void) {
+                        self._run = run
+                    }
+                    func run(workflow: Workflow, input: Input) async throws {
+                        try await self._run(workflow, input)
+                    }
+
+                    static var unfinishedPolicy: HandlerUnfinishedPolicy { .abandon }
+                }
+
+                static var foo: Foo {
+                    Foo(run: {
+                            try await $0.foo(input: $1)
+                        })
+                }
+
+                static var signals: [any WorkflowSignalDefinition<FooWorkflow>] {
+                    [Self.foo]
+                }
+
+                required init(input: Input) {}
+            }
+
+            extension FooWorkflow: WorkflowDefinition {
+            }
+            """,
+            removeWhitespace: true
+        )
+        let (actualOutput, _) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowSignal(unfinishedPolicy: .abandon)
+                func foo(input: String) async throws {}
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(expectedOutput == actualOutput)
+    }
+
+    @Test
+    func updateWithUnfinishedPolicy() throws {
+        let (expectedOutput, _) = try parse(
+            """
+            final class FooWorkflow {
+                func foo(input: String) async throws -> Int {}
+
+                struct Foo: WorkflowUpdateDefinition {
+                    typealias Input = String
+                    typealias Output = Int
+                    typealias Workflow = FooWorkflow
+
+                    let _run: @Sendable (Workflow, Input) async throws -> Output
+                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Output) {
+                        self._run = run
+                    }
+                    func run(workflow: Workflow, input: Input) async throws -> Output {
+                        try await self._run(workflow, input)
+                    }
+
+                    static var unfinishedPolicy: HandlerUnfinishedPolicy { .abandon }
+                }
+
+                static var foo: Foo {
+                    Foo(run: {
+                            try await $0.foo(input: $1)
+                        })
+                }
+
+                static var updates: [any WorkflowUpdateDefinition<FooWorkflow>] {
+                    [Self.foo]
+                }
+
+                required init(input: Input) {}
+            }
+
+            extension FooWorkflow: WorkflowDefinition {
+            }
+            """,
+            removeWhitespace: true
+        )
+        let (actualOutput, _) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(unfinishedPolicy: .abandon)
+                func foo(input: String) async throws -> Int {}
+            }
+            """,
+            removeWhitespace: true
         )
         #expect(expectedOutput == actualOutput)
     }

--- a/Tests/TemporalTests/Worker/Workflow/HandlerUnfinishedPolicyTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/HandlerUnfinishedPolicyTests.swift
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import Synchronization
+import Temporal
+import TemporalTestKit
+import Testing
+
+extension TestServerDependentTests {
+    @Suite(.tags(.workflowTests))
+    struct HandlerUnfinishedPolicyIntegrationTests {
+        @Workflow
+        final class UnfinishedSignalWorkflow {
+            private var signalReceived = false
+
+            func run(input: Void) async throws {
+                try await Workflow.condition { self.signalReceived }
+            }
+
+            @WorkflowSignal
+            func warnSignal(input: Void) async throws {
+                self.signalReceived = true
+                try await Workflow.sleep(for: .seconds(999_999))
+            }
+
+            @WorkflowSignal(unfinishedPolicy: .abandon)
+            func abandonSignal(input: Void) async throws {
+                self.signalReceived = true
+                try await Workflow.sleep(for: .seconds(999_999))
+            }
+        }
+
+        @Workflow
+        final class UnfinishedUpdateWorkflow {
+            private var updateReceived = false
+
+            func run(input: Void) async throws {
+                try await Workflow.condition { self.updateReceived }
+            }
+
+            @WorkflowUpdate
+            func warnUpdate(input: Void) async throws -> String {
+                self.updateReceived = true
+                try await Workflow.sleep(for: .seconds(999_999))
+                return "done"
+            }
+
+            @WorkflowUpdate(unfinishedPolicy: .abandon)
+            func abandonUpdate(input: Void) async throws -> String {
+                self.updateReceived = true
+                try await Workflow.sleep(for: .seconds(999_999))
+                return "done"
+            }
+        }
+
+        @Test
+        func warnAndAbandonSignalAppearsInWarning() async throws {
+            let logHandler = InMemoryLogHandler()
+            let workerLogger = Logger(label: "TestWorker", factory: { _ in logHandler })
+
+            try await withTestWorkerAndClient(
+                workflows: [UnfinishedSignalWorkflow.self],
+                workerLogger: workerLogger
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: UnfinishedSignalWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+
+                try await handle.signal(signalType: UnfinishedSignalWorkflow.WarnSignal.self)
+                try await handle.result()
+
+                let infoEntries = logHandler.entries.withLock { entries in
+                    entries.filter { $0.level == .info }
+                }
+                let warningEntry = infoEntries.first {
+                    "\($0.message)".contains("Workflow finished while signal or update handlers are still running")
+                }
+
+                #expect(warningEntry != nil, "Expected an unfinished handler warning at info level")
+                if let entry = warningEntry, let metadata = entry.metadata {
+                    let signalMeta = metadata["temporal.workflow.unfinished.signals"]
+                    #expect(signalMeta != nil, "Expected signal metadata key")
+                    if let signalMeta {
+                        #expect("\(signalMeta)".contains("WarnSignal"), "Expected metadata to mention WarnSignal")
+                    }
+                }
+            }
+        }
+
+        @Test
+        func abandonSignalDoesNotAppearInWarning() async throws {
+            let logHandler = InMemoryLogHandler()
+            let workerLogger = Logger(label: "TestWorker", factory: { _ in logHandler })
+
+            try await withTestWorkerAndClient(
+                workflows: [UnfinishedSignalWorkflow.self],
+                workerLogger: workerLogger
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: UnfinishedSignalWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+
+                try await handle.signal(signalType: UnfinishedSignalWorkflow.AbandonSignal.self)
+                try await handle.result()
+
+                let allMessages = logHandler.entries.withLock { entries in
+                    entries.map { "\($0.message)" }
+                }
+                let unfinishedWarning = allMessages.first {
+                    $0.contains("Workflow finished while signal or update handlers are still running")
+                }
+
+                #expect(
+                    unfinishedWarning == nil,
+                    "Expected no unfinished handler warning when only .abandon handlers are unfinished"
+                )
+            }
+        }
+
+        @Test
+        func warnAndAbandonUpdateAppearsInWarning() async throws {
+            let logHandler = InMemoryLogHandler()
+            let workerLogger = Logger(label: "TestWorker", factory: { _ in logHandler })
+
+            try await withTestWorkerAndClient(
+                workflows: [UnfinishedUpdateWorkflow.self],
+                workerLogger: workerLogger
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: UnfinishedUpdateWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+
+                _ = try await handle.startUpdate(
+                    updateType: UnfinishedUpdateWorkflow.WarnUpdate.self,
+                    waitForStage: .accepted,
+                    input: ()
+                )
+                try await handle.result()
+
+                let infoEntries = logHandler.entries.withLock { entries in
+                    entries.filter { $0.level == .info }
+                }
+                let warningEntry = infoEntries.first {
+                    "\($0.message)".contains("Workflow finished while signal or update handlers are still running")
+                }
+
+                #expect(warningEntry != nil, "Expected an unfinished handler warning at info level")
+                if let entry = warningEntry, let metadata = entry.metadata {
+                    let updateMeta = metadata["temporal.workflow.unfinished.updates"]
+                    #expect(updateMeta != nil, "Expected update metadata key")
+                    if let updateMeta {
+                        #expect("\(updateMeta)".contains("WarnUpdate"), "Expected metadata to mention WarnUpdate")
+                    }
+                }
+            }
+        }
+
+        @Test
+        func abandonUpdateDoesNotAppearInWarning() async throws {
+            let logHandler = InMemoryLogHandler()
+            let workerLogger = Logger(label: "TestWorker", factory: { _ in logHandler })
+
+            try await withTestWorkerAndClient(
+                workflows: [UnfinishedUpdateWorkflow.self],
+                workerLogger: workerLogger
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: UnfinishedUpdateWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+
+                _ = try await handle.startUpdate(
+                    updateType: UnfinishedUpdateWorkflow.AbandonUpdate.self,
+                    waitForStage: .accepted,
+                    input: ()
+                )
+                try await handle.result()
+
+                let allMessages = logHandler.entries.withLock { entries in
+                    entries.map { "\($0.message)" }
+                }
+                let unfinishedWarning = allMessages.first {
+                    $0.contains("Workflow finished while signal or update handlers are still running")
+                }
+
+                #expect(
+                    unfinishedWarning == nil,
+                    "Expected no unfinished handler warning when only .abandon update handlers are unfinished"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `HandlerUnfinishedPolicy` with `warnAndAbandon` (default) and `abandon` options. Configurable per signal/update handler via the definition protocol and `@WorkflowSignal`/`@WorkflowUpdate` macros. This PR also adds tests that the expected log message is emitted.