### PR TITLE
Ensure we respect access modifiers for Activity Container generation

### DIFF
--- a/Sources/TemporalMacros/ActivityContainerMacro.swift
+++ b/Sources/TemporalMacros/ActivityContainerMacro.swift
@@ -21,6 +21,7 @@ private struct ActivityInfo {
     var isDynamic: Bool
     var parentMethodName: String
     var parentTypeName: String
+    var accessModifier: DeclModifierListSyntax
     var isStatic: Bool
     var inputType: String
     var resultType: String
@@ -36,11 +37,11 @@ private struct ActivityInfo {
         }
 
         return """
-            struct \(raw: parentMethodName.capitalizingFirst()): ActivityDefinition {
-                \(raw: nameDecl)
+            \(accessModifier)struct \(raw: parentMethodName.capitalizingFirst()): ActivityDefinition {
+                \(accessModifier)\(raw: nameDecl)
                 var _run: \(raw: closureType)
                 init(run: @escaping \(raw: closureType)) { self._run = run }
-                func run(input: \(raw: inputType == "" ? "Void" : inputType)) async throws -> \(raw: resultType) {
+                \(accessModifier)func run(input: \(raw: inputType == "" ? "Void" : inputType)) async throws -> \(raw: resultType) {
                     return try await self._run(\(raw: inputType == "" ? "" : "input"))
                 }
             }
@@ -49,7 +50,7 @@ private struct ActivityInfo {
 
     var varDefinition: DeclSyntax {
         return """
-            var \(raw: parentMethodName): \(raw: parentMethodName.capitalizingFirst()) {
+            \(accessModifier)var \(raw: parentMethodName): \(raw: parentMethodName.capitalizingFirst()) {
                 return .init(run: \(raw: isStatic ? parentTypeName : "self.container").\(raw: parentMethodName))
             }
             """
@@ -74,6 +75,8 @@ public struct ActivityContainerMacro: ExtensionMacro {
 
         var activities: [ActivityInfo] = []
 
+        let declarationAccessModifier = declaration.modifiers.accessModifierPrefix(supportedModifiers: .workflowDefinitionAccessModifiers)
+
         for member in declaration.memberBlock.members {
             guard let functionDecl = member.decl.as(FunctionDeclSyntax.self),
                 let activityAttribute = functionDecl.attributes.first(where: {
@@ -83,6 +86,7 @@ public struct ActivityContainerMacro: ExtensionMacro {
                 continue
             }
 
+            let activityAccessModifiers = functionDecl.modifiers.accessModifierPrefix(supportedModifiers: .allAccessModifiers)
             let methodName = functionDecl.name.trimmedDescription
             let isDynamic = activityAttribute.boolValueForArgument(named: "dynamic") ?? false
             let activityName: String?
@@ -98,6 +102,7 @@ public struct ActivityContainerMacro: ExtensionMacro {
                     isDynamic: isDynamic,
                     parentMethodName: methodName,
                     parentTypeName: type.trimmedDescription,
+                    accessModifier: activityAccessModifiers,
                     isStatic: functionDecl.modifiers.contains { $0.trimmedDescription == "static" },
                     inputType: functionDecl.signature.parameterClause.parameters.first?.type.trimmedDescription ?? "",
                     resultType: functionDecl.signature.returnClause?.type.trimmedDescription ?? "Void"
@@ -105,10 +110,11 @@ public struct ActivityContainerMacro: ExtensionMacro {
             )
         }
 
-        let rawAccessModifier = declaration.modifiers.accessModifierPrefix(supportedModifiers: .workflowDefinitionAccessModifiers)
-
         let allStatic = activities.allSatisfy { $0.isStatic }
-        let activitiesStruct: StructDeclSyntax = StructDeclSyntax(name: "Activities") {
+        let activitiesStruct: StructDeclSyntax = StructDeclSyntax(
+            modifiers: declarationAccessModifier,
+            name: "Activities"
+        ) {
             if !allStatic {
                 DeclSyntax("let container: \(type)")
             }
@@ -124,8 +130,8 @@ public struct ActivityContainerMacro: ExtensionMacro {
                 """
                 extension \(type): ActivityContainer {
                     \(activitiesStruct.formatted())
-                    var activities: Activities { return .init(\(raw: allStatic ? "" : "container: self")) }
-                    \(raw: rawAccessModifier)var allActivities: [any ActivityDefinition] { return [\(raw: activities.map { "self.activities.\($0.parentMethodName)" }.joined(separator: ", "))] }
+                    \(declarationAccessModifier)var activities: Activities { return .init(\(raw: allStatic ? "" : "container: self")) }
+                    \(declarationAccessModifier)var allActivities: [any ActivityDefinition] { return [\(raw: activities.map { "self.activities.\($0.parentMethodName)" }.joined(separator: ", "))] }
                 }
                 """
             )

--- a/Sources/TemporalMacros/DeclModifierListSyntax+AccessModifier.swift
+++ b/Sources/TemporalMacros/DeclModifierListSyntax+AccessModifier.swift
@@ -15,19 +15,25 @@
 import SwiftSyntax
 
 extension DeclModifierListSyntax {
-    func accessModifierPrefix(supportedModifiers: Set<Keyword>) -> String {
-        let modifier = compactMap { (modifier: DeclModifierSyntax) -> TokenSyntax? in
-            guard case let .keyword(keyword) = modifier.name.tokenKind else {
-                return nil
+    func accessModifierPrefix(supportedModifiers: Set<Keyword>) -> DeclModifierListSyntax {
+        let modifier =
+            self
+            .compactMap { modifier -> DeclModifierSyntax? in
+                guard case let .keyword(keyword) = modifier.name.tokenKind else {
+                    return nil
+                }
+                guard supportedModifiers.contains(keyword) else {
+                    return nil
+                }
+                // we create a fresh syntax node as the existing one might, e.g., contain leading whitespace trivia
+                return DeclModifierSyntax(
+                    name: .keyword(keyword),
+                    trailingTrivia: .space
+                )
             }
+            .first
 
-            guard supportedModifiers.contains(keyword) else {
-                return nil
-            }
-            return .keyword(keyword)
-        }.first
-
-        return modifier.map { $0.text + " " } ?? ""
+        return modifier.map { [$0] } ?? []
     }
 }
 

--- a/Sources/TemporalMacros/WorkflowMacro.swift
+++ b/Sources/TemporalMacros/WorkflowMacro.swift
@@ -36,14 +36,14 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         guard let workflowName = node.stringLiteralValueForArgument(named: "name") else {
             return [try .init("extension \(type): WorkflowDefinition {}")]
         }
-        let rawAccessModifier = declaration.modifiers.accessModifierPrefix(supportedModifiers: .workflowDefinitionAccessModifiers)
+        let accessModifier = declaration.modifiers.accessModifierPrefix(supportedModifiers: .workflowDefinitionAccessModifiers)
 
         // The first argument to our @Workflow macro is the custom name
         return [
             try .init(
                 """
                 extension \(type): WorkflowDefinition {
-                    \(raw: rawAccessModifier)static var name: String { \(workflowName) }
+                    \(accessModifier)static var name: String { \(workflowName) }
                 }
                 """
             )
@@ -88,13 +88,13 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
             }
         }
 
-        let rawAccessModifier = declaration.modifiers.accessModifierPrefix(supportedModifiers: .workflowDefinitionAccessModifiers)
+        let accessModifier = declaration.modifiers.accessModifierPrefix(supportedModifiers: .workflowDefinitionAccessModifiers)
 
         var messageHandlerDecls = [DeclSyntax]()
         if !signalNames.isEmpty {
             messageHandlerDecls.append(
                 """
-                \(raw: rawAccessModifier)static var signals: [any WorkflowSignalDefinition<\(raw: classDecl.name.text)>] {
+                \(accessModifier)static var signals: [any WorkflowSignalDefinition<\(raw: classDecl.name.text)>] {
                     [\(raw: signalNames.lazy.map { "Self.\($0)" }.joined(separator: ", "))]
                 }
                 """
@@ -103,7 +103,7 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         if !queryNames.isEmpty {
             messageHandlerDecls.append(
                 """
-                \(raw: rawAccessModifier)static var queries: [any WorkflowQueryDefinition<\(raw: classDecl.name.text)>] {
+                \(accessModifier)static var queries: [any WorkflowQueryDefinition<\(raw: classDecl.name.text)>] {
                     [\(raw: queryNames.lazy.map { "Self.\($0)" }.joined(separator: ", "))]
                 }
                 """
@@ -112,14 +112,14 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         if !updateNames.isEmpty {
             messageHandlerDecls.append(
                 """
-                \(raw: rawAccessModifier)static var updates: [any WorkflowUpdateDefinition<\(raw: classDecl.name.text)>] {
+                \(accessModifier)static var updates: [any WorkflowUpdateDefinition<\(raw: classDecl.name.text)>] {
                     [\(raw: updateNames.lazy.map { "Self.\($0)" }.joined(separator: ", "))]
                 }
                 """
             )
         }
 
-        var emptyInitDecl: DeclSyntax?
+        var emptyInitDecl: InitializerDeclSyntax?
 
         // Check if an initializer with a single "input:" parameter (from `WorkflowDefinition` protocol) is already provided
         let hasMatchingInitializer = declaration.memberBlock.members.contains {
@@ -138,14 +138,21 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         }
 
         if !hasMatchingInitializer {
-            emptyInitDecl = DeclSyntax(
-                stringLiteral: """
-                    \(rawAccessModifier)required init(input: Input) {}
-                    """
+            emptyInitDecl = InitializerDeclSyntax(
+                modifiers: (accessModifier) + [
+                    .init(name: .keyword(.required))
+                ],
+                signature: .init(
+                    parameterClause: .init(parameters: [
+                        FunctionParameterSyntax(firstName: .identifier("input"), type: IdentifierTypeSyntax(name: .identifier("Input")))
+                        // .init(firstName: "input", type: "Input")
+                    ])
+                ),
+                bodyBuilder: {}
             )
         }
 
-        return messageHandlerDecls + (emptyInitDecl.map { [$0] } ?? [])
+        return messageHandlerDecls + (DeclSyntax(emptyInitDecl).map { [$0] } ?? [])
     }
 
     public static func expansion(

--- a/Tests/TemporalMacrosTests/ActivityMacrosTests.swift
+++ b/Tests/TemporalMacrosTests/ActivityMacrosTests.swift
@@ -59,17 +59,20 @@ struct ActivityMacrosTests {
         #expect(diagnostics.isEmpty)
     }
 
-    @Test(arguments: ["public", "package", "fileprivate", "internal"])
+    @Test(arguments: ["public", "package", "fileprivate", "internal", "private"])
     func accessModifier(modifier: String) throws {
+        let declarationModifier = modifier == "private" ? "fileprivate" : modifier  // private is not allowed for @ActivityContainer
+        let activityModifier = modifier
+
         let (expectedOutput, _) = try parse(
             """
-            \(modifier) struct Foo {
+            \(declarationModifier) struct Foo {
                 func bar(input: Int) -> Int { return input }
-                \(modifier) func bar2(input: Int) -> Int { return input }
+                \(activityModifier) func bar2(input: Int) -> Int { return input }
             }
 
             extension Foo: ActivityContainer {
-                struct Activities {
+                \(declarationModifier) struct Activities {
                     let container: Foo
                     struct Bar: ActivityDefinition {
                         static var name: String { "Bar" }
@@ -78,28 +81,28 @@ struct ActivityMacrosTests {
                         func run(input: Int) async throws -> Int { return try await self._run(input) }
                     }
                     var bar: Bar { return .init(run: self.container.bar) }
-                    struct Bar2: ActivityDefinition {
-                        static var name: String { "Bar2" }
+                    \(activityModifier) struct Bar2: ActivityDefinition {
+                        \(activityModifier) static var name: String { "Bar2" }
                         var _run: @Sendable (Int) async throws -> Int
                         init(run: @escaping @Sendable (Int) async throws -> Int) { self._run = run }
-                        func run(input: Int) async throws -> Int { return try await self._run(input) }
+                        \(activityModifier) func run(input: Int) async throws -> Int { return try await self._run(input) }
                     }
-                    var bar2: Bar2 { return .init(run: self.container.bar2) }
+                    \(activityModifier) var bar2: Bar2 { return .init(run: self.container.bar2) }
                 }
-                var activities: Activities { return .init(container: self) }
-                \(modifier) var allActivities: [any ActivityDefinition] { return [self.activities.bar, self.activities.bar2] }
+                \(declarationModifier) var activities: Activities { return .init(container: self) }
+                \(declarationModifier) var allActivities: [any ActivityDefinition] { return [self.activities.bar, self.activities.bar2] }
             }
             """
         )
         let (actualOutput, diagnostics) = try parse(
             """
             @ActivityContainer
-            \(modifier) struct Foo {
+            \(declarationModifier) struct Foo {
                 @Activity
                 func bar(input: Int) -> Int {  return input }
 
                 @Activity
-                \(modifier) func bar2(input: Int) -> Int { return input }
+                \(activityModifier) func bar2(input: Int) -> Int { return input }
             }
             """
         )
@@ -123,7 +126,7 @@ struct ActivityMacrosTests {
             }
 
             extension Foo: ActivityContainer {
-                struct Activities {
+                \(rawResultingModifier)struct Activities {
                     let container: Foo
                     struct Bar: ActivityDefinition {
                         static var name: String { "Bar" }
@@ -133,7 +136,7 @@ struct ActivityMacrosTests {
                     }
                     var bar: Bar { return .init(run: self.container.bar) }
                 }
-                var activities: Activities { return .init(container: self) }
+                \(rawResultingModifier)var activities: Activities { return .init(container: self) }
                 \(rawResultingModifier)var allActivities: [any ActivityDefinition] { return [self.activities.bar] }
             }
             """


### PR DESCRIPTION
### Motivation

The access modifier of an activity container is not fully considered for the generated Code. We were missing the modifier for the nested `Activities` type.

### Modifications

Track the access modifier of the activity container type and the activity function separately. We use these then to generate the `Activities` type and nested types.

### Test Plan

Existing unit tests were modified to verify this behavior.
