### PR TITLE
Add missing `WorkflowUpdateRPCTimeoutOrCanceledError` error type

### DIFF
--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+Update.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+Update.swift
@@ -15,6 +15,7 @@
 import SwiftProtobuf
 
 public import struct GRPCCore.CallOptions
+import struct GRPCCore.RPCError
 
 #if canImport(FoundationEssentials)
 public import FoundationEssentials
@@ -178,6 +179,12 @@ extension TemporalClient.WorkflowService {
                     request: request,
                     callOptions: callOptions
                 )
+            } catch let rpcError as RPCError
+                where rpcError.code == .deadlineExceeded || rpcError.code == .cancelled
+            {
+                throw WorkflowUpdateRPCTimeoutOrCanceledError(cause: rpcError)
+            } catch is CancellationError {
+                throw WorkflowUpdateRPCTimeoutOrCanceledError()
             } catch {
                 throw error
             }
@@ -287,8 +294,13 @@ extension TemporalClient.WorkflowService {
                         break
                     }
                 }
+            } catch let rpcError as RPCError
+                where rpcError.code == .deadlineExceeded || rpcError.code == .cancelled
+            {
+                throw WorkflowUpdateRPCTimeoutOrCanceledError(cause: rpcError)
+            } catch is CancellationError {
+                throw WorkflowUpdateRPCTimeoutOrCanceledError()
             } catch {
-                // TODO: We need to convert out deadline exceeds and cancels here
                 throw error
             }
         }

--- a/Sources/Temporal/Converters/DefaultFailureConverter.swift
+++ b/Sources/Temporal/Converters/DefaultFailureConverter.swift
@@ -110,7 +110,8 @@ public struct DefaultFailureConverter: FailureConverter {
                 details: application.details.payloads,
                 type: application.type,
                 isNonRetryable: application.nonRetryable,
-                nextRetryDelay: .init(protobufDuration: application.nextRetryDelay)
+                nextRetryDelay: .init(protobufDuration: application.nextRetryDelay),
+                category: application.category
             )
         case .canceledFailureInfo(let cancelled):
             return CanceledError(
@@ -206,6 +207,7 @@ public struct DefaultFailureConverter: FailureConverter {
                     if let nextRetryDelay = applicationError.nextRetryDelay {
                         $0.nextRetryDelay = .init(duration: nextRetryDelay)
                     }
+                    $0.category = applicationError.category
                 }
             )
         case let cancelledError as CanceledError:

--- a/Sources/Temporal/Errors/Failures/ApplicationError.swift
+++ b/Sources/Temporal/Errors/Failures/ApplicationError.swift
@@ -41,6 +41,9 @@ public struct ApplicationError: TemporalFailureError {
     /// Delay duration before the next retry attempt.
     public var nextRetryDelay: Duration?
 
+    /// The error category.
+    public var category: Api.Enums.V1.ApplicationErrorCategory
+
     /// Initializes a new application error.
     ///
     /// - Parameters:
@@ -51,6 +54,7 @@ public struct ApplicationError: TemporalFailureError {
     ///   - type: The string type of the error if any. Defaults to `nil`.
     ///   - isNonRetryable: Boolean indicating wehter the error was set as non-retry. Defaults to `false`.
     ///   - nextRetryDelay: Delay duration before the next retry attempt. Defaults to `nil`.
+    ///   - category: The error category. Defaults to `.unspecified`.
     public init(
         message: String,
         cause: (any Error)? = nil,
@@ -58,7 +62,8 @@ public struct ApplicationError: TemporalFailureError {
         details: [Api.Common.V1.Payload] = [],
         type: String? = nil,
         isNonRetryable: Bool = false,
-        nextRetryDelay: Duration? = nil
+        nextRetryDelay: Duration? = nil,
+        category: Api.Enums.V1.ApplicationErrorCategory = .unspecified
     ) {
         self.message = message
         self.cause = cause
@@ -67,5 +72,6 @@ public struct ApplicationError: TemporalFailureError {
         self.type = type
         self.isNonRetryable = isNonRetryable
         self.nextRetryDelay = nextRetryDelay
+        self.category = category
     }
 }

--- a/Sources/Temporal/Errors/WorkflowUpdateRPCTimeoutOrCanceledError.swift
+++ b/Sources/Temporal/Errors/WorkflowUpdateRPCTimeoutOrCanceledError.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Error thrown when an update RPC call times out or is canceled.
+///
+/// This is not to be confused with an update itself timing out or being canceled,
+/// this is only related to the client call itself.
+public struct WorkflowUpdateRPCTimeoutOrCanceledError: TemporalError {
+    /// The error's message.
+    public var message: String
+
+    /// The cause of the current error.
+    public var cause: (any Error)?
+
+    /// The stack trace of the current error.
+    public var stackTrace: String
+
+    /// Creates a new workflow update RPC timeout or canceled error.
+    ///
+    /// - Parameters:
+    ///   - cause: The underlying cause of the timeout or cancellation.
+    ///   - stackTrace: The stack trace at the point of failure.
+    public init(
+        cause: (any Error)? = nil,
+        stackTrace: String = ""
+    ) {
+        self.message = "Timeout or cancellation waiting for update"
+        self.cause = cause
+        self.stackTrace = stackTrace
+    }
+}

--- a/Tests/TemporalTests/Converters/DefaultFailureConverterTests.swift
+++ b/Tests/TemporalTests/Converters/DefaultFailureConverterTests.swift
@@ -444,4 +444,54 @@ struct DefaultFailureConverterTests {
         #expect(convertedError.type == "TestError")
         #expect(convertedError.isNonRetryable == true)
     }
+
+    @Test
+    func applicationErrorCategoryRoundTrips() async throws {
+        let applicationError = ApplicationError(
+            message: "Benign error",
+            type: "SomeType",
+            category: .benign
+        )
+
+        let failureConverter = DefaultFailureConverter()
+        let jsonPayloadConverter = JSONPayloadConverter()
+
+        let failure = failureConverter.convertError(
+            applicationError,
+            payloadConverter: jsonPayloadConverter
+        )
+
+        let error = failureConverter.convertFailure(
+            failure,
+            payloadConverter: jsonPayloadConverter
+        )
+
+        let convertedError = try #require(error as? ApplicationError)
+        #expect(convertedError.message == "Benign error")
+        #expect(convertedError.type == "SomeType")
+        #expect(convertedError.category == .benign)
+    }
+
+    @Test
+    func applicationErrorCategoryDefaultsToUnspecified() async throws {
+        let applicationError = ApplicationError(
+            message: "Default category"
+        )
+
+        let failureConverter = DefaultFailureConverter()
+        let jsonPayloadConverter = JSONPayloadConverter()
+
+        let failure = failureConverter.convertError(
+            applicationError,
+            payloadConverter: jsonPayloadConverter
+        )
+
+        let error = failureConverter.convertFailure(
+            failure,
+            payloadConverter: jsonPayloadConverter
+        )
+
+        let convertedError = try #require(error as? ApplicationError)
+        #expect(convertedError.category == .unspecified)
+    }
 }


### PR DESCRIPTION
Adds `WorkflowUpdateRPCTimeoutOrCanceledError` for update poll timeouts, and add the `ApplicationError.category` field.