### PR TITLE
Add continue-as-new to different workflow type

### DIFF
--- a/Sources/Temporal/Errors/ContinueAsNewError.swift
+++ b/Sources/Temporal/Errors/ContinueAsNewError.swift
@@ -53,13 +53,14 @@ public struct ContinueAsNewError: TemporalError {
 
     init(
         workflowContext: WorkflowContext,
+        workflowName: String,
         headers: [String: Api.Common.V1.Payload],
         inputs: [Api.Common.V1.Payload],
         options: ContinueAsNewOptions,
         payloadConverter: any PayloadConverter
     ) throws {
         self.stackTrace = ""
-        self.workflowName = workflowContext.info.workflowName
+        self.workflowName = workflowName
         self.inputs = inputs
         self.headers = headers
         self.taskQueue = options.taskQueue ?? workflowContext.info.taskQueue

--- a/Sources/Temporal/Worker/Interceptors/Inputs/MakeContinueAsNewErrorInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/MakeContinueAsNewErrorInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for workflow continue-as-new error generation in interceptor chains.
 public struct MakeContinueAsNewErrorInput<each Input: Sendable>: Sendable {
+    /// The workflow name to continue as.
+    public var workflowName: String
+
     /// The configuration options for the continue-as-new workflow execution.
     public var options: ContinueAsNewOptions
 

--- a/Sources/Temporal/Worker/Workflow/Workflow.swift
+++ b/Sources/Temporal/Worker/Workflow/Workflow.swift
@@ -919,7 +919,7 @@ public struct Workflow: Sendable {
 
     // MARK: - Continue As New
 
-    /// Creates a continue-as-new error to restart the workflow.
+    /// Creates a continue-as-new error to restart the workflow as the same type.
     ///
     /// ## Usage
     ///
@@ -962,6 +962,77 @@ public struct Workflow: Sendable {
         options: ContinueAsNewOptions,
         input: repeat each Input
     ) async throws -> ContinueAsNewError {
-        try await self._context.makeContinueAsNewError(options: options, input: repeat each input)
+        try await self._context.makeContinueAsNewError(
+            workflowName: self.info.workflowName,
+            options: options,
+            input: repeat each input
+        )
+    }
+
+    /// Creates a continue-as-new error to restart as a different workflow type.
+    ///
+    /// This overload allows continuing execution as a different workflow type.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// // Continue as a different workflow type
+    /// throw try await Workflow.makeContinueAsNewError(
+    ///     workflowType: ProcessingWorkflowV2.self,
+    ///     options: .init(),
+    ///     input: migratedInput
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - workflowType: The workflow type to continue as.
+    ///   - options: The continue-as-new options.
+    ///   - input: The input values for the new workflow execution.
+    /// - Returns: A continue-as-new error.
+    /// - Throws: When the input, headers or memo fails to convert.
+    public static func makeContinueAsNewError<W: WorkflowDefinition, each Input: Sendable>(
+        workflowType: W.Type,
+        options: ContinueAsNewOptions = .init(),
+        input: repeat each Input
+    ) async throws -> ContinueAsNewError {
+        try await self._context.makeContinueAsNewError(
+            workflowName: W.name,
+            options: options,
+            input: repeat each input
+        )
+    }
+
+    /// Creates a continue-as-new error to restart as a different workflow by name.
+    ///
+    /// This overload allows continuing execution as a different workflow identified by its
+    /// string name. This is useful when the workflow type is not available at compile time.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// // Continue as a different workflow by name
+    /// throw try await Workflow.makeContinueAsNewError(
+    ///     workflowName: "ProcessingWorkflowV2",
+    ///     options: .init(),
+    ///     input: migratedInput
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - workflowName: The name of the workflow to continue as.
+    ///   - options: The continue-as-new options.
+    ///   - input: The input values for the new workflow execution.
+    /// - Returns: A continue-as-new error.
+    /// - Throws: When the input, headers or memo fails to convert.
+    public static func makeContinueAsNewError<each Input: Sendable>(
+        workflowName: String,
+        options: ContinueAsNewOptions = .init(),
+        input: repeat each Input
+    ) async throws -> ContinueAsNewError {
+        try await self._context.makeContinueAsNewError(
+            workflowName: workflowName,
+            options: options,
+            input: repeat each input
+        )
     }
 }

--- a/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
@@ -331,12 +331,14 @@ package struct WorkflowContext: Sendable {
     // MARK: ContinueAsNew
 
     func makeContinueAsNewError<each Input: Sendable>(
+        workflowName: String,
         options: ContinueAsNewOptions,
         input: repeat each Input
     ) async throws -> ContinueAsNewError {
         try await self.implementation.makeContinueAsNewError(
             context: self,
             input: MakeContinueAsNewErrorInput<repeat each Input>(
+                workflowName: workflowName,
                 options: options,
                 headers: [:],
                 input: (repeat each input)
@@ -447,6 +449,7 @@ extension WorkflowContext.Implementation {
 
             return try ContinueAsNewError(
                 workflowContext: context,
+                workflowName: input.workflowName,
                 headers: input.headers,
                 inputs: inputPayloads,
                 options: input.options,

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowContinueAsNewTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowContinueAsNewTests.swift
@@ -90,5 +90,58 @@ extension TestServerDependentTests {
             )
             #expect(result.count == interceptor.counter.withLock { $0 })
         }
+
+        // MARK: - Continue as different workflow type
+
+        @Workflow
+        final class ContinueAsDifferentTypedWorkflow {
+            func run(input: String) async throws -> String {
+                throw try await Workflow.makeContinueAsNewError(
+                    workflowType: ContinueAsNewTargetWorkflow.self,
+                    input: input + "-continued"
+                )
+            }
+        }
+
+        @Workflow
+        final class ContinueAsDifferentUntypedWorkflow {
+            func run(input: String) async throws -> String {
+                throw try await Workflow.makeContinueAsNewError(
+                    workflowName: ContinueAsNewTargetWorkflow.name,
+                    input: input + "-continued"
+                )
+            }
+        }
+
+        @Workflow
+        final class ContinueAsNewTargetWorkflow {
+            func run(input: String) async throws -> String {
+                return input + "-done"
+            }
+        }
+
+        @Test
+        func continueAsNewToDifferentWorkflowType() async throws {
+            let result: String = try await workflowHandle(
+                for: ContinueAsDifferentTypedWorkflow.self,
+                input: "hello",
+                moreWorkflows: [ContinueAsNewTargetWorkflow.self]
+            ) { handle in
+                return try await handle.untypedHandle.result(resultTypes: String.self)
+            }
+            #expect(result == "hello-continued-done")
+        }
+
+        @Test
+        func continueAsNewToDifferentWorkflowByName() async throws {
+            let result: String = try await workflowHandle(
+                for: ContinueAsDifferentUntypedWorkflow.self,
+                input: "hello",
+                moreWorkflows: [ContinueAsNewTargetWorkflow.self]
+            ) { handle in
+                return try await handle.untypedHandle.result(resultTypes: String.self)
+            }
+            #expect(result == "hello-continued-done")
+        }
     }
 }


### PR DESCRIPTION
Adds overloads for Workflow.makeContinueAsNewError that accept a workflow type or name, enabling workflows to continue as a different workflow type. The existing overload continues as the same type.