### PR TITLE
Add new `isTemporalCancellation` API

### DIFF
--- a/Sources/Temporal/Errors/Error+isTemporalCancellation.swift
+++ b/Sources/Temporal/Errors/Error+isTemporalCancellation.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+extension Error {
+    /// Whether this error represents a Temporal cancellation from a workflow, activity, or child workflow.
+    ///
+    /// This is useful when catching errors in workflow code to determine whether they represent
+    /// a cancellation. When an activity or child workflow is cancelled, the cancellation may be
+    /// thrown directly as ``CanceledError`` or wrapped inside an ``ActivityError`` or
+    /// ``ChildWorkflowError``. This property handles all cases, making cancellation detection
+    /// straightforward in catch clauses.
+    public var isTemporalCancellation: Bool {
+        switch self {
+        case is CancellationError:
+            true
+        case is CanceledError:
+            true
+        case let error as ActivityError:
+            error.cause is CanceledError
+        case let error as ChildWorkflowError:
+            error.cause is CanceledError
+        default:
+            false
+        }
+    }
+}

--- a/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
@@ -1005,7 +1005,7 @@ struct WorkflowInstance: Sendable {
         if let continueAsNewError = error as? ContinueAsNewError {
             self.logger.debug("Workflow requested continue as new")
             self.stateMachine.continueAsNew(continueAsNewError)
-        } else if Task.isCancelled && error.isWorkflowCancellationError() {
+        } else if Task.isCancelled && error.isTemporalCancellation {
             self.logger.debug("Workflow raised a cancellation.")
             self.stateMachine.cancelWorkflowExecution()
         } else if let temporalFailureError = error as? any TemporalFailureError {
@@ -1018,23 +1018,6 @@ struct WorkflowInstance: Sendable {
             // so that the workflow task can be retried
             let failure = self.failureConverter.convertError(error, payloadConverter: self.payloadConverter)
             self.stateMachine.workflowTaskFailed(failure: failure)
-        }
-    }
-}
-
-extension Error {
-    fileprivate func isWorkflowCancellationError() -> Bool {
-        switch self {
-        case is CancellationError:
-            true
-        case is CanceledError:
-            true
-        case let error as ActivityError:
-            error.cause is CanceledError
-        case let error as ChildWorkflowError:
-            error.cause is CanceledError
-        default:
-            false
         }
     }
 }

--- a/Tests/TemporalTests/Converters/IsCanceledTests.swift
+++ b/Tests/TemporalTests/Converters/IsCanceledTests.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Temporal
+import Testing
+
+@Suite
+struct IsCanceledTests {
+    @Test
+    func canceledError() {
+        let error = CanceledError(message: "canceled")
+        #expect(error.isTemporalCancellation)
+    }
+
+    @Test
+    func swiftCancellationError() {
+        let error = CancellationError()
+        #expect(error.isTemporalCancellation)
+    }
+
+    @Test
+    func activityErrorWrappingCanceledError() {
+        let error = ActivityError(
+            message: "Activity failed",
+            cause: CanceledError(message: "canceled"),
+            stackTrace: "",
+            scheduledEventID: 1,
+            startedEventID: 2,
+            activityID: "activity-1",
+            activityType: "MyActivity",
+            identity: "worker-1",
+            retryState: .inProgress
+        )
+        #expect(error.isTemporalCancellation)
+    }
+
+    @Test
+    func activityErrorWithoutCanceledCause() {
+        let error = ActivityError(
+            message: "Activity failed",
+            cause: ApplicationError(message: "some error"),
+            stackTrace: "",
+            scheduledEventID: 1,
+            startedEventID: 2,
+            activityID: "activity-1",
+            activityType: "MyActivity",
+            identity: "worker-1",
+            retryState: .inProgress
+        )
+        #expect(!error.isTemporalCancellation)
+    }
+
+    @Test
+    func childWorkflowErrorWrappingCanceledError() {
+        let error = ChildWorkflowError(
+            message: "Child workflow failed",
+            cause: CanceledError(message: "canceled"),
+            stackTrace: "",
+            namespace: "default",
+            workflowID: "wf-1",
+            runID: "run-1",
+            workflowName: "MyWorkflow",
+            retryState: .inProgress
+        )
+        #expect(error.isTemporalCancellation)
+    }
+
+    @Test
+    func childWorkflowErrorWithoutCanceledCause() {
+        let error = ChildWorkflowError(
+            message: "Child workflow failed",
+            cause: ApplicationError(message: "some error"),
+            stackTrace: "",
+            namespace: "default",
+            workflowID: "wf-1",
+            runID: "run-1",
+            workflowName: "MyWorkflow",
+            retryState: .inProgress
+        )
+        #expect(!error.isTemporalCancellation)
+    }
+
+    @Test
+    func applicationErrorIsNotCanceled() {
+        let error = ApplicationError(message: "some error")
+        #expect(!error.isTemporalCancellation)
+    }
+
+    @Test
+    func workflowUpdateRPCTimeoutOrCanceledErrorIsNotCanceled() {
+        let error = WorkflowUpdateRPCTimeoutOrCanceledError()
+        #expect(!error.isTemporalCancellation)
+    }
+}


### PR DESCRIPTION
It is common for users to want to check if an error is a kind of cancellation error in the Temporal sense. The `WorkflowInstance` is already checking for that to generate a cancelled command. This PR adds an extension on Error that allows developers to check if an error is a cancellation error in Temporal terms.