### PR TITLE
Generate all public enums and one_ofs as `@nonexhaustive`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ build-protos: $(PROTOC_GEN_SWIFT) $(PROTOC_GEN_GRPC_SWIFT) ./dependencies/sdk-co
 		--swift_opt=FileNaming=PathToUnderscores \
 		--swift_opt=Visibility=Public \
 		--swift_opt=UseAccessLevelOnImports=true \
+		--swift_opt=EnumGeneration=Nonexhaustive \
 		-I ./dependencies/sdk-core/crates/common/protos/api_cloud_upstream \
 		-I ./dependencies/sdk-core/crates/common/protos/api_upstream \
 		-I ./dependencies/sdk-core/crates/common/protos/google \

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.36.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.7.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.2.0"),

--- a/Sources/Temporal/Generated/temporal_api_activity_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_activity_v1_message.pb.swift
@@ -50,7 +50,7 @@ extension Api.Activity.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Value: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Value: Equatable, Sendable {
       /// The result if the activity completed successfully.
       case result(Api.Common.V1.Payloads)
       /// The failure if the activity completed unsuccessfully.

--- a/Sources/Temporal/Generated/temporal_api_batch_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_batch_v1_message.pb.swift
@@ -312,7 +312,7 @@ extension Api.Batch.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// The activity to unpause. If match_all is set to true, all activities will be unpaused.
-    public enum OneOf_Activity: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Activity: Equatable, Sendable {
       case type(String)
       case matchAll(Bool)
 
@@ -357,7 +357,7 @@ extension Api.Batch.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Rule: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Rule: Equatable, Sendable {
       /// ID of existing rule.
       case id(String)
       /// Rule specification to be applied to the workflow without creating a new rule.
@@ -428,7 +428,7 @@ extension Api.Batch.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// The activities to reset. If match_all is set to true, all activities will be reset.
-    public enum OneOf_Activity: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Activity: Equatable, Sendable {
       case type(String)
       case matchAll(Bool)
 
@@ -501,7 +501,7 @@ extension Api.Batch.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// The activity to update. If match_all is set to true, all activities will be updated.
-    public enum OneOf_Activity: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Activity: Equatable, Sendable {
       case type(String)
       case matchAll(Bool)
 

--- a/Sources/Temporal/Generated/temporal_api_cloud_account_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_account_v1_message.pb.swift
@@ -170,7 +170,7 @@ extension Api.Cloud.Account.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_SinkType: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_SinkType: Equatable, Sendable {
       /// The KinesisSpec when destination_type is Kinesis
       case kinesisSink(Api.Cloud.Sink.V1.KinesisSpec)
       /// The PubSubSpec when destination_type is PubSub

--- a/Sources/Temporal/Generated/temporal_api_cloud_connectivityrule_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_connectivityrule_v1_message.pb.swift
@@ -98,7 +98,7 @@ extension Api.Cloud.Connectivityrule.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_ConnectionType: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_ConnectionType: Equatable, Sendable {
       /// This allows access via public internet.
       case publicRule(Api.Cloud.Connectivityrule.V1.PublicConnectivityRule)
       /// This allows access via specific private vpc.

--- a/Sources/Temporal/Generated/temporal_api_cloud_identity_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_identity_v1_message.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 extension Api.Cloud.Identity.V1 {
 
 
-  public enum OwnerType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum OwnerType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -92,7 +92,7 @@ extension Api.Cloud.Identity.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum Role: SwiftProtobuf.Enum, Swift.CaseIterable {
+    @nonexhaustive public enum Role: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case unspecified // = 0
 
@@ -186,7 +186,7 @@ extension Api.Cloud.Identity.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum Permission: SwiftProtobuf.Enum, Swift.CaseIterable {
+    @nonexhaustive public enum Permission: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case unspecified // = 0
 
@@ -552,7 +552,7 @@ extension Api.Cloud.Identity.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_GroupType: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_GroupType: Equatable, Sendable {
       /// The specification of the google group that this group is associated with.
       case googleGroup(Api.Cloud.Identity.V1.GoogleGroupSpec)
       /// The specification of the SCIM group that this group is associated with.
@@ -660,7 +660,7 @@ extension Api.Cloud.Identity.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_MemberType: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_MemberType: Equatable, Sendable {
       case userID(String)
 
     }

--- a/Sources/Temporal/Generated/temporal_api_cloud_namespace_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_namespace_v1_message.pb.swift
@@ -339,7 +339,7 @@ extension Api.Cloud.Namespace.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum SearchAttributeType: SwiftProtobuf.Enum, Swift.CaseIterable {
+    @nonexhaustive public enum SearchAttributeType: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case unspecified // = 0
       case text // = 1
@@ -651,7 +651,7 @@ extension Api.Cloud.Namespace.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum State: SwiftProtobuf.Enum, Swift.CaseIterable {
+    @nonexhaustive public enum State: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case unspecified // = 0
 
@@ -826,7 +826,7 @@ extension Api.Cloud.Namespace.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum Health: SwiftProtobuf.Enum, Swift.CaseIterable {
+    @nonexhaustive public enum Health: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case unspecified // = 0
       case ok // = 1

--- a/Sources/Temporal/Generated/temporal_api_cloud_nexus_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_nexus_v1_message.pb.swift
@@ -93,7 +93,7 @@ extension Api.Cloud.Nexus.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       /// A target spec for routing nexus requests to a specific cloud namespace worker.
       case workerTargetSpec(Api.Cloud.Nexus.V1.WorkerTargetSpec)
 
@@ -142,7 +142,7 @@ extension Api.Cloud.Nexus.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       /// A policy spec that allows one caller namespace to access the endpoint.
       case allowedCloudNamespacePolicySpec(Api.Cloud.Nexus.V1.AllowedCloudNamespacePolicySpec)
 

--- a/Sources/Temporal/Generated/temporal_api_cloud_operation_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_operation_v1_message.pb.swift
@@ -93,7 +93,7 @@ extension Api.Cloud.Operation.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum State: SwiftProtobuf.Enum, Swift.CaseIterable {
+    @nonexhaustive public enum State: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_cloud_region_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_region_v1_message.pb.swift
@@ -52,7 +52,7 @@ extension Api.Cloud.Region.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// The cloud provider that's hosting the region.
-    public enum CloudProvider: SwiftProtobuf.Enum, Swift.CaseIterable {
+    @nonexhaustive public enum CloudProvider: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case unspecified // = 0
       case aws // = 1

--- a/Sources/Temporal/Generated/temporal_api_cloud_resource_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_resource_v1_message.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 extension Api.Cloud.Resource.V1 {
 
 
-  public enum ResourceState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ResourceState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_cloud_usage_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_cloud_usage_v1_message.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 extension Api.Cloud.Usage.V1 {
 
 
-  public enum RecordType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum RecordType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case actions // = 1
@@ -67,7 +67,7 @@ extension Api.Cloud.Usage.V1 {
 extension Api.Cloud.Usage.V1 {
 
 
-  public enum RecordUnit: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum RecordUnit: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case number // = 1
@@ -108,7 +108,7 @@ extension Api.Cloud.Usage.V1 {
 extension Api.Cloud.Usage.V1 {
 
 
-  public enum GroupByKey: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum GroupByKey: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case namespace // = 1

--- a/Sources/Temporal/Generated/temporal_api_command_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_command_v1_message.pb.swift
@@ -1117,7 +1117,7 @@ extension Api.Command.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// The command details. The type must match that in `command_type`.
-    public enum OneOf_Attributes: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Attributes: Equatable, Sendable {
       case scheduleActivityTaskCommandAttributes(Api.Command.V1.ScheduleActivityTaskCommandAttributes)
       case startTimerCommandAttributes(Api.Command.V1.StartTimerCommandAttributes)
       case completeWorkflowExecutionCommandAttributes(Api.Command.V1.CompleteWorkflowExecutionCommandAttributes)

--- a/Sources/Temporal/Generated/temporal_api_common_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_common_v1_message.pb.swift
@@ -392,7 +392,7 @@ extension Api.Common.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// Which workflow task to reset to.
-    public enum OneOf_Target: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Target: Equatable, Sendable {
       /// Resets to the first workflow task completed or started event.
       case firstWorkflowTask(SwiftProtobuf.Google_Protobuf_Empty)
       /// Resets to the last workflow task completed or started event.
@@ -446,7 +446,7 @@ extension Api.Common.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       case nexus(Api.Common.V1.Callback.Nexus)
       case `internal`(Api.Common.V1.Callback.Internal)
 
@@ -520,7 +520,7 @@ extension Api.Common.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       case workflowEvent(Api.Common.V1.Link.WorkflowEvent)
       case batchJob(Api.Common.V1.Link.BatchJob)
 
@@ -561,7 +561,7 @@ extension Api.Common.V1 {
 
       /// Additional information about the workflow event.
       /// Eg: the caller workflow can send the history event details that made the Nexus call.
-      public enum OneOf_Reference: Equatable, Sendable {
+      @nonexhaustive public enum OneOf_Reference: Equatable, Sendable {
         case eventRef(Api.Common.V1.Link.WorkflowEvent.EventReference)
         case requestIDRef(Api.Common.V1.Link.WorkflowEvent.RequestIdReference)
 
@@ -752,7 +752,7 @@ extension Api.Common.V1 {
     /// string query = 5;
     /// string task_queue = 6;
     /// ...
-    public enum OneOf_Selector: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Selector: Equatable, Sendable {
       /// Worker instance key to which the command should be sent.
       case workerInstanceKey(String)
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_activity.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_activity.pb.swift
@@ -27,7 +27,7 @@ extension Api.Enums.V1 {
   /// status.
   /// (-- api-linter: core::0216::synonyms=disabled
   ///     aip.dev/not-precedent: Named consistently with WorkflowExecutionStatus. --)
-  public enum ActivityExecutionStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ActivityExecutionStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -116,7 +116,7 @@ extension Api.Enums.V1 {
   /// If the request is denied, the server returns an `ActivityExecutionAlreadyStarted` error.
   ///
   /// See `ActivityIdConflictPolicy` for handling ID duplication with a *running* activity.
-  public enum ActivityIdReusePolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ActivityIdReusePolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -173,7 +173,7 @@ extension Api.Enums.V1 {
   /// Note that it is *never* valid to have two running instances of the same activity ID.
   ///
   /// See `ActivityIdReusePolicy` for handling activity ID duplication with a *closed* activity.
-  public enum ActivityIdConflictPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ActivityIdConflictPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_batch_operation.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_batch_operation.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 extension Api.Enums.V1 {
 
 
-  public enum BatchOperationType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum BatchOperationType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case terminate // = 1
@@ -91,7 +91,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum BatchOperationState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum BatchOperationState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case running // = 1

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_command_type.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_command_type.pb.swift
@@ -23,7 +23,7 @@ extension Api.Enums.V1 {
 
 
   /// Whenever this list of command types is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering.
-  public enum CommandType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum CommandType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case scheduleActivityTask // = 1

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_common.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_common.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 extension Api.Enums.V1 {
 
 
-  public enum EncodingType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum EncodingType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case proto3 // = 1
@@ -63,7 +63,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum IndexedValueType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum IndexedValueType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case text // = 1
@@ -124,7 +124,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum Severity: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum Severity: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case high // = 1
@@ -170,7 +170,7 @@ extension Api.Enums.V1 {
 
 
   /// State of a callback.
-  public enum CallbackState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum CallbackState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Default value, unspecified state.
@@ -242,7 +242,7 @@ extension Api.Enums.V1 {
 
 
   /// State of a pending Nexus operation.
-  public enum PendingNexusOperationState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum PendingNexusOperationState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Default value, unspecified state.
@@ -302,7 +302,7 @@ extension Api.Enums.V1 {
 
 
   /// State of a Nexus operation cancellation.
-  public enum NexusOperationCancellationState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum NexusOperationCancellationState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Default value, unspecified state.
@@ -373,7 +373,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum WorkflowRuleActionScope: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum WorkflowRuleActionScope: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Default value, unspecified scope.
@@ -420,7 +420,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum ApplicationErrorCategory: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ApplicationErrorCategory: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -461,7 +461,7 @@ extension Api.Enums.V1 {
 
   /// (-- api-linter: core::0216::synonyms=disabled
   ///     aip.dev/not-precedent: It seems we have both state and status, and status is a better fit for workers. --)
-  public enum WorkerStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum WorkerStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case running // = 1

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_deployment.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_deployment.pb.swift
@@ -24,7 +24,7 @@ extension Api.Enums.V1 {
 
   /// Specify the reachability level for a deployment so users can decide if it is time to
   /// decommission the deployment.
-  public enum DeploymentReachability: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum DeploymentReachability: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Reachability level is not specified.
@@ -86,7 +86,7 @@ extension Api.Enums.V1 {
   /// Specify the drainage status for a Worker Deployment Version so users can decide whether they
   /// can safely decommission the version.
   /// Experimental. Worker Deployments are experimental and might significantly change in the future.
-  public enum VersionDrainageStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum VersionDrainageStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Drainage Status is not specified.
@@ -143,7 +143,7 @@ extension Api.Enums.V1 {
   ///   tasks to it.
   /// - Whether or not the workflows processed by this worker are versioned using the worker's version.
   /// Experimental. Worker Deployments are experimental and might significantly change in the future.
-  public enum WorkerVersioningMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum WorkerVersioningMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -207,7 +207,7 @@ extension Api.Enums.V1 {
   ///     aip.dev/not-precedent: Call this status because it is . --)
   /// Specify the status of a Worker Deployment Version.
   /// Experimental. Worker Deployments are experimental and might significantly change in the future.
-  public enum WorkerDeploymentVersionStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum WorkerDeploymentVersionStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_event_type.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_event_type.pb.swift
@@ -23,7 +23,7 @@ extension Api.Enums.V1 {
 
 
   /// Whenever this list of events is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering
-  public enum EventType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum EventType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Place holder and should never appear in a Workflow execution history

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_failed_cause.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_failed_cause.pb.swift
@@ -24,7 +24,7 @@ extension Api.Enums.V1 {
 
   /// Workflow tasks can fail for various reasons. Note that some of these reasons can only originate
   /// from the server, and some of them can only originate from the SDK/worker.
-  public enum WorkflowTaskFailedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum WorkflowTaskFailedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -251,7 +251,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum StartChildWorkflowExecutionFailedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum StartChildWorkflowExecutionFailedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case workflowAlreadyExists // = 1
@@ -292,7 +292,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum CancelExternalWorkflowExecutionFailedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum CancelExternalWorkflowExecutionFailedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case externalWorkflowExecutionNotFound // = 1
@@ -333,7 +333,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum SignalExternalWorkflowExecutionFailedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum SignalExternalWorkflowExecutionFailedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case externalWorkflowExecutionNotFound // = 1
@@ -380,7 +380,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum ResourceExhaustedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ResourceExhaustedCause: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -473,7 +473,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum ResourceExhaustedScope: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ResourceExhaustedScope: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_namespace.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_namespace.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 extension Api.Enums.V1 {
 
 
-  public enum NamespaceState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum NamespaceState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case registered // = 1
@@ -67,7 +67,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum ArchivalState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ArchivalState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case disabled // = 1
@@ -108,7 +108,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum ReplicationState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ReplicationState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case normal // = 1

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_nexus.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_nexus.pb.swift
@@ -25,7 +25,7 @@ extension Api.Enums.V1 {
   /// NexusHandlerErrorRetryBehavior allows nexus handlers to explicity set the retry behavior of a HandlerError. If not
   /// specified, retry behavior is determined from the error type. For example internal errors are not retryable by default
   /// unless specified otherwise.
-  public enum NexusHandlerErrorRetryBehavior: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum NexusHandlerErrorRetryBehavior: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_query.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_query.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 extension Api.Enums.V1 {
 
 
-  public enum QueryResultType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum QueryResultType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case answered // = 1
@@ -63,7 +63,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum QueryRejectCondition: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum QueryRejectCondition: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_reset.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_reset.pb.swift
@@ -23,7 +23,7 @@ extension Api.Enums.V1 {
 
 
   /// Event types to exclude when reapplying events beyond the reset point.
-  public enum ResetReapplyExcludeType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ResetReapplyExcludeType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -85,7 +85,7 @@ extension Api.Enums.V1 {
   /// Deprecated: applications should use ResetReapplyExcludeType to specify
   /// exclusions from this set, and new event types should be added to ResetReapplyExcludeType
   /// instead of here.
-  public enum ResetReapplyType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ResetReapplyType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -137,7 +137,7 @@ extension Api.Enums.V1 {
 
 
   /// Deprecated, see temporal.api.common.v1.ResetOptions.
-  public enum ResetType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ResetType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_schedule.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_schedule.pb.swift
@@ -24,7 +24,7 @@ extension Api.Enums.V1 {
 
   /// ScheduleOverlapPolicy controls what happens when a workflow would be started
   /// by a schedule, and is already running.
-  public enum ScheduleOverlapPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ScheduleOverlapPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_task_queue.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_task_queue.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 extension Api.Enums.V1 {
 
 
-  public enum TaskQueueKind: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum TaskQueueKind: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Tasks from any non workflow task may be unspecified.
@@ -84,7 +84,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum TaskQueueType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum TaskQueueType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -138,7 +138,7 @@ extension Api.Enums.V1 {
   /// Specifies which category of tasks may reach a worker on a versioned task queue.
   /// Used both in a reachability query and its response.
   /// Deprecated.
-  public enum TaskReachability: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum TaskReachability: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -210,7 +210,7 @@ extension Api.Enums.V1 {
   /// assignment rules of their Task Queue. Same goes for Child Workflows or Continue-As-New Workflows
   /// who inherit the parent/previous workflow's Build ID but not its Task Queue. In those cases, make
   /// sure to query reachability for the parent/previous workflow's Task Queue as well.
-  public enum BuildIdTaskReachability: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum BuildIdTaskReachability: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Task reachability is not reported
@@ -267,7 +267,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum DescribeTaskQueueMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum DescribeTaskQueueMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Unspecified means legacy behavior.
@@ -309,7 +309,7 @@ extension Api.Enums.V1 {
 
 
   /// Source for the effective rate limit.
-  public enum RateLimitSource: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum RateLimitSource: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -362,7 +362,7 @@ extension Api.Enums.V1 {
 
   /// Indicates whether a change to the Routing Config has been
   /// propagated to all relevant Task Queues and their partitions.
-  public enum RoutingConfigUpdateState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum RoutingConfigUpdateState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_update.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_update.pb.swift
@@ -31,7 +31,7 @@ extension Api.Enums.V1 {
   /// completion.
   /// If specified stage wasn't reached before server timeout, server returns
   /// actual stage reached.
-  public enum UpdateWorkflowExecutionLifecycleStage: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum UpdateWorkflowExecutionLifecycleStage: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// An unspecified value for this enum.
@@ -91,7 +91,7 @@ extension Api.Enums.V1 {
 
   /// Records why a WorkflowExecutionUpdateAdmittedEvent was written to history.
   /// Note that not all admitted Updates result in this event.
-  public enum UpdateAdmittedEventOrigin: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum UpdateAdmittedEventOrigin: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_enums_v1_workflow.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_enums_v1_workflow.pb.swift
@@ -26,7 +26,7 @@ extension Api.Enums.V1 {
   /// If the request is denied, the server returns a `WorkflowExecutionAlreadyStartedFailure` error.
   ///
   /// See `WorkflowIdConflictPolicy` for handling workflow id duplication with a *running* workflow.
-  public enum WorkflowIdReusePolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum WorkflowIdReusePolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -96,7 +96,7 @@ extension Api.Enums.V1 {
   /// Note that it is *never* valid to have two actively running instances of the same workflow id.
   ///
   /// See `WorkflowIdReusePolicy` for handling workflow id duplication with a *closed* workflow.
-  public enum WorkflowIdConflictPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum WorkflowIdConflictPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -148,7 +148,7 @@ extension Api.Enums.V1 {
 
 
   /// Defines how child workflows will react to their parent completing
-  public enum ParentClosePolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ParentClosePolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -199,7 +199,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum ContinueAsNewInitiator: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ContinueAsNewInitiator: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -252,7 +252,7 @@ extension Api.Enums.V1 {
 
   /// (-- api-linter: core::0216::synonyms=disabled
   ///     aip.dev/not-precedent: There is WorkflowExecutionState already in another package. --)
-  public enum WorkflowExecutionStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum WorkflowExecutionStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -319,7 +319,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum PendingActivityState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum PendingActivityState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case scheduled // = 1
@@ -376,7 +376,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum PendingWorkflowTaskState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum PendingWorkflowTaskState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case scheduled // = 1
@@ -417,7 +417,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum HistoryEventFilterType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum HistoryEventFilterType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case allEvent // = 1
@@ -458,7 +458,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum RetryState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum RetryState: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case inProgress // = 1
@@ -519,7 +519,7 @@ extension Api.Enums.V1 {
 extension Api.Enums.V1 {
 
 
-  public enum TimeoutType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum TimeoutType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
     case startToClose // = 1
@@ -573,7 +573,7 @@ extension Api.Enums.V1 {
   /// who completes the first task of the execution, but is also overridable manually for new and
   /// existing workflows (see VersioningOverride).
   /// Experimental. Worker Deployments are experimental and might significantly change in the future.
-  public enum VersioningBehavior: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum VersioningBehavior: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     /// Workflow execution does not have a Versioning Behavior and is called Unversioned. This is the
@@ -658,7 +658,7 @@ extension Api.Enums.V1 {
 
 
   /// Experimental. Defines the versioning behavior to be used by the first task of a new workflow run in a continue-as-new chain.
-  public enum ContinueAsNewVersioningBehavior: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum ContinueAsNewVersioningBehavior: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 
@@ -706,7 +706,7 @@ extension Api.Enums.V1 {
 
 
   /// SuggestContinueAsNewReason specifies why SuggestContinueAsNew is true.
-  public enum SuggestContinueAsNewReason: SwiftProtobuf.Enum, Swift.CaseIterable {
+  @nonexhaustive public enum SuggestContinueAsNewReason: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case unspecified // = 0
 

--- a/Sources/Temporal/Generated/temporal_api_failure_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_failure_v1_message.pb.swift
@@ -442,7 +442,7 @@ extension Api.Failure.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_FailureInfo: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_FailureInfo: Equatable, Sendable {
       case applicationFailureInfo(Api.Failure.V1.ApplicationFailureInfo)
       case timeoutFailureInfo(Api.Failure.V1.TimeoutFailureInfo)
       case canceledFailureInfo(Api.Failure.V1.CanceledFailureInfo)

--- a/Sources/Temporal/Generated/temporal_api_history_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_history_v1_message.pb.swift
@@ -3837,7 +3837,7 @@ extension Api.History.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// The event details. The type must match that in `event_type`.
-    public enum OneOf_Attributes: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Attributes: Equatable, Sendable {
       case workflowExecutionStartedEventAttributes(Api.History.V1.WorkflowExecutionStartedEventAttributes)
       case workflowExecutionCompletedEventAttributes(Api.History.V1.WorkflowExecutionCompletedEventAttributes)
       case workflowExecutionFailedEventAttributes(Api.History.V1.WorkflowExecutionFailedEventAttributes)

--- a/Sources/Temporal/Generated/temporal_api_nexus_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_nexus_v1_message.pb.swift
@@ -278,7 +278,7 @@ extension Api.Nexus.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       case startOperation(Api.Nexus.V1.StartOperationRequest)
       case cancelOperation(Api.Nexus.V1.CancelOperationRequest)
 
@@ -355,7 +355,7 @@ extension Api.Nexus.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       case syncSuccess(Api.Nexus.V1.StartOperationResponse.Sync)
       case asyncSuccess(Api.Nexus.V1.StartOperationResponse.Async)
       /// The operation completed unsuccessfully (failed or canceled).
@@ -462,7 +462,7 @@ extension Api.Nexus.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// Variant must correlate to the corresponding Request's variant.
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       case startOperation(Api.Nexus.V1.StartOperationResponse)
       case cancelOperation(Api.Nexus.V1.CancelOperationResponse)
 
@@ -607,7 +607,7 @@ extension Api.Nexus.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       case worker(Api.Nexus.V1.EndpointTarget.Worker)
       case external(Api.Nexus.V1.EndpointTarget.External)
 

--- a/Sources/Temporal/Generated/temporal_api_protocol_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_protocol_v1_message.pb.swift
@@ -73,7 +73,7 @@ extension Api.`Protocol`.V1 {
     /// The event ID or command ID after which this message can be delivered. The
     /// effects of history up to and including this event ID should be visible to
     /// the code that handles this message. Omit to opt out of sequencing.
-    public enum OneOf_SequencingID: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_SequencingID: Equatable, Sendable {
       case eventID(Int64)
       case commandIndex(Int64)
 

--- a/Sources/Temporal/Generated/temporal_api_rules_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_rules_v1_message.pb.swift
@@ -41,7 +41,7 @@ extension Api.Rules.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// Supported actions.
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       case activityPause(Api.Rules.V1.WorkflowRuleAction.ActionActivityPause)
 
     }
@@ -111,7 +111,7 @@ extension Api.Rules.V1 {
 
     /// Specifies how the rule should be triggered and evaluated.
     /// Currently, only "activity start" type is supported.
-    public enum OneOf_Trigger: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Trigger: Equatable, Sendable {
       case activityStart(Api.Rules.V1.WorkflowRuleSpec.ActivityStartingTrigger)
 
     }

--- a/Sources/Temporal/Generated/temporal_api_schedule_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_schedule_v1_message.pb.swift
@@ -406,7 +406,7 @@ extension Api.Schedule.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Action: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Action: Equatable, Sendable {
       /// All fields of NewWorkflowExecutionInfo are valid except for:
       /// - workflow_id_reuse_policy
       /// - cron_schedule

--- a/Sources/Temporal/Generated/temporal_api_sdk_v1_worker_config.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_sdk_v1_worker_config.pb.swift
@@ -49,7 +49,7 @@ extension Api.Sdk.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_PollerBehavior: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_PollerBehavior: Equatable, Sendable {
       case simplePollerBehavior(Api.Sdk.V1.WorkerConfig.SimplePollerBehavior)
       case autoscalingPollerBehavior(Api.Sdk.V1.WorkerConfig.AutoscalingPollerBehavior)
 

--- a/Sources/Temporal/Generated/temporal_api_taskqueue_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_taskqueue_v1_message.pb.swift
@@ -594,7 +594,7 @@ extension Api.Taskqueue.V1 {
     /// tasks according to the provided percentage.
     /// This option can be used only on "terminal" Build IDs (the ones not used
     /// as source in any redirect rules).
-    public enum OneOf_Ramp: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Ramp: Equatable, Sendable {
       /// This ramp is useful for gradual Blue/Green deployments (and similar)
       /// where you want to send a certain portion of the traffic to the target
       /// Build ID.

--- a/Sources/Temporal/Generated/temporal_api_update_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_update_v1_message.pb.swift
@@ -96,7 +96,7 @@ extension Api.Update.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Value: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Value: Equatable, Sendable {
       case success(Api.Common.V1.Payloads)
       case failure(Api.Failure.V1.Failure)
 

--- a/Sources/Temporal/Generated/temporal_api_workflow_v1_message.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_workflow_v1_message.pb.swift
@@ -903,7 +903,7 @@ extension Api.Workflow.V1 {
     /// In rare cases, it can also mean that the task queue is versioned but we failed to write activity's
     /// independently-assigned build ID to the database. This case heals automatically once the task is dispatched.
     /// Deprecated. This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
-    public enum OneOf_AssignedBuildID: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_AssignedBuildID: Equatable, Sendable {
       /// Deprecated. When present, it means this activity is assigned to the build ID of its workflow.
       ///
       /// NOTE: This field was marked as deprecated in the .proto file.
@@ -955,7 +955,7 @@ extension Api.Workflow.V1 {
 
       public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-      public enum OneOf_PausedBy: Equatable, Sendable {
+      @nonexhaustive public enum OneOf_PausedBy: Equatable, Sendable {
         /// activity was paused by the manual intervention
         case manual(Api.Workflow.V1.PendingActivityInfo.PauseInfo.Manual)
         /// activity was paused by the rule
@@ -1426,7 +1426,7 @@ extension Api.Workflow.V1 {
 
       public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-      public enum OneOf_Variant: Equatable, Sendable {
+      @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
         case workflowClosed(Api.Workflow.V1.CallbackInfo.WorkflowClosed)
 
       }
@@ -1779,7 +1779,7 @@ extension Api.Workflow.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// Indicates whether to override the workflow to be AutoUpgrade or Pinned.
-    public enum OneOf_Override: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Override: Equatable, Sendable {
       /// Override the workflow to have Pinned behavior.
       case pinned(Api.Workflow.V1.VersioningOverride.PinnedOverride)
       /// Override the workflow to have AutoUpgrade behavior.
@@ -1787,7 +1787,7 @@ extension Api.Workflow.V1 {
 
     }
 
-    public enum PinnedOverrideBehavior: SwiftProtobuf.Enum, Swift.CaseIterable {
+    @nonexhaustive public enum PinnedOverrideBehavior: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       /// Unspecified.
@@ -1944,7 +1944,7 @@ extension Api.Workflow.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Variant: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Variant: Equatable, Sendable {
       case signalWorkflow(Api.Workflow.V1.PostResetOperation.SignalWorkflow)
       case updateWorkflowOptions(Api.Workflow.V1.PostResetOperation.UpdateWorkflowOptions)
 

--- a/Sources/Temporal/Generated/temporal_api_workflowservice_v1_request_response.pb.swift
+++ b/Sources/Temporal/Generated/temporal_api_workflowservice_v1_request_response.pb.swift
@@ -2814,7 +2814,7 @@ extension Api.Workflowservice.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Filters: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Filters: Equatable, Sendable {
       case executionFilter(Api.Filter.V1.WorkflowExecutionFilter)
       case typeFilter(Api.Filter.V1.WorkflowTypeFilter)
 
@@ -2893,7 +2893,7 @@ extension Api.Workflowservice.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Filters: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Filters: Equatable, Sendable {
       case executionFilter(Api.Filter.V1.WorkflowExecutionFilter)
       case typeFilter(Api.Filter.V1.WorkflowTypeFilter)
       case statusFilter(Api.Filter.V1.StatusFilter)
@@ -4458,7 +4458,7 @@ extension Api.Workflowservice.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Operation: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Operation: Equatable, Sendable {
       /// A new build id. This operation will create a new set which will be the new overall
       /// default version for the queue, with this id as its only member. This new set is
       /// incompatible with all previous sets/versions.
@@ -4672,7 +4672,7 @@ extension Api.Workflowservice.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Operation: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Operation: Equatable, Sendable {
       case insertAssignmentRule(Api.Workflowservice.V1.UpdateWorkerVersioningRulesRequest.InsertBuildIdAssignmentRule)
       case replaceAssignmentRule(Api.Workflowservice.V1.UpdateWorkerVersioningRulesRequest.ReplaceBuildIdAssignmentRule)
       case deleteAssignmentRule(Api.Workflowservice.V1.UpdateWorkerVersioningRulesRequest.DeleteBuildIdAssignmentRule)
@@ -5223,7 +5223,7 @@ extension Api.Workflowservice.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// Operation input
-    public enum OneOf_Operation: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Operation: Equatable, Sendable {
       case terminationOperation(Api.Batch.V1.BatchOperationTermination)
       case signalOperation(Api.Batch.V1.BatchOperationSignal)
       case cancellationOperation(Api.Batch.V1.BatchOperationCancellation)
@@ -5767,7 +5767,7 @@ extension Api.Workflowservice.V1 {
 
       public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-      public enum OneOf_Operation: Equatable, Sendable {
+      @nonexhaustive public enum OneOf_Operation: Equatable, Sendable {
         /// Additional restrictions:
         /// - setting `cron_schedule` is invalid
         /// - setting `request_eager_execution` is invalid
@@ -5829,7 +5829,7 @@ extension Api.Workflowservice.V1 {
 
       public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-      public enum OneOf_Response: Equatable, Sendable {
+      @nonexhaustive public enum OneOf_Response: Equatable, Sendable {
         case startWorkflow(Api.Workflowservice.V1.StartWorkflowExecutionResponse)
         case updateWorkflow(Api.Workflowservice.V1.UpdateWorkflowExecutionResponse)
 
@@ -5926,7 +5926,7 @@ extension Api.Workflowservice.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// either activity id, activity type or update_all must be provided
-    public enum OneOf_Activity: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Activity: Equatable, Sendable {
       /// Only activity with this ID will be updated.
       case id(String)
       /// Update all running activities of this type.
@@ -6020,7 +6020,7 @@ extension Api.Workflowservice.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// either activity id or activity type must be provided
-    public enum OneOf_Activity: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Activity: Equatable, Sendable {
       /// Only the activity with this ID will be paused.
       case id(String)
       /// Pause all running activities of this type.
@@ -6120,7 +6120,7 @@ extension Api.Workflowservice.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// either activity id or activity type must be provided
-    public enum OneOf_Activity: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Activity: Equatable, Sendable {
       /// Only the activity with this ID will be unpaused.
       case id(String)
       /// Unpause all running activities with of this type.
@@ -6230,7 +6230,7 @@ extension Api.Workflowservice.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// either activity id, activity type or update_all must be provided
-    public enum OneOf_Activity: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Activity: Equatable, Sendable {
       /// Only activity with this ID will be reset.
       case id(String)
       /// Reset all running activities with of this type.
@@ -7175,7 +7175,7 @@ extension Api.Workflowservice.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_NewManagerIdentity: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_NewManagerIdentity: Equatable, Sendable {
       /// Arbitrary value for `manager_identity`.
       /// Empty will unset the field.
       case managerIdentity(String)
@@ -7547,7 +7547,7 @@ extension Api.Workflowservice.V1 {
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// Either provide id of existing rule, or rule specification
-    public enum OneOf_Rule: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Rule: Equatable, Sendable {
       case id(String)
       /// Note: Rule ID and expiration date are not used in the trigger request.
       case spec(Api.Rules.V1.WorkflowRuleSpec)
@@ -7913,7 +7913,7 @@ extension Api.Workflowservice.V1 {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum OneOf_Response: Equatable, Sendable {
+    @nonexhaustive public enum OneOf_Response: Equatable, Sendable {
       /// The worker configuration. Will be returned if the command was sent to a single worker.
       case workerConfig(Api.Sdk.V1.WorkerConfig)
 


### PR DESCRIPTION
This ensures that when regenerated the protos we are not breaking our APIs unintentionally.