### PR TITLE
Enable Swift 6.3 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable"
+      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,6 +23,7 @@ jobs:
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable"
+      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable"
 


### PR DESCRIPTION
Motivation:

Swift 6.3 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.3 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
