### PR TITLE
Add priority, summary, and other fields to workflow operation options

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,6 +34,8 @@ jobs:
       build_scheme: swift-temporal-sdk-Package
       xcode_16_3_enabled: false
       xcode_16_4_enabled: false
+      xcode_26_0_enabled: false
+      xcode_26_1_enabled: false
       watchos_xcode_build_enabled: false
       tvos_xcode_build_enabled: false
       visionos_xcode_build_enabled: false

--- a/Sources/Temporal/Client/WorkflowService/Model/Workflows/Priority.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Workflows/Priority.swift
@@ -28,7 +28,7 @@
 /// 1. First, consider ``priorityKey``: lower numbers go first (higher priority).
 /// 2. Then, consider fairness: the fairness mechanism attempts to dispatch tasks for a given
 ///    ``fairnessKey`` in proportion to its ``fairnessWeight``.
-public struct Priority: Sendable {
+public struct Priority: Hashable, Sendable {
     /// The priority key, which is a positive integer from 1 to *n*, where smaller integers
     /// correspond to higher priorities (tasks run sooner).
     ///

--- a/Sources/Temporal/Extensions/ChildWorkflowOptions+Proto.swift
+++ b/Sources/Temporal/Extensions/ChildWorkflowOptions+Proto.swift
@@ -72,5 +72,9 @@ extension Coresdk.WorkflowCommands.StartChildWorkflowExecution {
         if let cronSchedule = childWorkflowOptions.cronSchedule {
             self.cronSchedule = cronSchedule
         }
+
+        if let priority = childWorkflowOptions.priority {
+            self.priority = .init(priority)
+        }
     }
 }

--- a/Sources/Temporal/Extensions/ScheduleActivity+Proto.swift
+++ b/Sources/Temporal/Extensions/ScheduleActivity+Proto.swift
@@ -51,5 +51,8 @@ extension Coresdk.WorkflowCommands.ScheduleActivity {
         if !headers.isEmpty {
             self.headers = headers
         }
+        if let priority = options.priority {
+            self.priority = .init(priority)
+        }
     }
 }

--- a/Sources/Temporal/Extensions/ScheduleLocalActivity.swift
+++ b/Sources/Temporal/Extensions/ScheduleLocalActivity.swift
@@ -54,5 +54,8 @@ extension Coresdk.WorkflowCommands.ScheduleLocalActivity {
         if let originalScheduleTime {
             self.originalScheduleTime = originalScheduleTime
         }
+        if let localRetryThreshold = options.localRetryThreshold {
+            self.localRetryThreshold = .init(duration: localRetryThreshold)
+        }
     }
 }

--- a/Sources/Temporal/Worker/Workflow/ActivityExecutionOptions.swift
+++ b/Sources/Temporal/Worker/Workflow/ActivityExecutionOptions.swift
@@ -25,6 +25,13 @@ enum ActivityExecutionOptions {
         }
     }
 
+    var summary: String? {
+        switch self {
+        case let .remote(options): options.summary
+        case let .local(options, _, _): options.summary
+        }
+    }
+
     func withBackoff(_ backoff: Coresdk.ActivityResult.DoBackoff) -> Self {
         switch self {
         case .remote:

--- a/Sources/Temporal/Worker/Workflow/ActivityOptions.swift
+++ b/Sources/Temporal/Worker/Workflow/ActivityOptions.swift
@@ -149,6 +149,21 @@ public struct ActivityOptions: Hashable, Sendable {
     /// The default value is ``VersioningIntent/unspecified``.
     public var versioningIntent: VersioningIntent = .unspecified
 
+    /// The priority to use for this activity.
+    ///
+    /// Activities inherit priority from the workflow that created them, but may override
+    /// individual fields when they are started. A value of `nil` means inherit the priority
+    /// from the calling workflow.
+    public var priority: Priority?
+
+    /// Short-form text that provides a summary for this activity.
+    ///
+    /// This value is displayed in user interfaces and can be used to provide additional
+    /// context about the activity's purpose.
+    ///
+    /// - Important: This is currently experimental.
+    public var summary: String?
+
     /// Creates activity options with a schedule-to-close timeout as the primary constraint.
     ///
     /// This initializer is suitable when you want to control the total time allowed for activity
@@ -164,6 +179,8 @@ public struct ActivityOptions: Hashable, Sendable {
     ///   - taskQueue: The task queue for execution. If `nil`, uses the workflow's task queue.
     ///   - retryPolicy: The retry policy. If `nil`, retries indefinitely with exponential backoff.
     ///   - versioningIntent: Whether to require compatible worker build IDs.
+    ///   - priority: The priority for this activity. If `nil`, inherits from the calling workflow.
+    ///   - summary: Short-form summary text for the activity. If `nil`, no summary is set.
     public init(
         scheduleToCloseTimeout: Duration,
         startToCloseTimeout: Duration? = nil,
@@ -172,7 +189,9 @@ public struct ActivityOptions: Hashable, Sendable {
         heartbeatTimeout: Duration? = nil,
         taskQueue: String? = nil,
         retryPolicy: RetryPolicy? = nil,
-        versioningIntent: VersioningIntent = .unspecified
+        versioningIntent: VersioningIntent = .unspecified,
+        priority: Priority? = nil,
+        summary: String? = nil
     ) {
         self.scheduleToCloseTimeout = scheduleToCloseTimeout
         self.startToCloseTimeout = startToCloseTimeout
@@ -182,6 +201,8 @@ public struct ActivityOptions: Hashable, Sendable {
         self.taskQueue = taskQueue
         self.retryPolicy = retryPolicy
         self.versioningIntent = versioningIntent
+        self.priority = priority
+        self.summary = summary
     }
 
     /// Creates activity options with a start-to-close timeout as the primary constraint.
@@ -199,6 +220,8 @@ public struct ActivityOptions: Hashable, Sendable {
     ///   - taskQueue: The task queue for execution. If `nil`, uses the workflow's task queue.
     ///   - retryPolicy: The retry policy. If `nil`, retries indefinitely with exponential backoff.
     ///   - versioningIntent: Whether to require compatible worker build IDs.
+    ///   - priority: The priority for this activity. If `nil`, inherits from the calling workflow.
+    ///   - summary: Short-form summary text for the activity. If `nil`, no summary is set.
     public init(
         startToCloseTimeout: Duration,
         scheduleToCloseTimeout: Duration? = nil,
@@ -207,7 +230,9 @@ public struct ActivityOptions: Hashable, Sendable {
         heartbeatTimeout: Duration? = nil,
         taskQueue: String? = nil,
         retryPolicy: RetryPolicy? = nil,
-        versioningIntent: VersioningIntent = .unspecified
+        versioningIntent: VersioningIntent = .unspecified,
+        priority: Priority? = nil,
+        summary: String? = nil
     ) {
         self.scheduleToCloseTimeout = scheduleToCloseTimeout
         self.startToCloseTimeout = startToCloseTimeout
@@ -217,5 +242,7 @@ public struct ActivityOptions: Hashable, Sendable {
         self.taskQueue = taskQueue
         self.retryPolicy = retryPolicy
         self.versioningIntent = versioningIntent
+        self.priority = priority
+        self.summary = summary
     }
 }

--- a/Sources/Temporal/Worker/Workflow/ChildWorkflowOptions.swift
+++ b/Sources/Temporal/Worker/Workflow/ChildWorkflowOptions.swift
@@ -140,6 +140,29 @@ public struct ChildWorkflowOptions: Sendable {
     /// The default value is ``VersioningIntent/unspecified``.
     public var versioningIntent: VersioningIntent = .unspecified
 
+    /// The priority to use for this child workflow.
+    ///
+    /// Child workflows inherit priority from the parent workflow that created them, but may
+    /// override individual fields when they are started. A value of `nil` means inherit the
+    /// priority from the parent workflow.
+    public var priority: Priority?
+
+    /// Short-form text that provides a summary for this child workflow.
+    ///
+    /// This value is stored with the workflow execution and displayed in user interfaces.
+    /// It can be used to provide additional context about the child workflow's purpose.
+    ///
+    /// - Important: This is currently experimental.
+    public var staticSummary: String?
+
+    /// Detailed text providing extended information about this child workflow.
+    ///
+    /// This value is stored with the workflow execution and can be used to provide
+    /// comprehensive details about the child workflow's purpose and context.
+    ///
+    /// - Important: This is currently experimental.
+    public var staticDetails: String?
+
     /// Creates child workflow options with the specified configuration parameters.
     ///
     /// All parameters are optional, allowing you to configure only the aspects relevant to your
@@ -159,6 +182,9 @@ public struct ChildWorkflowOptions: Sendable {
     ///   - cronSchedule: Cron schedule expression for recurring execution.
     ///   - cancellationType: How the parent handles child workflow cancellation.
     ///   - versioningIntent: Whether to require compatible worker build IDs.
+    ///   - priority: The priority for this child workflow. If `nil`, inherits from the parent workflow.
+    ///   - staticSummary: Short-form summary text for the child workflow. If `nil`, no summary is set.
+    ///   - staticDetails: Detailed text for the child workflow. If `nil`, no details are set.
     public init(
         id: String? = nil,
         taskQueue: String? = nil,
@@ -172,7 +198,10 @@ public struct ChildWorkflowOptions: Sendable {
         idReusePolicy: Api.Enums.V1.WorkflowIdReusePolicy = .allowDuplicate,
         cronSchedule: String? = nil,
         cancellationType: ChildWorkflowCancellationType = .waitCancellationCompleted,
-        versioningIntent: VersioningIntent = .unspecified
+        versioningIntent: VersioningIntent = .unspecified,
+        priority: Priority? = nil,
+        staticSummary: String? = nil,
+        staticDetails: String? = nil
     ) {
         self.id = id
         self.taskQueue = taskQueue
@@ -187,5 +216,8 @@ public struct ChildWorkflowOptions: Sendable {
         self.cronSchedule = cronSchedule
         self.cancellationType = cancellationType
         self.versioningIntent = versioningIntent
+        self.priority = priority
+        self.staticSummary = staticSummary
+        self.staticDetails = staticDetails
     }
 }

--- a/Sources/Temporal/Worker/Workflow/LocalActivityOptions.swift
+++ b/Sources/Temporal/Worker/Workflow/LocalActivityOptions.swift
@@ -101,6 +101,31 @@ public struct LocalActivityOptions: Sendable {
     /// or the ``scheduleToCloseTimeout`` timeout is exceeded.
     public var retryPolicy: RetryPolicy?
 
+    /// The local retry threshold duration.
+    ///
+    /// If the backoff for a retry would exceed this value, a timer is scheduled and the activity
+    /// will be retried after the timer fires. Otherwise, the backoff will happen internally within
+    /// the core SDK. Defaults to 1 minute if unset.
+    ///
+    /// This is useful for controlling whether long retry backoffs are handled locally or via
+    /// the timer mechanism.
+    public var localRetryThreshold: Duration?
+
+    /// The priority to use for this local activity.
+    ///
+    /// Activities inherit priority from the workflow that created them, but may override
+    /// individual fields when they are started. A value of `nil` means inherit the priority
+    /// from the calling workflow.
+    public var priority: Priority?
+
+    /// Short-form text that provides a summary for this local activity.
+    ///
+    /// This value is displayed in user interfaces and can be used to provide additional
+    /// context about the activity's purpose.
+    ///
+    /// - Important: This is currently experimental.
+    public var summary: String?
+
     /// Creates activity options with a schedule-to-close timeout as the primary constraint.
     ///
     /// This initializer is suitable when you want to control the total time allowed for activity
@@ -112,16 +137,25 @@ public struct LocalActivityOptions: Sendable {
     ///     uses the schedule-to-close timeout for individual attempts.
     ///   - cancellationType: How the workflow handles activity cancellation confirmation.
     ///   - retryPolicy: The retry policy. If `nil`, retries indefinitely with exponential backoff.
+    ///   - localRetryThreshold: The threshold for local vs timer-based retry backoff.
+    ///   - priority: The priority for this local activity. If `nil`, inherits from the calling workflow.
+    ///   - summary: Short-form summary text for the local activity. If `nil`, no summary is set.
     public init(
         scheduleToCloseTimeout: Duration,
         startToCloseTimeout: Duration? = nil,
         cancellationType: ActivityOptions.CancellationType = .tryCancel,
-        retryPolicy: RetryPolicy? = nil
+        retryPolicy: RetryPolicy? = nil,
+        localRetryThreshold: Duration? = nil,
+        priority: Priority? = nil,
+        summary: String? = nil
     ) {
         self.scheduleToCloseTimeout = scheduleToCloseTimeout
         self.startToCloseTimeout = startToCloseTimeout
         self.cancellationType = cancellationType
         self.retryPolicy = retryPolicy
+        self.localRetryThreshold = localRetryThreshold
+        self.priority = priority
+        self.summary = summary
     }
 
     /// Creates activity options with a start-to-close timeout as the primary constraint.
@@ -135,15 +169,24 @@ public struct LocalActivityOptions: Sendable {
     ///     If `nil`, activities may retry indefinitely within workflow execution limits.
     ///   - cancellationType: How the workflow handles activity cancellation confirmation.
     ///   - retryPolicy: The retry policy. If `nil`, retries indefinitely with exponential backoff.
+    ///   - localRetryThreshold: The threshold for local vs timer-based retry backoff.
+    ///   - priority: The priority for this local activity. If `nil`, inherits from the calling workflow.
+    ///   - summary: Short-form summary text for the local activity. If `nil`, no summary is set.
     public init(
         startToCloseTimeout: Duration,
         scheduleToCloseTimeout: Duration? = nil,
         cancellationType: ActivityOptions.CancellationType = .tryCancel,
-        retryPolicy: RetryPolicy? = nil
+        retryPolicy: RetryPolicy? = nil,
+        localRetryThreshold: Duration? = nil,
+        priority: Priority? = nil,
+        summary: String? = nil
     ) {
         self.scheduleToCloseTimeout = scheduleToCloseTimeout
         self.startToCloseTimeout = startToCloseTimeout
         self.cancellationType = cancellationType
         self.retryPolicy = retryPolicy
+        self.localRetryThreshold = localRetryThreshold
+        self.priority = priority
+        self.summary = summary
     }
 }

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachine.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachine.swift
@@ -520,6 +520,7 @@ struct WorkflowStateMachine: ~Copyable {
         workflowTaskQueue: String,
         headers: [String: Api.Common.V1.Payload],
         input: [Api.Common.V1.Payload],
+        summary: Api.Common.V1.Payload?,
         continuation: CheckedContinuation<Coresdk.ActivityResult.ActivityResolution, any Error>
     ) {
         switch consume self.state {
@@ -547,6 +548,10 @@ struct WorkflowStateMachine: ~Copyable {
                             attempt: attempt,
                             originalScheduleTime: originalScheduleTime
                         )
+                    }
+
+                    if let summary {
+                        $0.userMetadata.summary = summary
                     }
                 }
             )
@@ -701,6 +706,8 @@ struct WorkflowStateMachine: ~Copyable {
         inputs: [Api.Common.V1.Payload],
         childWorkflowOptions: ChildWorkflowOptions,
         memo: [String: Api.Common.V1.Payload]?,
+        staticSummary: Api.Common.V1.Payload?,
+        staticDetails: Api.Common.V1.Payload?,
         state: UntypedChildWorkflowHandle.State,
         continuation: CheckedContinuation<(String, String), any Error>
     ) {
@@ -722,6 +729,16 @@ struct WorkflowStateMachine: ~Copyable {
                         headers: headers,
                         inputs: inputs
                     )
+
+                    if staticSummary != nil || staticDetails != nil {
+                        $0.userMetadata = .init()
+                        if let staticSummary {
+                            $0.userMetadata.summary = staticSummary
+                        }
+                        if let staticDetails {
+                            $0.userMetadata.details = staticDetails
+                        }
+                    }
                 }
             )
             active.childWorkflowStartContinuations[sequenceNumber] = (workflowID, continuation)

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
@@ -186,6 +186,8 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
             throw CanceledError(message: "Activity cancelled before scheduled")
         }
 
+        let convertedSummary = try options.summary.flatMap { try self.payloadConverter.convertValue($0) }
+
         var options = options
         let isLocal = options.isLocal
         while true {
@@ -199,6 +201,7 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
                         workflowTaskQueue: workflowTaskQueue,
                         headers: headers,
                         input: input,
+                        summary: convertedSummary,
                         continuation: continuation
                     )
                 }
@@ -300,6 +303,13 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
             childWorkflowMemo = nil
         }
 
+        let convertedStaticSummary = try childWorkflowOptions.staticSummary.flatMap {
+            try self.payloadConverter.convertValue($0)
+        }
+        let convertedStaticDetails = try childWorkflowOptions.staticDetails.flatMap {
+            try self.payloadConverter.convertValue($0)
+        }
+
         let sequenceNumber = self.stateMachine.nextChildWorkflowSequenceNumber()
         let state = UntypedChildWorkflowHandle.State(resolutionState: .unresolved(sequenceNumber: sequenceNumber))
         let (workflowID, firstExecutionRunID) = try await withTaskCancellationHandler {
@@ -313,6 +323,8 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
                     inputs: inputs,
                     childWorkflowOptions: childWorkflowOptions,
                     memo: childWorkflowMemo,
+                    staticSummary: convertedStaticSummary,
+                    staticDetails: convertedStaticDetails,
                     state: state,
                     continuation: continuation
                 )


### PR DESCRIPTION
Add priority and summary fields to `ActivityOptions`, `LocalActivityOptions`, and `ChildWorkflowOptions`. Wire priority through to proto conversions for `ScheduleActivity`, `ScheduleLocalActivity` (localRetryThreshold), and `StartChildWorkflowExecution`.