### PR TITLE
Refactor interceptor protocols to use idiomatic Swift patterns

### DIFF
--- a/Sources/Temporal/Client/Interceptors/ClientInterceptor.swift
+++ b/Sources/Temporal/Client/Interceptors/ClientInterceptor.swift
@@ -12,20 +12,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Factory protocol that creates interceptors for client-side operations.
+/// Protocol for a client interceptor.
 public protocol ClientInterceptor: Sendable {
-    /// The type of client outbound interceptor created by this factory.
+    /// The type of client outbound interceptor created by this interceptor.
     associatedtype ClientOutboundInterceptorType: ClientOutboundInterceptor = ForwardingClientOutboundInterceptor
 
-    /// Creates a client outbound interceptor for intercepting and modifying client operations.
-    func makeClientOutboundInterceptor() -> ClientOutboundInterceptorType?
+    /// The client outbound interceptor for intercepting and modifying client operations, or `nil` if no interception is needed.
+    var clientOutboundInterceptor: ClientOutboundInterceptorType? { get }
 }
 
 extension ClientInterceptor {
-    /// Provides a default implementation that disables interception by returning `nil`.
-    ///
-    /// - Returns: `nil` to disable interception by default.
-    public func makeClientOutboundInterceptor() -> ClientOutboundInterceptorType? { nil }
+    /// Default implementation that returns no client outbound interceptor.
+    public var clientOutboundInterceptor: ClientOutboundInterceptorType? { nil }
 }
 
 /// A client outbound interceptor that forwards all operations to the next interceptor in the chain.

--- a/Sources/Temporal/Client/TemporalClient.swift
+++ b/Sources/Temporal/Client/TemporalClient.swift
@@ -136,7 +136,7 @@ public final class TemporalClient: Sendable {
             workflowService: self.workflowService,
             interceptors: configuration
                 .interceptors
-                .compactMap { $0.makeClientOutboundInterceptor() }
+                .compactMap { $0.clientOutboundInterceptor }
         )
 
         self.interceptedService = .init(

--- a/Sources/Temporal/Instrumentation/TemporalClientTracingInterceptor.swift
+++ b/Sources/Temporal/Instrumentation/TemporalClientTracingInterceptor.swift
@@ -69,7 +69,7 @@ public struct TemporalClientTracingInterceptor: ClientInterceptor {
         self.tracingHeaderKey = tracingHeaderKey
     }
 
-    public func makeClientOutboundInterceptor() -> Self.Outbound? {
+    public var clientOutboundInterceptor: Self.Outbound? {
         Self.Outbound(tracer: self.tracer, tracingHeaderKey: self.tracingHeaderKey)
     }
 }

--- a/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor.swift
+++ b/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor.swift
@@ -71,15 +71,15 @@ public struct TemporalWorkerTracingInterceptor: WorkerInterceptor {
         self.tracingHeaderKey = tracingHeaderKey
     }
 
-    public func makeWorkflowInboundInterceptor() -> WorkflowInbound? {
+    public var workflowInboundInterceptor: WorkflowInbound? {
         Self.WorkflowInbound(tracer: self.tracer, tracingHeaderKey: self.tracingHeaderKey)
     }
 
-    public func makeWorkflowOutboundInterceptor() -> WorkflowOutbound? {
+    public var workflowOutboundInterceptor: WorkflowOutbound? {
         Self.WorkflowOutbound(tracer: self.tracer, tracingHeaderKey: self.tracingHeaderKey)
     }
 
-    public func makeActivityInboundInterceptor() -> ActivityInbound? {
+    public var activityInboundInterceptor: ActivityInbound? {
         Self.ActivityInbound(tracer: self.tracer, tracingHeaderKey: self.tracingHeaderKey)
     }
 

--- a/Sources/Temporal/Worker/Activities/ActivityWorker.swift
+++ b/Sources/Temporal/Worker/Activities/ActivityWorker.swift
@@ -132,7 +132,7 @@ package final class ActivityWorker<BridgeWorker: BridgeWorkerProtocol>: Activity
         self.logger = logger
         self.state = .init(.init(runningActivities: [:]))
         self.interceptors = interceptors
-        self.implementation = .init(interceptors: interceptors.compactMap { $0.makeActivityInboundInterceptor() })
+        self.implementation = .init(interceptors: interceptors.compactMap { $0.activityInboundInterceptor })
     }
 
     package convenience init(
@@ -293,7 +293,7 @@ package final class ActivityWorker<BridgeWorker: BridgeWorkerProtocol>: Activity
                             taskToken: taskToken,
                             dataConverter: self.dataConverter,
                             logger: logger,
-                            outboundInterceptors: self.interceptors.compactMap { $0.makeActivityOutboundInterceptor() },
+                            outboundInterceptors: self.interceptors.compactMap { $0.activityOutboundInterceptor },
                             heartbeatContinuation: heartbeatContinuation,
                             lookupCancellationReason: { runningActivity.cancellationReason }
                         )

--- a/Sources/Temporal/Worker/Interceptors/WorkerInterceptor.swift
+++ b/Sources/Temporal/Worker/Interceptors/WorkerInterceptor.swift
@@ -12,69 +12,45 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Factory protocol for creating interceptors that process workflows and activities within worker execution contexts.
+/// Protocol for a worker interceptor that process workflows and activities within worker execution contexts.
 public protocol WorkerInterceptor: Sendable {
-    /// The type of workflow inbound interceptor this factory creates for processing incoming workflow requests.
+    /// The type of workflow inbound interceptor for processing incoming workflow requests.
     associatedtype WorkflowInboundInterceptorType: WorkflowInboundInterceptor = ForwardingWorkflowInboundInterceptor
 
-    /// The type of workflow outbound interceptor this factory creates for processing outgoing workflow requests.
+    /// The type of workflow outbound interceptor for processing outgoing workflow requests.
     associatedtype WorkflowOutboundInterceptorType: WorkflowOutboundInterceptor = ForwardingWorkflowOutboundInterceptor
 
-    /// The type of activity inbound interceptor this factory creates for processing incoming activity requests.
+    /// The type of activity inbound interceptor for processing incoming activity requests.
     associatedtype ActivityInboundInterceptorType: ActivityInboundInterceptor = ForwardingActivityInboundInterceptor
 
-    /// The type of activity outbound interceptor this factory creates for processing outgoing activity requests.
+    /// The type of activity outbound interceptor for processing outgoing activity requests.
     associatedtype ActivityOutboundInterceptorType: ActivityOutboundInterceptor = ForwardingActivityOutboundInterceptor
 
-    /// Creates a workflow inbound interceptor for processing incoming workflow requests.
-    ///
-    /// - Returns: A workflow inbound interceptor instance, or `nil` if no interception is needed.
-    func makeWorkflowInboundInterceptor() -> WorkflowInboundInterceptorType?
+    /// The workflow inbound interceptor for processing incoming workflow requests, or `nil` if no interception is needed.
+    var workflowInboundInterceptor: WorkflowInboundInterceptorType? { get }
 
-    /// Creates a workflow outbound interceptor for processing outgoing workflow requests.
-    ///
-    /// - Returns: A workflow outbound interceptor instance, or `nil` if no interception is needed.
-    func makeWorkflowOutboundInterceptor() -> WorkflowOutboundInterceptorType?
+    /// The workflow outbound interceptor for processing outgoing workflow requests, or `nil` if no interception is needed.
+    var workflowOutboundInterceptor: WorkflowOutboundInterceptorType? { get }
 
-    /// Creates an activity inbound interceptor for processing incoming activity requests.
-    ///
-    /// - Returns: An activity inbound interceptor instance, or `nil` if no interception is needed.
-    func makeActivityInboundInterceptor() -> ActivityInboundInterceptorType?
+    /// The activity inbound interceptor for processing incoming activity requests, or `nil` if no interception is needed.
+    var activityInboundInterceptor: ActivityInboundInterceptorType? { get }
 
-    /// Creates an activity outbound interceptor for processing outgoing activity requests.
-    ///
-    /// - Returns: An activity outbound interceptor instance, or `nil` if no interception is needed.
-    func makeActivityOutboundInterceptor() -> ActivityOutboundInterceptorType?
+    /// The activity outbound interceptor for processing outgoing activity requests, or `nil` if no interception is needed.
+    var activityOutboundInterceptor: ActivityOutboundInterceptorType? { get }
 }
 
 extension WorkerInterceptor {
     /// Default implementation that returns no workflow inbound interceptor.
-    ///
-    /// - Returns: `nil` to indicate no interception is performed.
-    public func makeWorkflowInboundInterceptor() -> WorkflowInboundInterceptorType? {
-        return nil
-    }
+    public var workflowInboundInterceptor: WorkflowInboundInterceptorType? { nil }
 
     /// Default implementation that returns no workflow outbound interceptor.
-    ///
-    /// - Returns: `nil` to indicate no interception is performed.
-    public func makeWorkflowOutboundInterceptor() -> WorkflowOutboundInterceptorType? {
-        return nil
-    }
+    public var workflowOutboundInterceptor: WorkflowOutboundInterceptorType? { nil }
 
     /// Default implementation that returns no activity inbound interceptor.
-    ///
-    /// - Returns: `nil` to indicate no interception is performed.
-    public func makeActivityInboundInterceptor() -> ActivityInboundInterceptorType? {
-        return nil
-    }
+    public var activityInboundInterceptor: ActivityInboundInterceptorType? { nil }
 
     /// Default implementation that returns no activity outbound interceptor.
-    ///
-    /// - Returns: `nil` to indicate no interception is performed.
-    public func makeActivityOutboundInterceptor() -> ActivityOutboundInterceptorType? {
-        return nil
-    }
+    public var activityOutboundInterceptor: ActivityOutboundInterceptorType? { nil }
 }
 
 /// Default workflow inbound interceptor that forwards all requests without modification.

--- a/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
@@ -79,9 +79,18 @@ struct WorkflowInstance: Sendable {
             payloadConverter: payloadConverter,
             failureConverter: failureConverter
         )
-        let inboundInterceptors = workflowWorker.interceptors.compactMap { $0.makeWorkflowInboundInterceptor() }
+        var inboundInterceptors = [any WorkflowInboundInterceptor]()
+        var outboundInterceptors = [any WorkflowOutboundInterceptor]()
+        for interceptor in workflowWorker.interceptors {
+            if let inbound = interceptor.workflowInboundInterceptor {
+                inboundInterceptors.append(inbound)
+            }
+            if let outbound = interceptor.workflowOutboundInterceptor {
+                outboundInterceptors.append(outbound)
+            }
+        }
         self.implementation = .init(interceptors: inboundInterceptors)
-        self.outboundInterceptors = workflowWorker.interceptors.compactMap { $0.makeWorkflowOutboundInterceptor() }
+        self.outboundInterceptors = outboundInterceptors
         self.logger = logger
     }
 

--- a/Sources/TemporalTestKit/TimeSkippingClientInterceptor.swift
+++ b/Sources/TemporalTestKit/TimeSkippingClientInterceptor.swift
@@ -32,7 +32,7 @@ struct TimeSkippingClientInterceptor: Temporal.ClientInterceptor, Sendable {
         self.testServer = testServer
     }
 
-    func makeClientOutboundInterceptor() -> Outbound? {
+    var clientOutboundInterceptor: Outbound? {
         Outbound(testServer: self.testServer)
     }
 

--- a/Tests/TemporalTests/Client/AsyncActivityHandleTests.swift
+++ b/Tests/TemporalTests/Client/AsyncActivityHandleTests.swift
@@ -80,7 +80,7 @@ extension TestServerDependentTests {
                 }
             }
 
-            func makeClientOutboundInterceptor() -> Outbound? {
+            var clientOutboundInterceptor: Outbound? {
                 Outbound(interceptor: self)
             }
 

--- a/Tests/TemporalTests/Client/ClientOutboundInterceptorTests.swift
+++ b/Tests/TemporalTests/Client/ClientOutboundInterceptorTests.swift
@@ -110,7 +110,7 @@ extension TestServerDependentTests {
                 }
             }
 
-            func makeClientOutboundInterceptor() -> Outbound? {
+            var clientOutboundInterceptor: Outbound? {
                 Outbound(ticker: ticker, interceptor: self)
             }
         }
@@ -164,7 +164,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeClientOutboundInterceptor() -> Outbound? {
+                var clientOutboundInterceptor: Outbound? {
                     Outbound(interceptor: self, otherInterceptor: otherInterceptor)
                 }
             }

--- a/Tests/TemporalTests/Client/InterceptedOperationsTests+Schedules.swift
+++ b/Tests/TemporalTests/Client/InterceptedOperationsTests+Schedules.swift
@@ -122,7 +122,7 @@ extension TestServerDependentTests.InterceptedOperationsTests {
             }
         }
 
-        func makeClientOutboundInterceptor() -> Outbound? {
+        var clientOutboundInterceptor: Outbound? {
             Outbound(interceptor: self)
         }
 

--- a/Tests/TemporalTests/Client/InterceptedOperationsTests+Workflows.swift
+++ b/Tests/TemporalTests/Client/InterceptedOperationsTests+Workflows.swift
@@ -113,7 +113,7 @@ extension TestServerDependentTests {
                 }
             }
 
-            func makeClientOutboundInterceptor() -> Outbound? {
+            var clientOutboundInterceptor: Outbound? {
                 Outbound(interceptor: self)
             }
 

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalClientOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalClientOutboundTracingInterceptorTests.swift
@@ -58,7 +58,7 @@ struct TemporalClientOutboundTracingInterceptorTests {
             let interceptor = try #require(
                 TemporalClientTracingInterceptor(
                     tracer: tracer
-                ).makeClientOutboundInterceptor()
+                ).clientOutboundInterceptor
             )
 
             _ = try await interceptor.queryWorkflow(
@@ -114,7 +114,7 @@ struct TemporalClientOutboundTracingInterceptorTests {
             let interceptor = try #require(
                 TemporalClientTracingInterceptor(
                     tracer: tracer
-                ).makeClientOutboundInterceptor()
+                ).clientOutboundInterceptor
             )
 
             do {

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
@@ -62,7 +62,7 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         let interceptor = try #require(
             TemporalWorkerTracingInterceptor(
                 tracer: tracer
-            ).makeWorkflowInboundInterceptor()
+            ).workflowInboundInterceptor
         )
 
         let mockIncomingHeaders: [String: Api.Common.V1.Payload] = await [
@@ -113,7 +113,7 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         let interceptor = try #require(
             TemporalWorkerTracingInterceptor(
                 tracer: tracer
-            ).makeWorkflowInboundInterceptor()
+            ).workflowInboundInterceptor
         )
 
         let mockIncomingHeaders: [String: Api.Common.V1.Payload] = await [
@@ -169,7 +169,7 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         let interceptor = try #require(
             TemporalWorkerTracingInterceptor(
                 tracer: tracer
-            ).makeActivityInboundInterceptor()
+            ).activityInboundInterceptor
         )
 
         let mockIncomingHeaders: [String: Api.Common.V1.Payload] = await [
@@ -215,7 +215,7 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         let interceptor = try #require(
             TemporalWorkerTracingInterceptor(
                 tracer: tracer
-            ).makeActivityInboundInterceptor()
+            ).activityInboundInterceptor
         )
 
         let mockIncomingHeaders: [String: Api.Common.V1.Payload] = await [

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
@@ -71,7 +71,7 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
                 let interceptor = try #require(
                     TemporalWorkerTracingInterceptor(
                         tracer: tracer
-                    ).makeWorkflowOutboundInterceptor()
+                    ).workflowOutboundInterceptor
                 )
 
                 let input = ScheduleActivityInput<Void>(
@@ -153,7 +153,7 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
                 let interceptor = try #require(
                     TemporalWorkerTracingInterceptor(
                         tracer: tracer
-                    ).makeWorkflowOutboundInterceptor()
+                    ).workflowOutboundInterceptor
                 )
 
                 do {

--- a/Tests/TemporalTests/Worker/Activities/ActivityInterceptorTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityInterceptorTests.swift
@@ -71,7 +71,7 @@ extension TestServerDependentTests {
                 }
             }
 
-            func makeActivityInboundInterceptor() -> Inbound? {
+            var activityInboundInterceptor: Inbound? {
                 return Inbound(interceptor: self)
             }
         }
@@ -116,7 +116,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeActivityInboundInterceptor() -> Inbound? {
+                var activityInboundInterceptor: Inbound? {
                     return Inbound(interceptor: self.firstInterceptor)
                 }
             }
@@ -165,7 +165,7 @@ extension TestServerDependentTests {
                 }
             }
 
-            func makeActivityOutboundInterceptor() -> Outbound? {
+            var activityOutboundInterceptor: Outbound? {
                 return Outbound(interceptor: self)
             }
         }
@@ -208,7 +208,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeActivityOutboundInterceptor() -> Outbound? {
+                var activityOutboundInterceptor: Outbound? {
                     return Outbound(interceptor: self.firstInterceptor)
                 }
             }

--- a/Tests/TemporalTests/Worker/Activities/ActivityWorkerTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityWorkerTests.swift
@@ -299,7 +299,7 @@ private final class ActivityHeaderToInputInterceptor: WorkerInterceptor {
             return try await next(input)
         }
     }
-    func makeActivityInboundInterceptor() -> Inbound? {
+    var activityInboundInterceptor: Inbound? {
         Inbound()
     }
 }

--- a/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowActivityTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowActivityTests.swift
@@ -113,7 +113,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowOutboundInterceptor() -> Outbound? {
+                var workflowOutboundInterceptor: Outbound? {
                     return Outbound(interceptor: self)
                 }
             }

--- a/Tests/TemporalTests/Worker/Workflow/Interceptors/WorkflowInboundInterceptorsTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/Interceptors/WorkflowInboundInterceptorsTests.swift
@@ -49,7 +49,7 @@ extension TestServerDependentTests {
                 }
             }
 
-            func makeWorkflowInboundInterceptor() -> Inbound? {
+            var workflowInboundInterceptor: Inbound? {
                 Inbound(interceptor: self)
             }
         }
@@ -97,7 +97,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowInboundInterceptor() -> Inbound? {
+                var workflowInboundInterceptor: Inbound? {
                     Inbound(firstInterceptor: firstInterceptor)
                 }
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowChildWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowChildWorkflowTests.swift
@@ -230,7 +230,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowOutboundInterceptor() -> Outbound? {
+                var workflowOutboundInterceptor: Outbound? {
                     return Outbound(interceptor: self)
                 }
             }
@@ -509,7 +509,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowOutboundInterceptor() -> Outbound? {
+                var workflowOutboundInterceptor: Outbound? {
                     return Outbound(interceptor: self)
                 }
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowContinueAsNewTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowContinueAsNewTests.swift
@@ -75,7 +75,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowOutboundInterceptor() -> Outbound? {
+                var workflowOutboundInterceptor: Outbound? {
                     return Outbound(interceptor: self)
                 }
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowExternalWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowExternalWorkflowTests.swift
@@ -227,7 +227,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowOutboundInterceptor() -> Outbound? {
+                var workflowOutboundInterceptor: Outbound? {
                     return Outbound(interceptor: self)
                 }
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowHeaderTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowHeaderTests.swift
@@ -122,11 +122,11 @@ extension TestServerDependentTests {
                 }
             }
 
-            func makeWorkflowInboundInterceptor() -> Inbound? {
+            var workflowInboundInterceptor: Inbound? {
                 Inbound(interceptor: self)
             }
 
-            func makeClientOutboundInterceptor() -> Outbound? {
+            var clientOutboundInterceptor: Outbound? {
                 Outbound()
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
@@ -222,7 +222,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowInboundInterceptor() -> Inbound? {
+                var workflowInboundInterceptor: Inbound? {
                     return Inbound(interceptor: self)
                 }
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
@@ -185,7 +185,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowInboundInterceptor() -> Inbound? {
+                var workflowInboundInterceptor: Inbound? {
                     return Inbound(interceptor: self)
                 }
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSleepTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSleepTests.swift
@@ -178,7 +178,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowOutboundInterceptor() -> Outbound? {
+                var workflowOutboundInterceptor: Outbound? {
                     return Outbound(interceptor: self)
                 }
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
@@ -105,7 +105,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                func makeWorkflowInboundInterceptor() -> Inbound? {
+                var workflowInboundInterceptor: Inbound? {
                     return Inbound(interceptor: self)
                 }
             }


### PR DESCRIPTION
Replace `make*Interceptor()` factory methods with computed properties on `WorkerInterceptor` and `ClientInterceptor` protocols.