### PR TITLE
Support update validators in `@WorkflowUpdate` macro

### DIFF
--- a/Sources/Temporal/API/ProtoConversions/Workflows/UpdateOutcome+Payloads.swift
+++ b/Sources/Temporal/API/ProtoConversions/Workflows/UpdateOutcome+Payloads.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+extension Api.Update.V1.Outcome {
+    /// Extracts the success payloads from this update outcome, or throws on failure.
+    ///
+    /// - Parameter dataConverter: The data converter to use for failure conversion.
+    /// - Returns: The raw success payloads.
+    /// - Throws: ``WorkflowUpdateFailedError`` if the outcome is a failure or has no value.
+    package func successPayloads(
+        using dataConverter: DataConverter
+    ) async throws -> [Api.Common.V1.Payload] {
+        switch self.value {
+        case .success(let success):
+            return success.payloads
+        case .failure(let failure):
+            let error = await dataConverter.convertFailure(failure)
+            throw WorkflowUpdateFailedError(cause: error)
+        case .none:
+            throw WorkflowUpdateFailedError(
+                cause: BasicTemporalFailureError(message: "Update outcome has no value", stackTrace: "")
+            )
+        }
+    }
+}

--- a/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowHandle+Operations.swift
+++ b/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowHandle+Operations.swift
@@ -436,6 +436,19 @@ extension TemporalClient.Interceptor {
         }
     }
 
+    func pollWorkflowUpdate(
+        _ input: PollWorkflowUpdateInput
+    ) async throws -> Api.Update.V1.Outcome {
+        try await self.intercept((any ClientOutboundInterceptor).pollWorkflowUpdate, input: input) { input in
+            try await self.workflowService.pollWorkflowUpdateOutcome(
+                workflowID: input.workflowID,
+                runID: input.runID,
+                updateID: input.updateID,
+                callOptions: input.callOptions
+            )
+        }
+    }
+
     func describeWorkflow(
         _ input: DescribeWorkflowInput
     ) async throws -> WorkflowExecutionDescription {

--- a/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowUpdateHandle+Operations.swift
+++ b/Sources/Temporal/Client/Handles/Workflow/UntypedWorkflowUpdateHandle+Operations.swift
@@ -46,12 +46,16 @@ extension UntypedWorkflowUpdateHandle {
                 as: repeat each resultTypes
             )
         }
-        return try await self.interceptor.workflowService.workflowUpdateResult(
-            workflowID: self.workflowID,
-            runID: self.workflowRunID,
-            updateID: self.id,
-            resultTypes: repeat each resultTypes,
-            callOptions: callOptions
+        let outcome = try await self.interceptor.pollWorkflowUpdate(
+            .init(
+                workflowID: self.workflowID,
+                runID: self.workflowRunID,
+                updateID: self.id,
+                callOptions: callOptions
+            )
         )
+        let dataConverter = self.interceptor.workflowService.configuration.dataConverter
+        let payloads = try await outcome.successPayloads(using: dataConverter)
+        return try await dataConverter.convertPayloads(payloads, as: repeat each resultTypes)
     }
 }

--- a/Sources/Temporal/Client/InterceptedService/InterceptedService+Workflows.swift
+++ b/Sources/Temporal/Client/InterceptedService/InterceptedService+Workflows.swift
@@ -492,13 +492,17 @@ extension TemporalClient.InterceptedService {
         resultTypes: repeat (each Result).Type,
         callOptions: CallOptions? = nil
     ) async throws -> (repeat each Result) {
-        try await self.interceptor.workflowService.workflowUpdateResult(  // Other SDKs also don't go through interceptor
-            workflowID: id,
-            runID: runID,
-            updateID: updateID,
-            resultTypes: repeat each resultTypes,
-            callOptions: callOptions
+        let outcome = try await self.interceptor.pollWorkflowUpdate(
+            .init(
+                workflowID: id,
+                runID: runID,
+                updateID: updateID,
+                callOptions: callOptions
+            )
         )
+        let dataConverter = self.interceptor.workflowService.configuration.dataConverter
+        let payloads = try await outcome.successPayloads(using: dataConverter)
+        return try await dataConverter.convertPayloads(payloads, as: repeat each resultTypes)
     }
 
     // MARK: Cancel

--- a/Sources/Temporal/Client/Interceptors/ClientOutboundInterceptor.swift
+++ b/Sources/Temporal/Client/Interceptors/ClientOutboundInterceptor.swift
@@ -88,6 +88,21 @@ public protocol ClientOutboundInterceptor: Sendable {
         next: (StartWorkflowUpdateInput<repeat each Input>) async throws -> UntypedWorkflowUpdateHandle
     ) async throws -> UntypedWorkflowUpdateHandle
 
+    /// Intercepts workflow update poll operations.
+    ///
+    /// This method is called when polling for the result of a previously started workflow update.
+    /// It enables interceptors to instrument long-running update polling.
+    ///
+    /// - Parameters:
+    ///   - input: The input passed to poll a workflow update result.
+    ///   - next: A closure that forwards the operation to the next interceptor.
+    /// - Returns: The update outcome from the poll response.
+    /// - Throws: Any error encountered during poll processing or forwarding.
+    func pollWorkflowUpdate(
+        input: PollWorkflowUpdateInput,
+        next: (PollWorkflowUpdateInput) async throws -> Api.Update.V1.Outcome
+    ) async throws -> Api.Update.V1.Outcome
+
     /// Intercepts workflow describe operations.
     ///
     /// - Parameters:
@@ -145,6 +160,22 @@ public protocol ClientOutboundInterceptor: Sendable {
         input: ListWorkflowsInput,
         next: (ListWorkflowsInput) async throws -> Sequence
     ) async throws -> Sequence
+
+    /// Intercepts paginated workflow list operations.
+    ///
+    /// This method is called for each page fetch, both when using
+    /// ``TemporalClient/listWorkflowsPage(query:pageSize:nextPageToken:callOptions:)`` directly
+    /// and internally when iterating the sequence returned by ``TemporalClient/listWorkflows(query:limit:callOptions:)``.
+    ///
+    /// - Parameters:
+    ///   - input: The input passed to fetch a single page of workflow executions.
+    ///   - next: A closure that forwards the operation to the next interceptor.
+    /// - Returns: A single page of workflow executions.
+    /// - Throws: Any error encountered during query processing or forwarding.
+    func listWorkflowsPage(
+        input: ListWorkflowsPageInput,
+        next: (ListWorkflowsPageInput) async throws -> WorkflowListPage
+    ) async throws -> WorkflowListPage
 
     /// Intercepts workflow count operations.
     ///
@@ -365,6 +396,13 @@ extension ClientOutboundInterceptor {
         try await next(input)
     }
 
+    public func pollWorkflowUpdate(
+        input: PollWorkflowUpdateInput,
+        next: (PollWorkflowUpdateInput) async throws -> Api.Update.V1.Outcome
+    ) async throws -> Api.Update.V1.Outcome {
+        try await next(input)
+    }
+
     public func describeWorkflow(
         input: DescribeWorkflowInput,
         next: (DescribeWorkflowInput) async throws -> (WorkflowExecutionDescription)
@@ -397,6 +435,13 @@ extension ClientOutboundInterceptor {
         input: ListWorkflowsInput,
         next: (ListWorkflowsInput) async throws -> Sequence
     ) async throws -> Sequence {
+        try await next(input)
+    }
+
+    public func listWorkflowsPage(
+        input: ListWorkflowsPageInput,
+        next: (ListWorkflowsPageInput) async throws -> WorkflowListPage
+    ) async throws -> WorkflowListPage {
         try await next(input)
     }
 

--- a/Sources/Temporal/Client/Interceptors/Inputs/Workflows/ListWorkflowsPageInput.swift
+++ b/Sources/Temporal/Client/Interceptors/Inputs/Workflows/ListWorkflowsPageInput.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+public import struct GRPCCore.CallOptions
+
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
+public import Foundation
+#endif
+
+/// Input parameters for fetching a single page of workflow executions in client interceptors.
+public struct ListWorkflowsPageInput: Sendable {
+    /// The query string to filter workflow executions using Temporal's visibility query language.
+    public var query: String
+
+    /// Optional maximum number of workflow executions to return per page.
+    public var pageSize: Int?
+
+    /// The token to retrieve the next page of results.
+    ///
+    /// Pass empty `Data` for the first page.
+    public var nextPageToken: Data
+
+    /// Optional gRPC call options for customizing the listing request.
+    public var callOptions: CallOptions?
+
+    /// Creates a new list workflows page input with the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - query: The query string to filter workflow executions using the visibility query language.
+    ///   - pageSize: Optional maximum number of workflow executions to return per page.
+    ///   - nextPageToken: The token to retrieve the next page of results. Pass empty `Data` for the first page.
+    ///   - callOptions: Optional gRPC call options for customizing the request.
+    public init(
+        query: String,
+        pageSize: Int? = nil,
+        nextPageToken: Data = Data(),
+        callOptions: CallOptions? = nil
+    ) {
+        self.query = query
+        self.pageSize = pageSize
+        self.nextPageToken = nextPageToken
+        self.callOptions = callOptions
+    }
+}

--- a/Sources/Temporal/Client/Interceptors/Inputs/Workflows/PollWorkflowUpdateInput.swift
+++ b/Sources/Temporal/Client/Interceptors/Inputs/Workflows/PollWorkflowUpdateInput.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+public import struct GRPCCore.CallOptions
+
+/// Input parameters for polling a workflow update result in client interceptors.
+public struct PollWorkflowUpdateInput: Sendable {
+    /// The unique identifier of the workflow whose update to poll.
+    public var workflowID: String
+
+    /// The specific run ID of the workflow execution whose update to poll.
+    public var runID: String?
+
+    /// The unique identifier of the update to poll for results.
+    public var updateID: String
+
+    /// Optional gRPC call options for customizing the poll request.
+    public var callOptions: CallOptions?
+
+    /// Creates a new poll workflow update input with the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - workflowID: The unique identifier of the workflow whose update to poll.
+    ///   - runID: The specific run ID of the workflow execution whose update to poll.
+    ///   - updateID: The unique identifier of the update to poll for results.
+    ///   - callOptions: Optional gRPC call options for customizing the request.
+    public init(
+        workflowID: String,
+        runID: String? = nil,
+        updateID: String,
+        callOptions: CallOptions? = nil
+    ) {
+        self.workflowID = workflowID
+        self.runID = runID
+        self.updateID = updateID
+        self.callOptions = callOptions
+    }
+}

--- a/Sources/Temporal/Client/OperatorService/TemporalClient+OperatorService.swift
+++ b/Sources/Temporal/Client/OperatorService/TemporalClient+OperatorService.swift
@@ -94,11 +94,13 @@ extension TemporalClient {
         nextPageToken: Data = Data(),
         callOptions: CallOptions? = nil
     ) async throws -> WorkflowListPage {
-        try await self.interceptor.workflowService.listWorkflowExecutionsPage(
-            query: query,
-            pageSize: pageSize,
-            nextPageToken: nextPageToken,
-            callOptions: callOptions
+        try await self.interceptor.listWorkflowsPage(
+            .init(
+                query: query,
+                pageSize: pageSize,
+                nextPageToken: nextPageToken,
+                callOptions: callOptions
+            )
         )
     }
 
@@ -202,6 +204,19 @@ extension TemporalClient.Interceptor {
             try await self.workflowService.listWorkflowExecutions(
                 query: input.query,
                 limit: input.limit,
+                callOptions: input.callOptions
+            )
+        }
+    }
+
+    package func listWorkflowsPage(
+        _ input: ListWorkflowsPageInput
+    ) async throws -> WorkflowListPage {
+        try await self.intercept((any ClientOutboundInterceptor).listWorkflowsPage, input: input) { input in
+            try await self.workflowService.listWorkflowExecutionsPage(
+                query: input.query,
+                pageSize: input.pageSize,
+                nextPageToken: input.nextPageToken,
                 callOptions: input.callOptions
             )
         }

--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+Update.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+Update.swift
@@ -281,6 +281,61 @@ extension TemporalClient.WorkflowService {
 
     // MARK: - Workflow Update Result
 
+    /// Polls for the outcome of a previously started workflow update using long polling.
+    ///
+    /// This method waits for a workflow update to complete and returns its raw outcome.
+    /// It uses long polling to efficiently wait until the update finishes processing,
+    /// automatically handling retries and connection timeouts.
+    ///
+    /// - Parameters:
+    ///   - workflowID: The unique identifier of the target workflow.
+    ///   - runID: The specific run ID that was updated. If nil, uses the latest run.
+    ///   - updateID: The unique identifier of the update to retrieve results for.
+    ///   - callOptions: Optional gRPC call options for customizing the behavior of the underlying request.
+    /// - Returns: The raw update outcome from the poll response.
+    /// - Throws: ``WorkflowUpdateRPCTimeoutOrCanceledError`` if the poll times out or is cancelled,
+    ///   or an error for other retrieval failures.
+    package func pollWorkflowUpdateOutcome(
+        workflowID: String,
+        runID: String? = nil,
+        updateID: String,
+        callOptions: CallOptions? = nil
+    ) async throws -> Api.Update.V1.Outcome {
+        // This setups a long poll since we need to wait until the
+        // update completed. We don't have to sleep between each request
+        // since the request will wait until the various timeouts trigger.
+        while true {
+            do {
+                let response: Api.Workflowservice.V1.PollWorkflowExecutionUpdateResponse = try await self.client.unary(
+                    method: Api.Workflowservice.V1.WorkflowService.Method.PollWorkflowExecutionUpdate.descriptor,
+                    request: Api.Workflowservice.V1.PollWorkflowExecutionUpdateRequest.with {
+                        $0.namespace = self.configuration.namespace
+                        $0.updateRef.workflowExecution.workflowID = workflowID
+                        if let runID {
+                            $0.updateRef.workflowExecution.runID = runID
+                        }
+                        $0.updateRef.updateID = updateID
+                        $0.identity = self.configuration.identity
+                        $0.waitPolicy.lifecycleStage = .completed
+                    },
+                    callOptions: callOptions ?? .userPollRetryOptions
+                )
+
+                if response.hasOutcome {
+                    return response.outcome
+                }
+            } catch let rpcError as RPCError
+                where rpcError.code == .deadlineExceeded || rpcError.code == .cancelled
+            {
+                throw WorkflowUpdateRPCTimeoutOrCanceledError(cause: rpcError)
+            } catch is CancellationError {
+                throw WorkflowUpdateRPCTimeoutOrCanceledError()
+            } catch {
+                throw error
+            }
+        }
+    }
+
     /// Retrieves the result of a previously started workflow update using long polling.
     ///
     /// This method waits for a workflow update to complete and returns its results.
@@ -303,50 +358,14 @@ extension TemporalClient.WorkflowService {
         resultTypes: repeat (each Result).Type,
         callOptions: CallOptions? = nil
     ) async throws -> (repeat each Result) {
-        // This setups a long poll since we need to wait until the
-        // update completed. We don't have to sleep between each request
-        // since the request will wait until the various timeouts trigger.
-        while true {
-            do {
-                let response: Api.Workflowservice.V1.PollWorkflowExecutionUpdateResponse = try await self.client.unary(
-                    method: Api.Workflowservice.V1.WorkflowService.Method.PollWorkflowExecutionUpdate.descriptor,
-                    request: Api.Workflowservice.V1.PollWorkflowExecutionUpdateRequest.with {
-                        $0.namespace = self.configuration.namespace
-                        $0.updateRef.workflowExecution.workflowID = workflowID
-                        if let runID {
-                            $0.updateRef.workflowExecution.runID = runID
-                        }
-                        $0.updateRef.updateID = updateID
-                        $0.identity = self.configuration.identity
-                        $0.waitPolicy.lifecycleStage = .completed
-                    },
-                    callOptions: callOptions ?? .userPollRetryOptions
-                )
-
-                if response.hasOutcome {
-                    switch response.outcome.value {
-                    case .success(let success):
-                        return try await self.configuration.dataConverter.convertPayloads(
-                            success.payloads,
-                            as: repeat each resultTypes
-                        )
-                    case .failure(let failure):
-                        let error = await self.configuration.dataConverter.convertFailure(failure)
-                        throw WorkflowUpdateFailedError(cause: error)
-                    case .none:
-                        break
-                    }
-                }
-            } catch let rpcError as RPCError
-                where rpcError.code == .deadlineExceeded || rpcError.code == .cancelled
-            {
-                throw WorkflowUpdateRPCTimeoutOrCanceledError(cause: rpcError)
-            } catch is CancellationError {
-                throw WorkflowUpdateRPCTimeoutOrCanceledError()
-            } catch {
-                throw error
-            }
-        }
+        let outcome = try await self.pollWorkflowUpdateOutcome(
+            workflowID: workflowID,
+            runID: runID,
+            updateID: updateID,
+            callOptions: callOptions
+        )
+        let payloads = try await outcome.successPayloads(using: self.configuration.dataConverter)
+        return try await self.configuration.dataConverter.convertPayloads(payloads, as: repeat each resultTypes)
     }
 
     /// Retrieves the result of a previously started strongly-typed workflow update using long polling.

--- a/Sources/Temporal/Macros/WorkflowMacro.swift
+++ b/Sources/Temporal/Macros/WorkflowMacro.swift
@@ -168,8 +168,16 @@ public macro WorkflowQuery(name: String? = nil, description: String? = nil) = #e
 /// - Parameter description: An optional description of the update's purpose.
 /// - Parameter unfinishedPolicy: The policy for handling unfinished instances of this handler when
 ///   the workflow exits. Defaults to ``HandlerUnfinishedPolicy/warnAndAbandon``.
+/// - Parameter validator: The name of a method on the workflow class that validates the update input
+///   before execution. The validator method must accept the same input type as the update handler
+///   and return `Void`. It may throw to reject the update. If not provided, no validation is performed.
 @attached(peer, names: arbitrary)
-public macro WorkflowUpdate(name: String? = nil, description: String? = nil, unfinishedPolicy: HandlerUnfinishedPolicy = .warnAndAbandon) =
+public macro WorkflowUpdate(
+    name: String? = nil,
+    description: String? = nil,
+    unfinishedPolicy: HandlerUnfinishedPolicy = .warnAndAbandon,
+    validator: String? = nil
+) =
     #externalMacro(module: "TemporalMacros", type: "WorkflowUpdateMacro")
 
 /// Makes workflow state sendable by ensuring it is modified on the workflow's executor.

--- a/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
@@ -851,6 +851,7 @@ struct WorkflowInstance: Sendable {
                 try Self.$isWorkflowStateFrozen.withValue(true) {
                     // Context is frozen during update validation to prevent side effects
                     try implementation.validateUpdate(
+                        workflow: workflow,
                         context: workflowContext,
                         input: .init(
                             id: id,
@@ -873,6 +874,7 @@ struct WorkflowInstance: Sendable {
                 )
                 let failure = self.failureConverter.convertError(error, payloadConverter: self.payloadConverter)
                 self.stateMachine.updateRejected(id: id, failure: failure)
+                return
             }
         }
 
@@ -1116,6 +1118,7 @@ extension WorkflowInstance.Implementation {
     }
 
     func validateUpdate<Update: WorkflowUpdateDefinition>(
+        workflow: Update.Workflow,
         context: WorkflowContext,
         input: HandleUpdateInput<Update>
     ) throws {
@@ -1126,7 +1129,7 @@ extension WorkflowInstance.Implementation {
                 try WorkflowInstance.$isWorkflowStateFrozen.withValue(true) {
                     try intercept((any WorkflowInboundInterceptor).validateUpdate, input: input) { input in
                         try WorkflowInstance.$isWorkflowStateFrozen.withValue(false) {
-                            try input.definition.validateInput(input.input)
+                            try input.definition.validateInput(workflow: workflow, input.input)
                         }
                     }
                 }

--- a/Sources/Temporal/Worker/Workflow/WorkflowUpdateDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowUpdateDefinition.swift
@@ -88,9 +88,11 @@ public protocol WorkflowUpdateDefinition<Workflow>: Sendable {
     /// and ensure the workflow is in an appropriate state to handle the update.
     /// Throwing an error from this method rejects the update.
     ///
-    /// - Parameter input: The input data to validate.
+    /// - Parameters:
+    ///   - workflow: The workflow instance being updated.
+    ///   - input: The input data to validate.
     /// - Throws: Any validation error that should prevent update execution.
-    func validateInput(_ input: Input) throws
+    func validateInput(workflow: Workflow, _ input: Input) throws
 
     /// Executes the update and returns the result.
     ///
@@ -135,5 +137,5 @@ extension WorkflowUpdateDefinition {
     /// Default implementation that performs no validation.
     ///
     /// Override this method to provide custom validation logic for update inputs.
-    public func validateInput(_ input: Input) throws {}
+    public func validateInput(workflow: Workflow, _ input: Input) throws {}
 }

--- a/Sources/TemporalMacros/WorkflowMacro.swift
+++ b/Sources/TemporalMacros/WorkflowMacro.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
@@ -23,6 +24,12 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         }
         var diagnosticID: MessageID { MessageID(domain: "WorkflowMacro", id: "unexpected_init") }
         var severity: DiagnosticSeverity { .warning }
+    }
+
+    struct ValidatorError: DiagnosticMessage {
+        var message: String
+        var diagnosticID: MessageID { MessageID(domain: "WorkflowMacro", id: "validator_error") }
+        var severity: DiagnosticSeverity { .error }
     }
 
     public static func expansion(
@@ -81,10 +88,89 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
                 queryNames.append(functionDecl.name.text)
             }
 
-            if functionDecl.attributes.contains(where: { element in
+            if let updateAttribute = functionDecl.attributes.first(where: { element in
                 element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "WorkflowUpdate"
-            }) {
+            })?.as(AttributeSyntax.self) {
                 updateNames.append(functionDecl.name.text)
+
+                // Validate the referenced validator method if specified
+                if let validatorName = updateAttribute.stringValueForArgument(named: "validator") {
+                    let allFunctions = declaration.memberBlock.members.compactMap {
+                        $0.decl.as(FunctionDeclSyntax.self)
+                    }
+                    if let validatorFunc = allFunctions.first(where: { $0.name.text == validatorName }) {
+                        // Validator must not be async
+                        if validatorFunc.signature.effectSpecifiers?.asyncSpecifier?.presence == .present {
+                            context.diagnose(
+                                Diagnostic(
+                                    node: Syntax(validatorFunc),
+                                    message: ValidatorError(message: "Validator method '\(validatorName)' must not be async")
+                                )
+                            )
+                        }
+
+                        // Validator must return Void
+                        if let returnClause = validatorFunc.signature.returnClause,
+                            returnClause.type.as(IdentifierTypeSyntax.self)?.name.text != "Void"
+                        {
+                            context.diagnose(
+                                Diagnostic(
+                                    node: Syntax(returnClause),
+                                    message: ValidatorError(message: "Validator method '\(validatorName)' must return Void")
+                                )
+                            )
+                        }
+
+                        // Validator must have exactly one parameter called 'input'
+                        let validatorParams = validatorFunc.signature.parameterClause.parameters
+                        if validatorParams.count != 1 {
+                            context.diagnose(
+                                Diagnostic(
+                                    node: Syntax(validatorFunc.signature.parameterClause),
+                                    message: ValidatorError(
+                                        message: "Validator method '\(validatorName)' must have exactly one parameter matching the update input"
+                                    )
+                                )
+                            )
+                        } else if let validatorParam = validatorParams.first {
+                            if validatorParam.firstName.text != "input" {
+                                context.diagnose(
+                                    Diagnostic(
+                                        node: Syntax(validatorParam),
+                                        message: ValidatorError(
+                                            message: "Validator method '\(validatorName)' parameter must be called 'input'"
+                                        )
+                                    )
+                                )
+                            }
+
+                            // Check input type matches
+                            let updateParams = functionDecl.signature.parameterClause.parameters
+                            if let updateParam = updateParams.first {
+                                let updateType = updateParam.type.description.trimmingCharacters(in: .whitespaces)
+                                let validatorType = validatorParam.type.description.trimmingCharacters(in: .whitespaces)
+                                if updateType != validatorType {
+                                    context.diagnose(
+                                        Diagnostic(
+                                            node: Syntax(validatorParam.type),
+                                            message: ValidatorError(
+                                                message:
+                                                    "Validator method '\(validatorName)' input type '\(validatorType)' does not match update input type '\(updateType)'"
+                                            )
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        context.diagnose(
+                            Diagnostic(
+                                node: Syntax(updateAttribute),
+                                message: ValidatorError(message: "Validator method '\(validatorName)' not found in workflow class")
+                            )
+                        )
+                    }
+                }
             }
         }
 

--- a/Sources/TemporalMacros/WorkflowUpdateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowUpdateMacro.swift
@@ -68,7 +68,38 @@ public struct WorkflowUpdateMacro: PeerMacro {
             unfinishedPolicyDecl = "\(raw: rawAccessModifier)static var unfinishedPolicy: HandlerUnfinishedPolicy { .\(raw: policyName) }"
         }
 
+        let validatorName = node.stringValueForArgument(named: "validator")
         let updateName = functionDecl.name.text.capitalizingFirst()
+
+        let initParams: String
+        let initBody: String
+        var validatorDecl: DeclSyntax?
+        if validatorName != nil {
+            initParams =
+                "run: @Sendable @escaping (Workflow, Input) async throws -> Output, validate: @Sendable @escaping (Workflow, Input) throws -> Void"
+            initBody = """
+                self._run = run
+                            self._validate = validate
+                """
+            validatorDecl = """
+                let _validate: @Sendable (Workflow, Input) throws -> Void
+                        \(raw: rawAccessModifier)func validateInput(workflow: Workflow, _ input: Input) throws {
+                            try self._validate(workflow, input)
+                        }
+                """
+        } else {
+            initParams = "run: @Sendable @escaping (Workflow, Input) async throws -> Output"
+            initBody = "self._run = run"
+        }
+
+        let staticVarBody: String
+        if let validatorName = validatorName {
+            staticVarBody =
+                "\(updateName)(run: { try await $0.\(functionDecl.name.text)(input: $1) }, validate: { try $0.\(validatorName)(input: $1) })"
+        } else {
+            staticVarBody = "\(updateName)(run: { try await $0.\(functionDecl.name.text)(input: $1) })"
+        }
+
         return [
             """
             \(raw: rawAccessModifier)struct \(raw: updateName): WorkflowUpdateDefinition {
@@ -77,8 +108,8 @@ public struct WorkflowUpdateMacro: PeerMacro {
                 \(raw: rawAccessModifier)typealias Workflow = \(parentClass.name)
 
                 let _run: @Sendable (Workflow, Input) async throws -> Output
-                init(run: @Sendable @escaping (Workflow, Input) async throws -> Output) {
-                    self._run = run
+                init(\(raw: initParams)) {
+                    \(raw: initBody)
                 }
                 \(raw: rawAccessModifier)func run(workflow: Workflow, input: Input) async throws -> Output{
                     try await self._run(workflow, input)
@@ -86,11 +117,12 @@ public struct WorkflowUpdateMacro: PeerMacro {
                 \(nameDecl)
                 \(descriptionDecl)
                 \(unfinishedPolicyDecl)
+                \(validatorDecl)
             }
             """,
             """
             static var \(raw: functionDecl.name.text): \(raw: updateName) {
-                \(raw: updateName)(run: { try await $0.\(raw: functionDecl.name.text)(input: $1) })
+                \(raw: staticVarBody)
             }
             """,
         ]

--- a/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
+++ b/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
@@ -733,5 +734,245 @@ struct WorkflowMacrosTests {
             removeWhitespace: true
         )
         #expect(expectedOutput == actualOutput)
+    }
+
+    @Test(arguments: [nil, "public", "package", "internal", "fileprivate", "private"])
+    func updateWithValidator(modifier: String?) throws {
+        let modifierPrefix = modifier.map { "\($0) " } ?? ""
+
+        let (expectedOutput, _) = try parse(
+            """
+            final class FooWorkflow {
+                \(modifierPrefix)func foo(input: String) async throws -> Int {}
+
+                \(modifierPrefix)struct Foo: WorkflowUpdateDefinition {
+                    \(modifierPrefix)typealias Input = String
+                    \(modifierPrefix)typealias Output = Int
+                    \(modifierPrefix)typealias Workflow = FooWorkflow
+
+                    let _run: @Sendable (Workflow, Input) async throws -> Output
+                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Output, validate: @Sendable @escaping (Workflow, Input) throws -> Void) {
+                        self._run = run
+                        self._validate = validate
+                    }
+                    \(modifierPrefix)func run(workflow: Workflow, input: Input) async throws -> Output {
+                        try await self._run(workflow, input)
+                    }
+
+                    let _validate: @Sendable (Workflow, Input) throws -> Void
+                    \(modifierPrefix)func validateInput(workflow: Workflow, _ input: Input) throws {
+                        try self._validate(workflow, input)
+                    }
+                }
+
+                static var foo: Foo {
+                    Foo(run: {
+                            try await $0.foo(input: $1)
+                        }, validate: {
+                            try $0.validateFoo(input: $1)
+                        })
+                }
+
+                func validateFoo(input: String) throws {}
+
+                static var updates: [any WorkflowUpdateDefinition<FooWorkflow>] {
+                    [Self.foo]
+                }
+
+                required init(input: Input) {}
+            }
+
+            extension FooWorkflow: WorkflowDefinition {
+            }
+            """,
+            removeWhitespace: true
+        )
+        let (actualOutput, _) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "validateFoo")
+                \(modifierPrefix)func foo(input: String) async throws -> Int {}
+
+                func validateFoo(input: String) throws {}
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(expectedOutput == actualOutput)
+    }
+
+    // MARK: - Validator Diagnostic Tests
+
+    @Test
+    func validatorGeneratesCorrectCall() throws {
+        let (_, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "validateFoo")
+                func foo(input: String) async throws -> Int {}
+
+                func validateFoo(input: String) throws {}
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(diagnostics.isEmpty)
+    }
+
+    @Test
+    func updateWithoutValidatorHasNoValidateMethod() throws {
+        let (output, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate
+                func foo(input: String) async throws -> Int {}
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(diagnostics.isEmpty)
+        #expect(!output.contains("validateInput"))
+        #expect(!output.contains("_validate"))
+    }
+
+    @Test
+    func updateWithValidatorGeneratesValidateInput() throws {
+        let (output, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "validateFoo")
+                func foo(input: String) async throws -> Int {}
+
+                func validateFoo(input: String) throws {}
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(diagnostics.isEmpty)
+        #expect(output.contains("validateInput"))
+        #expect(output.contains("_validate"))
+        #expect(output.contains("validateFoo"))
+    }
+
+    @Test
+    func validatorNotFound() throws {
+        let (_, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "doesNotExist")
+                func foo(input: String) async throws -> Int {}
+            }
+            """
+        )
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics.first?.message == "Validator method 'doesNotExist' not found in workflow class")
+        // Diagnostic should be on the @WorkflowUpdate attribute
+        #expect(diagnostics.first?.node.description.contains("WorkflowUpdate") == true)
+    }
+
+    @Test
+    func validatorIsAsync() throws {
+        let (_, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "validateFoo")
+                func foo(input: String) async throws -> Int {}
+
+                func validateFoo(input: String) async throws {}
+            }
+            """
+        )
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics.first?.message == "Validator method 'validateFoo' must not be async")
+        // Diagnostic should be on the validator function declaration
+        #expect(diagnostics.first?.node.description.contains("validateFoo") == true)
+    }
+
+    @Test
+    func validatorReturnsValue() throws {
+        let (_, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "validateFoo")
+                func foo(input: String) async throws -> Int {}
+
+                func validateFoo(input: String) throws -> Bool {}
+            }
+            """
+        )
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics.first?.message == "Validator method 'validateFoo' must return Void")
+        // Diagnostic should be on the return clause
+        #expect(diagnostics.first?.node.description.contains("Bool") == true)
+    }
+
+    @Test
+    func validatorWrongParameterCount() throws {
+        let (_, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "validateFoo")
+                func foo(input: String) async throws -> Int {}
+
+                func validateFoo(input: String, extra: Int) throws {}
+            }
+            """
+        )
+        #expect(diagnostics.count == 1)
+        #expect(
+            diagnostics.first?.message
+                == "Validator method 'validateFoo' must have exactly one parameter matching the update input"
+        )
+        // Diagnostic should be on the parameter clause
+        #expect(diagnostics.first?.node.description.contains("extra") == true)
+    }
+
+    @Test
+    func validatorWrongParameterName() throws {
+        let (_, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "validateFoo")
+                func foo(input: String) async throws -> Int {}
+
+                func validateFoo(value: String) throws {}
+            }
+            """
+        )
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics.first?.message == "Validator method 'validateFoo' parameter must be called 'input'")
+        // Diagnostic should be on the parameter
+        #expect(diagnostics.first?.node.description.contains("value") == true)
+    }
+
+    @Test
+    func validatorWrongInputType() throws {
+        let (_, diagnostics) = try parse(
+            """
+            @Workflow
+            final class FooWorkflow {
+                @WorkflowUpdate(validator: "validateFoo")
+                func foo(input: String) async throws -> Int {}
+
+                func validateFoo(input: Int) throws {}
+            }
+            """
+        )
+        #expect(diagnostics.count == 1)
+        #expect(
+            diagnostics.first?.message
+                == "Validator method 'validateFoo' input type 'Int' does not match update input type 'String'"
+        )
+        // Diagnostic should be on the parameter type
+        #expect(diagnostics.first?.node.description.contains("Int") == true)
     }
 }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
@@ -136,6 +136,85 @@ extension TestServerDependentTests {
             }
         }
 
+        // MARK: - Update Validator Tests
+
+        @Workflow
+        final class ValidatedUpdateWorkflow {
+            private var value = ""
+
+            func run(input: Void) async throws -> String {
+                try await Workflow.condition { !self.value.isEmpty }
+                return self.value
+            }
+
+            @WorkflowUpdate(validator: "validateSetValue")
+            func setValue(input: String) async throws -> String {
+                self.value = input
+                return "set:\(input)"
+            }
+
+            func validateSetValue(input: String) throws {
+                guard !input.isEmpty else {
+                    throw ApplicationError(message: "Input cannot be empty")
+                }
+                guard input.count <= 100 else {
+                    throw ApplicationError(message: "Input too long")
+                }
+            }
+        }
+
+        @Test
+        func updateValidatorAccepts() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [ValidatedUpdateWorkflow.self]
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: ValidatedUpdateWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+                let result = try await handle.executeUpdate(
+                    updateType: ValidatedUpdateWorkflow.SetValue.self,
+                    input: "hello"
+                )
+                #expect(result == "set:hello")
+
+                let workflowResult = try await handle.result()
+                #expect(workflowResult == "hello")
+            }
+        }
+
+        @Test
+        func updateValidatorRejects() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [ValidatedUpdateWorkflow.self]
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: ValidatedUpdateWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+
+                // Empty input should be rejected by the validator.
+                // executeUpdate waits for completion, so it will throw on rejection.
+                await #expect(throws: (any Error).self) {
+                    try await handle.executeUpdate(
+                        updateType: ValidatedUpdateWorkflow.SetValue.self,
+                        input: ""
+                    )
+                }
+
+                // Workflow should still be running (validator rejection doesn't fail the workflow).
+                // Send a valid update to complete it.
+                let result = try await handle.executeUpdate(
+                    updateType: ValidatedUpdateWorkflow.SetValue.self,
+                    input: "valid"
+                )
+                #expect(result == "set:valid")
+
+                let workflowResult = try await handle.result()
+                #expect(workflowResult == "valid")
+            }
+        }
+
         // MARK: - Update-with-Start Tests
 
         @Workflow


### PR DESCRIPTION
Add optional `validator:` parameter to `@WorkflowUpdate` that wires a validation method to run before the update handler. Also fix a bug where a rejected update would fall through and still execute the handler.