### PR TITLE
Add handle operation improvements for feature parity with other SDKs

### DIFF
--- a/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowHandle+Operations.swift
+++ b/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowHandle+Operations.swift
@@ -117,6 +117,35 @@ extension UntypedWorkflowHandle {
         )
     }
 
+    /// Returns a lazy async sequence of workflow execution history events with internal pagination.
+    ///
+    /// Unlike ``fetchHistoryEvents(waitNewEvent:eventFilterType:skipArchival:callOptions:)`` which
+    /// eagerly fetches all events into an array, this method returns an `AsyncSequence` that lazily
+    /// streams events with internal pagination. This is more memory-efficient for workflows with
+    /// large histories.
+    ///
+    /// - Parameters:
+    ///   - waitNewEvent: Whether to wait for new events if none are immediately available.
+    ///   - eventFilterType: The type of events to include in the response.
+    ///   - skipArchival: Whether to skip archived history events for performance.
+    ///   - callOptions: Optional gRPC call options for customizing the behavior of the underlying request.
+    /// - Returns: An `AsyncSequence` of history events representing the workflow's execution timeline.
+    public func fetchHistoryEventStream(
+        waitNewEvent: Bool = false,
+        eventFilterType: Api.Enums.V1.HistoryEventFilterType = .allEvent,
+        skipArchival: Bool = false,
+        callOptions: CallOptions? = nil
+    ) -> some AsyncSequence<Api.History.V1.HistoryEvent, any Error> & Sendable {
+        self.interceptor.workflowService.fetchWorkflowHistoryEventStream(
+            id: self.id,
+            runID: self.runID,
+            waitNewEvent: waitNewEvent,
+            eventFilterType: eventFilterType,
+            skipArchival: skipArchival,
+            callOptions: callOptions
+        )
+    }
+
     // MARK: Signals
 
     /// Sends a signal to the workflow execution with typed input data.
@@ -277,6 +306,25 @@ extension UntypedWorkflowHandle {
         )
     }
 
+    // MARK: Update Handle
+
+    /// Returns a handle for a previously started update operation.
+    ///
+    /// This method creates an ``UntypedWorkflowUpdateHandle`` for an update that was previously
+    /// started on this workflow. Use this to poll the result of an update when you only have
+    /// the update ID (for example, from a previous session or external system).
+    ///
+    /// - Parameter id: The unique identifier of the update operation.
+    /// - Returns: An ``UntypedWorkflowUpdateHandle`` for managing and retrieving the update result.
+    public func getUpdateHandle(id: String) -> UntypedWorkflowUpdateHandle {
+        UntypedWorkflowUpdateHandle(
+            interceptor: self.interceptor,
+            id: id,
+            workflowID: self.id,
+            workflowRunID: self.runID
+        )
+    }
+
     // MARK: Cancel
 
     /// Requests cancellation of the workflow execution.
@@ -366,7 +414,7 @@ extension TemporalClient.Interceptor {
         _ input: StartWorkflowUpdateInput<repeat each Input>
     ) async throws -> UntypedWorkflowUpdateHandle {
         try await self.intercept((any ClientOutboundInterceptor).startWorkflowUpdate, input: input) { input in
-            let updateID = try await self.workflowService.startWorkflowUpdate(
+            let result = try await self.workflowService.startWorkflowUpdateWithOutcome(
                 workflowID: input.id,
                 runID: input.runID,
                 firstExecutionRunID: input.firstExecutionRunID,
@@ -380,9 +428,10 @@ extension TemporalClient.Interceptor {
 
             return UntypedWorkflowUpdateHandle(
                 interceptor: self,
-                id: updateID,
+                id: result.updateID,
                 workflowID: input.id,
-                workflowRunID: input.runID  // Starting update does not create a new runID
+                workflowRunID: input.runID,  // Starting update does not create a new runID
+                knownOutcome: result.outcomePayloads
             )
         }
     }

--- a/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowUpdateHandle+Operations.swift
+++ b/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowUpdateHandle+Operations.swift
@@ -27,6 +27,10 @@ extension UntypedWorkflowUpdateHandle {
     /// must have been successfully processed by the workflow before this method can return a value.
     /// The method suspends until the update reaches a terminal state (completed or failed).
     ///
+    /// If the update outcome was already known at handle creation time (for example, when the
+    /// update was started with ``WorkflowUpdateStage/completed``), the cached result is returned
+    /// without making an additional RPC.
+    ///
     /// - Parameters:
     ///    - resultTypes: The expected result types from the update operation.
     ///    - callOptions: Optional gRPC call options for customizing the behavior of the underlying request.
@@ -36,7 +40,13 @@ extension UntypedWorkflowUpdateHandle {
         resultTypes: repeat (each Result).Type,
         callOptions: CallOptions? = nil
     ) async throws -> (repeat each Result) {
-        try await self.interceptor.workflowService.workflowUpdateResult(
+        if let knownOutcome {
+            return try await self.interceptor.workflowService.configuration.dataConverter.convertPayloads(
+                knownOutcome,
+                as: repeat each resultTypes
+            )
+        }
+        return try await self.interceptor.workflowService.workflowUpdateResult(
             workflowID: self.workflowID,
             runID: self.workflowRunID,
             updateID: self.id,

--- a/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowUpdateHandle.swift
+++ b/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowUpdateHandle.swift
@@ -47,6 +47,12 @@ public struct UntypedWorkflowUpdateHandle: Sendable {
     /// configured, providing precise targeting of workflow executions.
     public let workflowRunID: String?
 
+    /// Cached outcome payloads from a previously completed poll.
+    ///
+    /// When set, subsequent calls to ``result(resultTypes:callOptions:)`` will return the
+    /// cached payloads instead of making additional RPCs to the server.
+    package let knownOutcome: [Api.Common.V1.Payload]?
+
     /// Creates a workflow update handle for managing a specific update operation.
     ///
     /// - Parameters:
@@ -54,15 +60,18 @@ public struct UntypedWorkflowUpdateHandle: Sendable {
     ///   - id: The unique identifier for this update operation.
     ///   - workflowID: The unique identifier of the target workflow.
     ///   - workflowRunID: The optional run ID for precise workflow execution targeting.
+    ///   - knownOutcome: Optional cached outcome payloads from a prior poll.
     package init(
         interceptor: TemporalClient.Interceptor,
         id: String,
         workflowID: String,
         workflowRunID: String? = nil,
+        knownOutcome: [Api.Common.V1.Payload]? = nil,
     ) {
         self.interceptor = interceptor
         self.id = id
         self.workflowID = workflowID
         self.workflowRunID = workflowRunID
+        self.knownOutcome = knownOutcome
     }
 }

--- a/Sources/Temporal/Client/Handles/Workflow/WorkflowHandle+Operations.swift
+++ b/Sources/Temporal/Client/Handles/Workflow/WorkflowHandle+Operations.swift
@@ -89,6 +89,33 @@ extension WorkflowHandle {
         try await self.untypedHandle.fetchHistory(callOptions: callOptions)
     }
 
+    /// Returns a lazy async sequence of workflow execution history events with internal pagination.
+    ///
+    /// Unlike ``fetchHistoryEvents(waitNewEvent:eventFilterType:skipArchival:callOptions:)`` which
+    /// eagerly fetches all events into an array, this method returns an `AsyncSequence` that lazily
+    /// streams events with internal pagination. This is more memory-efficient for workflows with
+    /// large histories.
+    ///
+    /// - Parameters:
+    ///   - waitNewEvent: Whether to wait for new events if none are immediately available.
+    ///   - eventFilterType: The type of events to include in the response.
+    ///   - skipArchival: Whether to skip archived history events for performance.
+    ///   - callOptions: Optional gRPC call options for customizing the behavior of the underlying request.
+    /// - Returns: An `AsyncSequence` of history events representing the workflow's execution timeline.
+    public func fetchHistoryEventStream(
+        waitNewEvent: Bool = false,
+        eventFilterType: Api.Enums.V1.HistoryEventFilterType = .allEvent,
+        skipArchival: Bool = false,
+        callOptions: CallOptions? = nil
+    ) -> some AsyncSequence<Api.History.V1.HistoryEvent, any Error> & Sendable {
+        self.untypedHandle.fetchHistoryEventStream(
+            waitNewEvent: waitNewEvent,
+            eventFilterType: eventFilterType,
+            skipArchival: skipArchival,
+            callOptions: callOptions
+        )
+    }
+
     // MARK: Signals
 
     /// Sends a signal to the workflow execution with typed input data.
@@ -265,6 +292,25 @@ extension WorkflowHandle {
             resultTypes: Update.Output.self,
             callOptions: callOptions
         )
+    }
+
+    // MARK: Update Handle
+
+    /// Returns a handle for a previously started update operation.
+    ///
+    /// This method creates a ``WorkflowUpdateHandle`` for an update that was previously
+    /// started on this workflow. Use this to poll the result of an update when you only have
+    /// the update ID (for example, from a previous session or external system).
+    ///
+    /// - Parameters:
+    ///   - updateType: The update type.
+    ///   - id: The unique identifier of the update operation.
+    /// - Returns: A ``WorkflowUpdateHandle`` for managing and retrieving the update result.
+    public func getUpdateHandle<WorkflowUpdate: WorkflowUpdateDefinition>(
+        updateType: WorkflowUpdate.Type = WorkflowUpdate.self,
+        id: String
+    ) -> WorkflowUpdateHandle<WorkflowUpdate> {
+        WorkflowUpdateHandle(untypedHandle: self.untypedHandle.getUpdateHandle(id: id))
     }
 
     // MARK: Cancel

--- a/Sources/Temporal/Client/OperatorService/TemporalClient+OperatorService.swift
+++ b/Sources/Temporal/Client/OperatorService/TemporalClient+OperatorService.swift
@@ -14,6 +14,12 @@
 
 public import GRPCCore
 
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
+public import Foundation
+#endif
+
 extension TemporalClient {
     /// Provides access to Temporal operator services for administrative operations.
     public struct OperatorService: Sendable {
@@ -65,6 +71,34 @@ extension TemporalClient {
                 limit: limit,
                 callOptions: callOptions
             )
+        )
+    }
+
+    /// Returns a single page of workflow executions matching the given query.
+    ///
+    /// This method provides manual pagination control for listing workflow executions.
+    /// Each call returns a page of results along with a ``WorkflowListPage/nextPageToken``
+    /// that can be used to retrieve the next page.
+    ///
+    /// - Parameters:
+    ///   - query: The visibility query to match workflow executions against using Temporal's query syntax.
+    ///   - pageSize: The maximum number of results to return per page.
+    ///   - nextPageToken: The page token from a previous response to continue pagination.
+    ///     Pass empty `Data` (or omit) for the first page.
+    ///   - callOptions: Optional gRPC call options for customizing the behavior of the underlying request.
+    /// - Returns: A ``WorkflowListPage`` containing the executions and a token for the next page.
+    /// - Throws: An error if the query is malformed or the operation fails.
+    public func listWorkflowsPage(
+        query: String,
+        pageSize: Int? = nil,
+        nextPageToken: Data = Data(),
+        callOptions: CallOptions? = nil
+    ) async throws -> WorkflowListPage {
+        try await self.interceptor.workflowService.listWorkflowExecutionsPage(
+            query: query,
+            pageSize: pageSize,
+            nextPageToken: nextPageToken,
+            callOptions: callOptions
         )
     }
 

--- a/Sources/Temporal/Client/TemporalClient+Configuration.swift
+++ b/Sources/Temporal/Client/TemporalClient+Configuration.swift
@@ -58,6 +58,15 @@ extension TemporalClient {
         /// - Important: Ensure that you only configure either an API key or mTLS.
         public var apiKey: String?
 
+        /// The default query rejection condition applied to all query operations.
+        ///
+        /// When set, this condition is used as the default for all workflow query operations that
+        /// don't specify their own rejection condition. This allows you to globally configure query
+        /// behavior without passing the rejection condition to each individual query call.
+        ///
+        /// Individual query calls can override this default by passing a specific ``Api/Enums/V1/QueryRejectCondition``.
+        public var queryRejectCondition: Api.Enums.V1.QueryRejectCondition?
+
         /// The SDK name identifier sent in all RPC calls to identify the client implementation.
         ///
         /// This constant value identifies this SDK implementation to the Temporal server and appears in
@@ -98,13 +107,15 @@ extension TemporalClient {
         ///   - dataConverter: The converter that handles serialization of workflow data. Defaults to the standard JSON converter.
         ///   - interceptors: Request processing interceptors applied in the specified order. Defaults to the tracing interceptor.
         ///   - apiKey: The API key to use for authenticating with a Temporal Cloud instance. Defaults to none.
+        ///   - queryRejectCondition: The default query rejection condition for all query operations. Defaults to none.
         public init(
             instrumentation: Instrumentation,
             namespace: String = "default",
             identity: String? = nil,
             dataConverter: DataConverter = DataConverter.default,
             interceptors: [any ClientInterceptor] = [TemporalClientTracingInterceptor()],
-            apiKey: String? = nil
+            apiKey: String? = nil,
+            queryRejectCondition: Api.Enums.V1.QueryRejectCondition? = nil
         ) {
             self.instrumentation = instrumentation
             self.namespace = namespace
@@ -112,6 +123,7 @@ extension TemporalClient {
             self.dataConverter = dataConverter
             self.interceptors = interceptors
             self.apiKey = apiKey
+            self.queryRejectCondition = queryRejectCondition
         }
 
         /// Creates a Temporal client configuration from external configuration data.

--- a/Sources/Temporal/Client/WorkflowService/Model/Workflows/WorkflowListPage.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Workflows/WorkflowListPage.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
+public import Foundation
+#endif
+
+/// A single page of workflow execution results from a paginated list operation.
+///
+/// Use this type with ``TemporalClient/listWorkflowsPage(query:pageSize:nextPageToken:callOptions:)``
+/// when you need manual control over pagination, such as implementing custom pagination UIs
+/// or processing results page by page.
+public struct WorkflowListPage: Sendable {
+    /// The workflow executions in this page.
+    public let executions: [WorkflowExecution]
+
+    /// The token to retrieve the next page of results.
+    ///
+    /// Pass this value to the next call to
+    /// ``TemporalClient/listWorkflowsPage(query:pageSize:nextPageToken:callOptions:)``
+    /// to retrieve the next page. When empty, there are no more results.
+    public let nextPageToken: Data
+
+    /// Creates a new workflow list page.
+    ///
+    /// - Parameters:
+    ///   - executions: The workflow executions in this page.
+    ///   - nextPageToken: The token to retrieve the next page of results.
+    package init(executions: [WorkflowExecution], nextPageToken: Data) {
+        self.executions = executions
+        self.nextPageToken = nextPageToken
+    }
+}

--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+List.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+List.swift
@@ -16,6 +16,12 @@ import SwiftProtobuf
 
 public import struct GRPCCore.CallOptions
 
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
+public import Foundation
+#endif
+
 extension TemporalClient.WorkflowService {
     /// Returns an async sequence of workflow executions matching the specified query.
     ///
@@ -52,6 +58,51 @@ extension TemporalClient.WorkflowService {
             try WorkflowExecution(executionInfo, dataConverter: self.configuration.dataConverter)
         }
         .prefix(limit ?? .max)
+    }
+
+    /// Returns a single page of workflow executions matching the specified query.
+    ///
+    /// This method provides manual pagination control for listing workflow executions.
+    /// Each call returns a page of results along with a ``WorkflowListPage/nextPageToken``
+    /// that can be used to retrieve the next page.
+    ///
+    /// - Parameters:
+    ///   - query: The visibility query to match workflow executions using Temporal's query syntax.
+    ///   - pageSize: The maximum number of results to return per page.
+    ///   - nextPageToken: The page token from a previous response to continue pagination.
+    ///     Pass empty `Data` (or omit) for the first page.
+    ///   - callOptions: Optional gRPC call options for customizing the behavior of the underlying request.
+    /// - Returns: A ``WorkflowListPage`` containing the executions and a token for the next page.
+    /// - Throws: An error if the operation fails.
+    public func listWorkflowExecutionsPage(
+        query: String,
+        pageSize: Int? = nil,
+        nextPageToken: Data = Data(),
+        callOptions: CallOptions? = nil
+    ) async throws -> WorkflowListPage {
+        var request = Api.Workflowservice.V1.ListWorkflowExecutionsRequest.with {
+            $0.namespace = configuration.namespace
+            $0.query = query
+            $0.nextPageToken = nextPageToken
+        }
+        if let pageSize {
+            request.pageSize = Int32(pageSize)
+        }
+
+        let response: Api.Workflowservice.V1.ListWorkflowExecutionsResponse = try await self.client.unary(
+            method: Api.Workflowservice.V1.WorkflowService.Method.ListWorkflowExecutions.descriptor,
+            request: request,
+            callOptions: callOptions
+        )
+
+        let executions = try response.executions.map { executionInfo in
+            try WorkflowExecution(executionInfo, dataConverter: self.configuration.dataConverter)
+        }
+
+        return WorkflowListPage(
+            executions: executions,
+            nextPageToken: response.nextPageToken
+        )
     }
 
     /// Counts the number of workflow executions matching the specified query.

--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+Query.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+Query.swift
@@ -67,6 +67,8 @@ extension TemporalClient.WorkflowService {
             }
             if let rejectionCondition {
                 $0.queryRejectCondition = rejectionCondition
+            } else if let defaultCondition = self.configuration.queryRejectCondition {
+                $0.queryRejectCondition = defaultCondition
             }
         }
 

--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+Result.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+Result.swift
@@ -118,6 +118,57 @@ extension TemporalClient.WorkflowService {
         return events
     }
 
+    /// Returns a lazy async sequence of workflow execution history events with internal pagination.
+    ///
+    /// Unlike ``fetchWorkflowHistoryEvents(id:runID:waitNewEvent:eventFilterType:skipArchival:callOptions:)``
+    /// which eagerly fetches all events into an array, this method returns an `AsyncSequence` that
+    /// lazily streams events page by page. This is more memory-efficient for workflows with large
+    /// histories.
+    ///
+    /// - Parameters:
+    ///   - id: The unique identifier of the workflow whose history to retrieve.
+    ///   - runID: The specific run ID to get history for. If nil, retrieves history for the latest run.
+    ///   - waitNewEvent: Whether to use long-polling to wait for new events.
+    ///   - eventFilterType: The type of events to filter during retrieval.
+    ///   - skipArchival: Whether to skip archived history events for faster retrieval.
+    ///   - callOptions: Custom call options including timeout settings for the RPC operation.
+    /// - Returns: An `AsyncSequence` of ``Api/History/V1/HistoryEvent`` objects in chronological order.
+    public func fetchWorkflowHistoryEventStream(
+        id: String,
+        runID: String? = nil,
+        waitNewEvent: Bool? = nil,
+        eventFilterType: Api.Enums.V1.HistoryEventFilterType? = nil,
+        skipArchival: Bool? = nil,
+        callOptions: CallOptions? = nil
+    ) -> some AsyncSequence<Api.History.V1.HistoryEvent, any Error> & Sendable {
+        withFlattenedPagination { pageToken in
+            let response: Api.Workflowservice.V1.GetWorkflowExecutionHistoryResponse = try await self.client.unary(
+                method: Api.Workflowservice.V1.WorkflowService.Method.GetWorkflowExecutionHistory.descriptor,
+                request: Api.Workflowservice.V1.GetWorkflowExecutionHistoryRequest.with {
+                    $0.namespace = self.configuration.namespace
+                    $0.execution = .with {
+                        $0.workflowID = id
+                        if let runID {
+                            $0.runID = runID
+                        }
+                    }
+                    if let waitNewEvent {
+                        $0.waitNewEvent = waitNewEvent
+                    }
+                    if let eventFilterType {
+                        $0.historyEventFilterType = eventFilterType
+                    }
+                    if let skipArchival {
+                        $0.skipArchival = skipArchival
+                    }
+                    $0.nextPageToken = pageToken
+                },
+                callOptions: callOptions ?? .userPollRetryOptions
+            )
+            return (elements: response.history.events, pageToken: response.nextPageToken)
+        }
+    }
+
     // Fetch workflow result helper that abstracts the RPC call (RPC either intercepted or not)
     func result<Output: Sendable>(
         historyRunID: String? = nil,

--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+Update.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+Update.swift
@@ -114,6 +114,15 @@ extension TemporalClient.WorkflowService {
         )
     }
 
+    /// The result of starting a workflow update, containing the update ID and any known outcome.
+    package struct StartUpdateResult: Sendable {
+        /// The unique identifier for this update operation.
+        package let updateID: String
+
+        /// The outcome payloads if the update completed during the start call.
+        package let outcomePayloads: [Api.Common.V1.Payload]?
+    }
+
     // MARK: - Start Workflow Update
 
     /// Initiates a workflow update by name without waiting for completion.
@@ -146,6 +155,37 @@ extension TemporalClient.WorkflowService {
         input: repeat each Input,
         callOptions: CallOptions? = nil
     ) async throws -> String {
+        let result = try await self.startWorkflowUpdateWithOutcome(
+            workflowID: workflowID,
+            runID: runID,
+            firstExecutionRunID: firstExecutionRunID,
+            updateID: updateID,
+            updateName: updateName,
+            waitForStage: waitForStage,
+            headers: headers,
+            input: repeat each input,
+            callOptions: callOptions
+        )
+        return result.updateID
+    }
+
+    /// Initiates a workflow update by name and returns the update ID along with any known outcome.
+    ///
+    /// This is an internal variant that also captures the outcome payloads from the response
+    /// when the update completes during the start call (e.g., when ``waitForStage`` is
+    /// ``WorkflowUpdateStage/completed``). The captured outcome can be used to avoid
+    /// redundant RPCs when retrieving the update result.
+    package func startWorkflowUpdateWithOutcome<each Input: Sendable>(
+        workflowID: String,
+        runID: String? = nil,
+        firstExecutionRunID: String? = nil,
+        updateID: String = UUID().uuidString,
+        updateName: String,
+        waitForStage: WorkflowUpdateStage,
+        headers: [String: Api.Common.V1.Payload] = [:],
+        input: repeat each Input,
+        callOptions: CallOptions? = nil
+    ) async throws -> StartUpdateResult {
         let dataConverter = configuration.dataConverter
         let inputPayloads = try await dataConverter.convertValues(repeat each input)
 
@@ -188,7 +228,12 @@ extension TemporalClient.WorkflowService {
             }
         } while response.stage.rawValue < Api.Enums.V1.UpdateWorkflowExecutionLifecycleStage(waitForStage).rawValue
 
-        return updateID
+        var outcomePayloads: [Api.Common.V1.Payload]?
+        if response.hasOutcome, case .success(let success) = response.outcome.value {
+            outcomePayloads = success.payloads
+        }
+
+        return StartUpdateResult(updateID: updateID, outcomePayloads: outcomePayloads)
     }
 
     /// Initiates a strongly-typed workflow update without waiting for completion.


### PR DESCRIPTION
- Add getUpdateHandle(id:) to UntypedWorkflowHandle and WorkflowHandle for retrieving handles to previously started updates
- Add update result caching via knownOutcome on UntypedWorkflowUpdateHandle to avoid redundant RPCs when the outcome is already known
- Add fetchHistoryEventStream() returning a lazy AsyncSequence with internal pagination
- Add listWorkflowsPage() for manual page-based workflow listing with nextPageToken support
- Add queryRejectCondition to TemporalClient.Configuration as a default for all query operations