### PR TITLE
Add search attributes to schedule APIs

### DIFF
--- a/Sources/Temporal/API/ProtoConversions/Schedules/Listing/ScheduleListDescription+Proto.swift
+++ b/Sources/Temporal/API/ProtoConversions/Schedules/Listing/ScheduleListDescription+Proto.swift
@@ -18,5 +18,8 @@ extension ScheduleListDescription {
         self.info = .init(proto: proto.info)
         self.schedule = .init(proto: proto.info)
         // TODO: Memo
+        if proto.hasSearchAttributes && !proto.searchAttributes.indexedFields.isEmpty {
+            self.searchAttributes = try? SearchAttributeCollection(proto.searchAttributes)
+        }
     }
 }

--- a/Sources/Temporal/Client/WorkflowService/Model/Schedules/Listing/ScheduleListDescription.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Schedules/Listing/ScheduleListDescription.swift
@@ -30,5 +30,6 @@ public struct ScheduleListDescription: Sendable {
     /// Arbitrary key-value metadata associated with the schedule.
     public var memo: [String: any Sendable]?
 
-    // TODO: SearchAttributes
+    /// Indexed search attributes associated with the schedule for querying and filtering.
+    public var searchAttributes: SearchAttributeCollection?
 }

--- a/Sources/Temporal/Client/WorkflowService/Model/Schedules/ScheduleUpdate.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Schedules/ScheduleUpdate.swift
@@ -17,11 +17,31 @@ public struct ScheduleUpdate<Input: Sendable>: Sendable {
     /// The complete schedule configuration to apply as the update.
     public var schedule: Schedule<Input>
 
+    /// Optional indexed attributes that can be used while querying schedules via the list
+    /// schedules APIs.
+    ///
+    /// The key and value type must be registered with Temporal server.
+    ///
+    /// - If `nil`, the search attributes will not be updated.
+    /// - If present but empty, the search attributes will be cleared.
+    /// - If present and non-empty, all search attributes will be updated to the provided
+    ///   collection. This means existing attributes which do not exist in the provided collection
+    ///   will be removed. You can copy attributes from the existing ``ScheduleDescription``
+    ///   to avoid this.
+    public var searchAttributes: SearchAttributeCollection?
+
     /// Creates a schedule update with the specified configuration changes.
     ///
-    /// - Parameter schedule: The complete schedule configuration to apply.
-    public init(schedule: Schedule<Input>) {
+    /// - Parameters:
+    ///   - schedule: The complete schedule configuration to apply.
+    ///   - searchAttributes: Optional search attributes to update. If `nil`, search attributes are
+    ///     not changed.
+    public init(
+        schedule: Schedule<Input>,
+        searchAttributes: SearchAttributeCollection? = nil
+    ) {
         self.schedule = schedule
+        self.searchAttributes = searchAttributes
     }
 
     /// Creates a schedule update with the specified configuration changes.
@@ -29,12 +49,14 @@ public struct ScheduleUpdate<Input: Sendable>: Sendable {
     /// - Parameters:
     ///    - workflowType: The workflow type associated with this schedule update.
     ///    - schedule: The complete schedule configuration to apply.
+    ///    - searchAttributes: Optional search attributes to update. If `nil`, search attributes are
+    ///      not changed.
     public init<Workflow: WorkflowDefinition>(
         workflowType: Workflow.Type = Workflow.self,
-        schedule: Schedule<Workflow.Input>
+        schedule: Schedule<Workflow.Input>,
+        searchAttributes: SearchAttributeCollection? = nil
     ) where Workflow.Input == Input {
         self.schedule = schedule
+        self.searchAttributes = searchAttributes
     }
-
-    // TODO: SearchAttributeCollection
 }

--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+Schedule.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+Schedule.swift
@@ -15,6 +15,7 @@
 import SwiftProtobuf
 
 public import struct GRPCCore.CallOptions
+import struct GRPCCore.RPCError
 
 #if canImport(FoundationEssentials)
 public import FoundationEssentials
@@ -35,28 +36,32 @@ extension TemporalClient.WorkflowService {
     ///   - schedule: The ``Schedule`` configuration defining timing, actions, and policies.
     ///   - options: Optional ``ScheduleOptions`` for metadata, initial state, and search attributes.
     /// - Returns: A conflict token used for optimistic concurrency control in subsequent updates.
-    /// - Throws: An error if the operation fails.
+    /// - Throws: ``ScheduleAlreadyRunningError`` if a schedule with the given ID already exists.
     @discardableResult
     public func createSchedule<Input: Sendable>(
         id: String,
         schedule: Schedule<Input>,
         options: ScheduleOptions?
     ) async throws -> Data {
-        let response: Api.Workflowservice.V1.CreateScheduleResponse = try await self.client.unary(
-            method: Api.Workflowservice.V1.WorkflowService.Method.CreateSchedule.descriptor,
-            request: Api.Workflowservice.V1.CreateScheduleRequest(
-                namespace: self.configuration.namespace,
-                identity: self.configuration.identity,
-                requestID: UUID().uuidString,
-                scheduleID: id,
-                schedule: schedule,
-                scheduleOptions: options,
-                dataConverter: self.configuration.dataConverter
-            ),
-            callOptions: options?.callOptions
-        )
+        do {
+            let response: Api.Workflowservice.V1.CreateScheduleResponse = try await self.client.unary(
+                method: Api.Workflowservice.V1.WorkflowService.Method.CreateSchedule.descriptor,
+                request: Api.Workflowservice.V1.CreateScheduleRequest(
+                    namespace: self.configuration.namespace,
+                    identity: self.configuration.identity,
+                    requestID: UUID().uuidString,
+                    scheduleID: id,
+                    schedule: schedule,
+                    scheduleOptions: options,
+                    dataConverter: self.configuration.dataConverter
+                ),
+                callOptions: options?.callOptions
+            )
 
-        return response.conflictToken
+            return response.conflictToken
+        } catch let error as RPCError where error.code == .alreadyExists {
+            throw ScheduleAlreadyRunningError(cause: error)
+        }
     }
 
     /// Retrieves information about an existing workflow schedule.
@@ -206,7 +211,9 @@ extension TemporalClient.WorkflowService {
                 // Set the `conflictToken` once the Temporal behavior is adjusted.
                 //$0.conflictToken = description.conflictToken
 
-                // TODO: SearchAttributes
+                if let searchAttributes = scheduleUpdate.searchAttributes {
+                    $0.searchAttributes = .init(searchAttributes)
+                }
             },
             callOptions: callOptions
         )

--- a/Sources/Temporal/Errors/ScheduleAlreadyRunningError.swift
+++ b/Sources/Temporal/Errors/ScheduleAlreadyRunningError.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Error thrown by a client when attempting to create a schedule that already exists.
+public struct ScheduleAlreadyRunningError: TemporalError {
+    /// The error's message.
+    public var message: String = "Schedule already running"
+
+    /// The cause of the current error.
+    public var cause: (any Error)?
+
+    /// The stack trace of the current error.
+    public var stackTrace: String
+
+    /// Initializes a new schedule already running error.
+    ///
+    /// - Parameters:
+    ///   - cause: The error's cause.
+    ///   - stackTrace: The stack trace of the current error.
+    public init(
+        cause: (any Error)? = nil,
+        stackTrace: String = ""
+    ) {
+        self.cause = cause
+        self.stackTrace = stackTrace
+    }
+}

--- a/Tests/TemporalTests/Client/ScheduleTests.swift
+++ b/Tests/TemporalTests/Client/ScheduleTests.swift
@@ -37,7 +37,6 @@ extension TestServerDependentTests {
             }
         }
 
-        @Test(.timeLimit(.minutes(1)))
         func workflowScheduleWithoutInput() async throws {
             try await runScheduleTest(
                 workflow: HelloWorldScheduleWorkflow.self,
@@ -46,7 +45,6 @@ extension TestServerDependentTests {
             )
         }
 
-        @Test(.timeLimit(.minutes(1)))
         func workflowScheduleWithInput() async throws {
             let input = "Hello, Input!"
             try await runScheduleTest(
@@ -454,6 +452,85 @@ extension TestServerDependentTests {
                 }
 
                 try await handle.delete()
+            }
+        }
+
+        func createDuplicateScheduleThrowsAlreadyRunning() async throws {
+            let taskQueue = "tq-\(UUID().uuidString)"
+            let scheduleID = "sc-\(UUID().uuidString)"
+
+            try await scheduleHandle(
+                workflowType: HelloWorldScheduleWorkflow.self,
+                schedule: Schedule(
+                    action: .startWorkflow(
+                        .init(
+                            workflowType: HelloWorldScheduleWorkflow.self,
+                            options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                        )
+                    ),
+                    specification: .init()
+                ),
+                taskQueue: taskQueue,
+                id: scheduleID
+            ) { scheduleHandle in
+                // Attempt to create another schedule with the same ID
+                await #expect(throws: ScheduleAlreadyRunningError.self) {
+                    try await scheduleHandle.untypedHandle.interceptor.workflowService.createSchedule(
+                        id: scheduleID,
+                        schedule: Schedule(
+                            action: ScheduleAction.startWorkflow(
+                                .init(
+                                    workflowType: HelloWorldScheduleWorkflow.self,
+                                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                                )
+                            ),
+                            specification: .init()
+                        ),
+                        options: nil
+                    )
+                }
+
+                try await scheduleHandle.delete()
+            }
+        }
+
+        func updateScheduleWithSearchAttributes() async throws {
+            let taskQueue = "tq-\(UUID().uuidString)"
+            let searchAttrKey = SearchAttributeKey<String>.keyword("CustomScheduleKeyword")
+
+            // Ensure custom search attribute is registered
+            try await ensureSearchAttributesPresent(attributes: searchAttrKey)
+
+            try await scheduleHandle(
+                workflowType: HelloWorldScheduleWorkflow.self,
+                schedule: Schedule(
+                    action: .startWorkflow(
+                        .init(
+                            workflowType: HelloWorldScheduleWorkflow.self,
+                            options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                        )
+                    ),
+                    specification: .init()
+                ),
+                taskQueue: taskQueue
+            ) { scheduleHandle in
+                let searchAttributes = SearchAttributeCollection {
+                    $0[searchAttrKey] = "schedule-test-value"
+                }
+
+                // Update with search attributes
+                try await scheduleHandle.update { description in
+                    .init(
+                        schedule: description.schedule,
+                        searchAttributes: searchAttributes
+                    )
+                }
+
+                // Verify search attributes are persisted
+                let description = try await scheduleHandle.describe()
+                #expect(description.searchAttributes?[searchAttrKey] == "schedule-test-value")
+
+                try await scheduleHandle.delete()
             }
         }
     }


### PR DESCRIPTION
Adds search attributes to `ScheduleUpdate` and `ScheduleListDescription`. Creates `ScheduleAlreadyRunningError` for duplicate schedule creation. Adds workflow-level memo and search attributes to schedule actions.