### PR TITLE
Fix async activity heartbeat cancellation detection

### DIFF
--- a/Sources/Temporal/Client/Handles/AsyncActivity/AsyncActivityHandle+Operations.swift
+++ b/Sources/Temporal/Client/Handles/AsyncActivity/AsyncActivityHandle+Operations.swift
@@ -22,8 +22,8 @@ extension AsyncActivityHandle {
     ///
     /// - Parameter options: Optional heartbeat configuration, including progress details
     ///   and gRPC call options.
-    /// - Throws: ``AsyncActivityCanceledError`` if the service has requested that the activity be cancelled.
-    ///           This should be caught by the caller, and ``reportCancellation(options:)`` invoked for proper handling.
+    /// - Throws: ``AsyncActivityCanceledError`` if the service has requested that the activity be cancelled,
+    ///           paused, or reset. The error's ``AsyncActivityCanceledError/details`` indicate which flags were set.
     public func heartbeat(options: AsyncActivityHeartbeatOptions? = nil) async throws {
         try await self.interceptor.heartbeatAsyncActivity(
             .init(

--- a/Sources/Temporal/Client/InterceptedService/InterceptedService+AsyncActivites.swift
+++ b/Sources/Temporal/Client/InterceptedService/InterceptedService+AsyncActivites.swift
@@ -20,15 +20,16 @@ extension TemporalClient.InterceptedService {
     /// optionally attach progress details. The interceptor may observe, modify, or reject
     /// the call before it reaches the service layer.
     ///
-    /// If the server has requested that this activity be cancelled, the operation throws
-    /// ``AsyncActivityCanceledError``. Call ``AsyncActivityHandle/reportCancellation(options:)``
+    /// If the server has requested that this activity be cancelled, paused, or reset, the
+    /// operation throws ``AsyncActivityCanceledError`` with details indicating which flags
+    /// were set. Call ``AsyncActivityHandle/reportCancellation(options:)``
     /// afterward to acknowledge cancellation.
     ///
     /// - Parameters:
     ///   - activity: The activity reference, either by `workflowID` and `activityID` (and optional `runID`) or by task token.
     ///   - options: Heartbeat options, including optional `details` and `callOptions`.
     ///   - dataConverter: Optional override for payload conversion. If nil, uses the client configuration converter.
-    /// - Throws: ``AsyncActivityCanceledError`` if cancellation was requested, or any error raised by interceptors or service.
+    /// - Throws: ``AsyncActivityCanceledError`` if cancellation, pause, or reset was requested, or any error raised by interceptors or service.
     package func heartbeatAsyncActivity(
         activity: AsyncActivityHandle.Reference,
         options: AsyncActivityHeartbeatOptions?,

--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+AsyncActivities.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+AsyncActivities.swift
@@ -29,15 +29,17 @@ extension TemporalClient.WorkflowService {
     /// - Communicate progress information back to the workflow.
     /// - Detect cancellation requests.
     ///
-    /// If the server has requested that this activity be cancelled, this method throws
-    /// ``AsyncActivityCanceledError``. Call ``AsyncActivityHandle/reportCancellation(options:)``
+    /// If the server has requested that this activity be cancelled, paused, or reset,
+    /// this method throws ``AsyncActivityCanceledError`` with
+    /// ``AsyncActivityCanceledError/details`` indicating which flags were set.
+    /// Call ``AsyncActivityHandle/reportCancellation(options:)``
     /// for proper cancellation reporting.
     ///
     /// - Parameters:
     ///   - activity: The activity reference, either by `workflowID`/`runID`/`activityID` or task token.
     ///   - options: Heartbeat options, including optional `details` and `callOptions`.
     ///   - dataConverter: Optional override for payload conversion.
-    /// - Throws: ``AsyncActivityCanceledError`` if the server requested cancellation,
+    /// - Throws: ``AsyncActivityCanceledError`` if the server requested cancellation, pause, or reset,
     ///           or any error that occurs during the heartbeat call.
     public func heartbeatAsyncActivity(
         activity: AsyncActivityHandle.Reference,
@@ -73,8 +75,14 @@ extension TemporalClient.WorkflowService {
                     },
                     callOptions: options?.callOptions
                 )
-            if response.cancelRequested {
-                throw AsyncActivityCanceledError()
+            if response.cancelRequested || response.activityPaused || response.activityReset {
+                throw AsyncActivityCanceledError(
+                    details: .init(
+                        cancelRequested: response.cancelRequested,
+                        paused: response.activityPaused,
+                        reset: response.activityReset
+                    )
+                )
             }
 
         case .taskToken(let token):
@@ -89,8 +97,14 @@ extension TemporalClient.WorkflowService {
                     },
                     callOptions: options?.callOptions
                 )
-            if response.cancelRequested {
-                throw AsyncActivityCanceledError()
+            if response.cancelRequested || response.activityPaused || response.activityReset {
+                throw AsyncActivityCanceledError(
+                    details: .init(
+                        cancelRequested: response.cancelRequested,
+                        paused: response.activityPaused,
+                        reset: response.activityReset
+                    )
+                )
             }
         }
     }

--- a/Sources/Temporal/Errors/AsyncActivityCanceledError.swift
+++ b/Sources/Temporal/Errors/AsyncActivityCanceledError.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Error thrown from ``AsyncActivityHandle/heartbeat(options:)`` or ``TemporalClient/WorkflowService-swift.struct/heartbeatAsyncActivity(activity:options:dataConverter:)`` if
-/// workflow has requested that an activity be cancelled.
+/// the server indicates the activity has been cancelled, paused, or reset.
 public struct AsyncActivityCanceledError: TemporalError {
     /// The error's message.
     public var message: String = "Activity cancelled"
@@ -23,4 +23,14 @@ public struct AsyncActivityCanceledError: TemporalError {
 
     /// The stack trace of the current error.
     public var stackTrace: String = ""
+
+    /// Details about why the activity was cancelled.
+    public var details: ActivityCancellationDetails
+
+    /// Creates an ``AsyncActivityCanceledError`` with the given cancellation details.
+    ///
+    /// - Parameter details: The cancellation details describing why the activity was cancelled.
+    public init(details: ActivityCancellationDetails) {
+        self.details = details
+    }
 }

--- a/Sources/Temporal/Worker/Activities/ActivityCancellationDetails.swift
+++ b/Sources/Temporal/Worker/Activities/ActivityCancellationDetails.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// Details about why an activity was cancelled, paused, or reset.
+public struct ActivityCancellationDetails: Sendable, Hashable {
+    /// Whether the activity was explicitly cancelled.
+    public var cancelRequested: Bool
+
+    /// Whether the activity was explicitly paused.
+    public var paused: Bool
+
+    /// Whether the activity was explicitly reset.
+    public var reset: Bool
+
+    /// Creates cancellation details.
+    ///
+    /// - Parameters:
+    ///   - cancelRequested: Whether the activity was explicitly cancelled.
+    ///   - paused: Whether the activity was explicitly paused.
+    ///   - reset: Whether the activity was explicitly reset.
+    public init(cancelRequested: Bool, paused: Bool, reset: Bool) {
+        self.cancelRequested = cancelRequested
+        self.paused = paused
+        self.reset = reset
+    }
+}

--- a/Sources/Temporal/Worker/Activities/ActivityExecutionContext.swift
+++ b/Sources/Temporal/Worker/Activities/ActivityExecutionContext.swift
@@ -280,6 +280,22 @@ public struct ActivityExecutionContext: Sendable {
     public var cancellationReason: ActivityCancellationReason? {
         self.lookupCancellationReason()
     }
+
+    /// Detailed cancellation information derived from the cancellation reason.
+    public var cancellationDetails: ActivityCancellationDetails? {
+        switch self.cancellationReason {
+        case .unknown, .goneFromServer, .timeout, .workerShutdown, .heartbeatRecordFailure:
+            return .init(cancelRequested: false, paused: false, reset: false)
+        case .none:
+            return nil
+        case .serverRequest:
+            return .init(cancelRequested: true, paused: false, reset: false)
+        case .paused:
+            return .init(cancelRequested: false, paused: true, reset: false)
+        case .reset:
+            return .init(cancelRequested: false, paused: false, reset: true)
+        }
+    }
 }
 
 extension ActivityExecutionContext {


### PR DESCRIPTION
Adds `AsyncActivityCancellationDetails` with `cancelRequested`, `paused`, and `reset` flags. Updates heartbeat response handling to check all three fields instead of only `cancelRequested`.