### PR TITLE
Fix clone URL format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ dependencies: [
 
 1. **Clone the repository**
    ```bash
-   git clone git@github.com/apple/swift-temporal-sdk.git
+   git clone git@github.com:apple/swift-temporal-sdk.git
    ```
 
 2. **Build the package**


### PR DESCRIPTION
### Motivation

```
> git clone git@github.com/apple/swift-temporal-sdk.git
fatal: repository 'git@github.com/apple/swift-temporal-sdk.git' does not exist
```
