### PR TITLE
Change Workflows from classes to structs

### DIFF
--- a/Examples/AsyncActivities/FilmPermitWorkflow.swift
+++ b/Examples/AsyncActivities/FilmPermitWorkflow.swift
@@ -17,7 +17,7 @@ import Temporal
 
 /// Workflow for processing NYC film permits with parallel and sequential modes.
 @Workflow
-final class FilmPermitWorkflow {
+struct FilmPermitWorkflow {
     enum ProcessingMode: String, Codable, Sendable {
         case sequential
         case parallel
@@ -33,7 +33,7 @@ final class FilmPermitWorkflow {
         let processingTimeMs: Double
     }
 
-    func run(input: BatchRequest) async throws -> BatchResult {
+    mutating func run(context: WorkflowContext<Self>, input: BatchRequest) async throws -> BatchResult {
         let startTime = Date()
 
         // Process permits based on mode (permits already fetched)
@@ -42,15 +42,14 @@ final class FilmPermitWorkflow {
         if input.mode == .sequential {
             // Sequential processing
             for permit in input.permits {
-                let analysis = try await processPermit(permit: permit)
+                let analysis = try await Self.processPermit(permit: permit, context: context)
                 analyses.append(analysis)
             }
         } else {
-            // Parallel processing with task group
             try await withThrowingTaskGroup(of: FilmPermitActivities.PermitAnalysis.self) { group in
                 for permit in input.permits {
                     group.addTask {
-                        try await self.processPermit(permit: permit)
+                        try await Self.processPermit(permit: permit, context: context)
                     }
                 }
 
@@ -61,7 +60,7 @@ final class FilmPermitWorkflow {
         }
 
         // Generate analytics report
-        let report = try await Workflow.executeActivity(
+        let report = try await context.executeActivity(
             FilmPermitActivities.Activities.GenerateAnalyticsReport.self,
             options: ActivityOptions(
                 startToCloseTimeout: .seconds(10)
@@ -78,23 +77,26 @@ final class FilmPermitWorkflow {
     }
 
     /// Process a single permit through validation, location analysis, and categorization.
-    private func processPermit(permit: FilmPermitActivities.FilmPermit) async throws -> FilmPermitActivities.PermitAnalysis {
+    private static func processPermit(
+        permit: FilmPermitActivities.FilmPermit,
+        context: WorkflowContext<Self>
+    ) async throws -> FilmPermitActivities.PermitAnalysis {
         let permitStart = Date()
 
         // Run three analyses in parallel using async let
-        async let validation = Workflow.executeActivity(
+        async let validation = context.executeActivity(
             FilmPermitActivities.Activities.ValidatePermit.self,
             options: ActivityOptions(startToCloseTimeout: .seconds(5)),
             input: permit
         )
 
-        async let location = Workflow.executeActivity(
+        async let location = context.executeActivity(
             FilmPermitActivities.Activities.AnalyzeLocation.self,
             options: ActivityOptions(startToCloseTimeout: .seconds(5)),
             input: permit
         )
 
-        async let category = Workflow.executeActivity(
+        async let category = context.executeActivity(
             FilmPermitActivities.Activities.CategorizePermit.self,
             options: ActivityOptions(startToCloseTimeout: .seconds(5)),
             input: permit

--- a/Examples/ChildWorkflows/AssignDeliveryWorkflow.swift
+++ b/Examples/ChildWorkflows/AssignDeliveryWorkflow.swift
@@ -18,7 +18,7 @@ import Temporal
 ///
 /// Runs sequentially after cooking is complete.
 @Workflow
-final class AssignDeliveryWorkflow {
+struct AssignDeliveryWorkflow {
     // MARK: - Input/Output Types
 
     struct DeliveryInput: Codable {
@@ -30,9 +30,9 @@ final class AssignDeliveryWorkflow {
 
     // MARK: - Workflow Implementation
 
-    func run(input: DeliveryInput) async throws -> String {
+    mutating func run(context: WorkflowContext<Self>, input: DeliveryInput) async throws -> String {
         // Step 1: Assign a driver
-        let driverInfo = try await Workflow.executeActivity(
+        let driverInfo = try await context.executeActivity(
             PizzaActivities.Activities.AssignDriver.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: PizzaActivities.AssignDriverInput(
@@ -43,7 +43,7 @@ final class AssignDeliveryWorkflow {
         )
 
         // Step 2: Simulate delivery
-        let deliveryResult = try await Workflow.executeActivity(
+        let deliveryResult = try await context.executeActivity(
             PizzaActivities.Activities.DeliverOrder.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: PizzaActivities.DeliverOrderInput(

--- a/Examples/ChildWorkflows/MakePizzaWorkflow.swift
+++ b/Examples/ChildWorkflows/MakePizzaWorkflow.swift
@@ -18,7 +18,7 @@ import Temporal
 ///
 /// Demonstrates a typical child workflow with multiple activities.
 @Workflow
-final class MakePizzaWorkflow {
+struct MakePizzaWorkflow {
     // MARK: - Input/Output Types
 
     struct PizzaInput: Codable {
@@ -29,16 +29,16 @@ final class MakePizzaWorkflow {
 
     // MARK: - Workflow Implementation
 
-    func run(input: PizzaInput) async throws -> String {
+    mutating func run(context: WorkflowContext<Self>, input: PizzaInput) async throws -> String {
         // Step 1: Prepare the dough
-        _ = try await Workflow.executeActivity(
+        _ = try await context.executeActivity(
             PizzaActivities.Activities.PrepareDough.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: PizzaActivities.PrepareDoughInput(size: input.size)
         )
 
         // Step 2: Add toppings
-        _ = try await Workflow.executeActivity(
+        _ = try await context.executeActivity(
             PizzaActivities.Activities.AddToppings.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: PizzaActivities.AddToppingsInput(
@@ -48,7 +48,7 @@ final class MakePizzaWorkflow {
         )
 
         // Step 3: Bake the pizza
-        let bakeResult = try await Workflow.executeActivity(
+        let bakeResult = try await context.executeActivity(
             PizzaActivities.Activities.BakePizza.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: PizzaActivities.BakePizzaInput(

--- a/Examples/ChildWorkflows/PizzaOrderWorkflow.swift
+++ b/Examples/ChildWorkflows/PizzaOrderWorkflow.swift
@@ -19,7 +19,7 @@ import Temporal
 ///
 /// Demonstrates parallel and sequential child workflow execution.
 @Workflow
-final class PizzaOrderWorkflow {
+struct PizzaOrderWorkflow {
     // MARK: - Input/Output Types
 
     struct OrderInput: Codable {
@@ -51,8 +51,8 @@ final class PizzaOrderWorkflow {
 
     // MARK: - Workflow Implementation
 
-    func run(input: OrderInput) async throws -> OrderOutput {
-        let startTime = Workflow.now
+    mutating func run(context: WorkflowContext<Self>, input: OrderInput) async throws -> OrderOutput {
+        let startTime = context.now
 
         print("📦 Order \(input.orderId) - Starting fulfillment")
         print("   \(input.pizzas.count) pizza(s), sides: \(input.sides.joined(separator: ", "))")
@@ -64,7 +64,7 @@ final class PizzaOrderWorkflow {
         let pizzaResults = try await withThrowingTaskGroup(of: (Int, String).self) { group in
             for (index, pizzaSpec) in input.pizzas.enumerated() {
                 group.addTask {
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         MakePizzaWorkflow.self,
                         options: .init(id: "\(input.orderId)-pizza-\(index + 1)"),
                         input: MakePizzaWorkflow.PizzaInput(
@@ -89,7 +89,7 @@ final class PizzaOrderWorkflow {
         // Execute sides preparation in parallel with pizzas (if any)
         let sidesResult: String
         if !input.sides.isEmpty {
-            let sidesHandle = try await Workflow.startChildWorkflow(
+            let sidesHandle = try await context.startChildWorkflow(
                 PrepareSidesWorkflow.self,
                 options: .init(id: "\(input.orderId)-sides"),
                 input: PrepareSidesWorkflow.SidesInput(sides: input.sides)
@@ -104,12 +104,12 @@ final class PizzaOrderWorkflow {
 
         // Stage 2: Package everything
         print("\n📦 Stage 2: Packaging order")
-        try await Workflow.sleep(for: .seconds(2))
+        try await context.sleep(for: .seconds(2))
         print("   ✓ Order packaged and ready for delivery")
 
         // Stage 3: Assign delivery (sequential - must happen after cooking)
         print("\n🚗 Stage 3: Delivery assignment (sequential execution)")
-        let deliveryHandle = try await Workflow.startChildWorkflow(
+        let deliveryHandle = try await context.startChildWorkflow(
             AssignDeliveryWorkflow.self,
             options: .init(id: "\(input.orderId)-delivery"),
             input: AssignDeliveryWorkflow.DeliveryInput(
@@ -122,7 +122,7 @@ final class PizzaOrderWorkflow {
         let deliveryResult = try await deliveryHandle.result()
         print("   ✓ \(deliveryResult)")
 
-        let endTime = Workflow.now
+        let endTime = context.now
         let totalMinutes = Int(endTime.timeIntervalSince(startTime) / 60)
 
         return OrderOutput(

--- a/Examples/ChildWorkflows/PrepareSidesWorkflow.swift
+++ b/Examples/ChildWorkflows/PrepareSidesWorkflow.swift
@@ -18,7 +18,7 @@ import Temporal
 ///
 /// Can run in parallel with pizza preparation.
 @Workflow
-final class PrepareSidesWorkflow {
+struct PrepareSidesWorkflow {
     // MARK: - Input/Output Types
 
     struct SidesInput: Codable {
@@ -27,9 +27,9 @@ final class PrepareSidesWorkflow {
 
     // MARK: - Workflow Implementation
 
-    func run(input: SidesInput) async throws -> String {
+    mutating func run(context: WorkflowContext<Self>, input: SidesInput) async throws -> String {
         // Prepare all sides
-        let result = try await Workflow.executeActivity(
+        let result = try await context.executeActivity(
             PizzaActivities.Activities.PrepareSides.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: PizzaActivities.PrepareSidesInput(sides: input.sides)

--- a/Examples/ErrorHandling/ErrorHandlingWorkflow.swift
+++ b/Examples/ErrorHandling/ErrorHandlingWorkflow.swift
@@ -22,7 +22,7 @@ import Temporal
 /// - Saga pattern for distributed transaction compensation
 /// - Proper error handling with retryable vs non-retryable errors
 @Workflow
-final class ErrorHandlingWorkflow {
+struct ErrorHandlingWorkflow {
     // MARK: - Input/Output Types
 
     struct TravelBookingRequest: Codable {
@@ -45,7 +45,7 @@ final class ErrorHandlingWorkflow {
 
     // MARK: - Workflow Implementation
 
-    func run(input: TravelBookingRequest) async throws -> BookingResult {
+    mutating func run(context: WorkflowContext<Self>, input: TravelBookingRequest) async throws -> BookingResult {
         let bookingId = "BOOKING-\(input.customerId)-\(Int.random(in: 1000...9999))"
 
         // Track reservations for potential compensation
@@ -55,7 +55,7 @@ final class ErrorHandlingWorkflow {
         do {
             // Step 1: Reserve flight
             // This activity demonstrates retry on transient failures
-            flightReservationId = try await Workflow.executeActivity(
+            flightReservationId = try await context.executeActivity(
                 ErrorHandlingActivities.Activities.ReserveFlight.self,
                 options: .init(
                     startToCloseTimeout: .seconds(30),
@@ -74,7 +74,7 @@ final class ErrorHandlingWorkflow {
 
             // Step 2: Reserve hotel
             // This activity also demonstrates retry on transient failures
-            hotelReservationId = try await Workflow.executeActivity(
+            hotelReservationId = try await context.executeActivity(
                 ErrorHandlingActivities.Activities.ReserveHotel.self,
                 options: .init(
                     startToCloseTimeout: .seconds(30),
@@ -93,7 +93,7 @@ final class ErrorHandlingWorkflow {
 
             // Step 3: Charge payment
             // This demonstrates non-retryable errors (insufficient funds, invalid card)
-            let paymentId = try await Workflow.executeActivity(
+            let paymentId = try await context.executeActivity(
                 ErrorHandlingActivities.Activities.ChargePayment.self,
                 options: .init(
                     startToCloseTimeout: .seconds(60),
@@ -131,7 +131,7 @@ final class ErrorHandlingWorkflow {
             if let hotelResId = hotelReservationId {
                 // Cancel hotel reservation
                 do {
-                    try await Workflow.executeActivity(
+                    try await context.executeActivity(
                         ErrorHandlingActivities.Activities.CancelHotel.self,
                         options: .init(
                             startToCloseTimeout: .seconds(30),
@@ -156,7 +156,7 @@ final class ErrorHandlingWorkflow {
             if let flightResId = flightReservationId {
                 // Cancel flight reservation
                 do {
-                    try await Workflow.executeActivity(
+                    try await context.executeActivity(
                         ErrorHandlingActivities.Activities.CancelFlight.self,
                         options: .init(
                             startToCloseTimeout: .seconds(30),

--- a/Examples/Greeting/GreetingWorkflow.swift
+++ b/Examples/Greeting/GreetingWorkflow.swift
@@ -15,9 +15,9 @@
 import Temporal
 
 @Workflow
-final class GreetingWorkflow {
-    func run(input: String) async throws -> String {
-        let greeting = try await Workflow.executeActivity(
+struct GreetingWorkflow {
+    mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+        let greeting = try await context.executeActivity(
             GreetingActivities.Activities.SayHello.self,
             options: ActivityOptions(
                 startToCloseTimeout: .seconds(30)

--- a/Examples/MultipleActivities/MultipleActivitiesWorkflow.swift
+++ b/Examples/MultipleActivities/MultipleActivitiesWorkflow.swift
@@ -21,7 +21,7 @@ import Temporal
 /// - Passing data between activities in a workflow
 /// - Why certain operations should be activities (external API calls, database operations)
 @Workflow
-final class MultipleActivitiesWorkflow {
+struct MultipleActivitiesWorkflow {
     struct OrderRequest: Codable {
         let orderId: String
         let customerId: String
@@ -36,10 +36,10 @@ final class MultipleActivitiesWorkflow {
         let trackingNumber: String
     }
 
-    func run(input: OrderRequest) async throws -> OrderResult {
+    mutating func run(context: WorkflowContext<Self>, input: OrderRequest) async throws -> OrderResult {
         // Step 1: Validate inventory for all items
         // This is an activity because it queries external inventory systems
-        _ = try await Workflow.executeActivity(
+        _ = try await context.executeActivity(
             MultipleActivitiesActivities.Activities.CheckInventory.self,
             options: .init(
                 startToCloseTimeout: .seconds(30),
@@ -56,7 +56,7 @@ final class MultipleActivitiesWorkflow {
         // Step 2: Process payment with payment gateway
         // This is an activity because it calls an external payment API
         // Payment operations need careful retry handling to avoid double-charging
-        let paymentId = try await Workflow.executeActivity(
+        let paymentId = try await context.executeActivity(
             MultipleActivitiesActivities.Activities.ProcessPayment.self,
             options: .init(
                 startToCloseTimeout: .seconds(60),
@@ -76,7 +76,7 @@ final class MultipleActivitiesWorkflow {
 
         // Step 3: Reserve inventory after successful payment
         // This is an activity because it updates external inventory database
-        try await Workflow.executeActivity(
+        try await context.executeActivity(
             MultipleActivitiesActivities.Activities.ReserveInventory.self,
             options: .init(
                 startToCloseTimeout: .seconds(30),
@@ -95,7 +95,7 @@ final class MultipleActivitiesWorkflow {
 
         // Step 4: Create shipment and get tracking number
         // This is an activity because it integrates with shipping provider APIs
-        let trackingNumber = try await Workflow.executeActivity(
+        let trackingNumber = try await context.executeActivity(
             MultipleActivitiesActivities.Activities.CreateShipment.self,
             options: .init(
                 startToCloseTimeout: .seconds(45),
@@ -115,7 +115,7 @@ final class MultipleActivitiesWorkflow {
 
         // Step 5: Send confirmation notification to customer
         // This is an activity because it calls external notification service (email/SMS)
-        try await Workflow.executeActivity(
+        try await context.executeActivity(
             MultipleActivitiesActivities.Activities.SendConfirmation.self,
             options: .init(
                 startToCloseTimeout: .seconds(30),
@@ -135,7 +135,7 @@ final class MultipleActivitiesWorkflow {
 
         // Step 6: Update order status in database
         // This is an activity because it performs database I/O
-        try await Workflow.executeActivity(
+        try await context.executeActivity(
             MultipleActivitiesActivities.Activities.UpdateOrderStatus.self,
             options: .init(
                 startToCloseTimeout: .seconds(30),

--- a/Examples/Schedule/Workflow.swift
+++ b/Examples/Schedule/Workflow.swift
@@ -16,8 +16,8 @@ import Foundation
 import Temporal
 
 @Workflow
-final class SpaceMissionWorkflow {
-    func run(input: MissionOperationInput) async throws -> MissionOperationResult {
+struct SpaceMissionWorkflow {
+    mutating func run(context: WorkflowContext<Self>, input: MissionOperationInput) async throws -> MissionOperationResult {
         let startTime = Date()
 
         let activityOptions = ActivityOptions(
@@ -31,7 +31,7 @@ final class SpaceMissionWorkflow {
         do {
             switch input.operation {
             case .collectTelemetry:
-                let telemetry = try await Workflow.executeActivity(
+                let telemetry = try await context.executeActivity(
                     SpaceMissionActivities.Activities.CollectRealTelemetry.self,
                     options: activityOptions,
                     input: TelemetryRequest()
@@ -45,7 +45,7 @@ final class SpaceMissionWorkflow {
                 )
 
             case .checkCrew:
-                let crew = try await Workflow.executeActivity(
+                let crew = try await context.executeActivity(
                     SpaceMissionActivities.Activities.CheckCrewStatus.self,
                     options: activityOptions,
                     input: CrewStatusRequest(filterCraft: "ISS")
@@ -59,7 +59,7 @@ final class SpaceMissionWorkflow {
                 )
 
             case .systemHealth:
-                let health = try await Workflow.executeActivity(
+                let health = try await context.executeActivity(
                     SpaceMissionActivities.Activities.PerformSystemHealthCheck.self,
                     options: activityOptions,
                     input: HealthCheckRequest(priority: input.priority)
@@ -74,7 +74,7 @@ final class SpaceMissionWorkflow {
 
             case .orbitCorrection:
                 // First get current telemetry
-                let telemetry = try await Workflow.executeActivity(
+                let telemetry = try await context.executeActivity(
                     SpaceMissionActivities.Activities.CollectRealTelemetry.self,
                     options: activityOptions,
                     input: TelemetryRequest()
@@ -96,10 +96,10 @@ final class SpaceMissionWorkflow {
                 }
                 // Simulate thruster burn duration
                 let burnDuration = 45
-                try await Workflow.sleep(for: .seconds(burnDuration))
+                try await context.sleep(for: .seconds(burnDuration))
 
                 // Execute correction
-                let correction = try await Workflow.executeActivity(
+                let correction = try await context.executeActivity(
                     SpaceMissionActivities.Activities.ExecuteOrbitCorrection.self,
                     options: activityOptions,
                     input: OrbitCorrectionInput(
@@ -119,7 +119,7 @@ final class SpaceMissionWorkflow {
                 )
 
             case .generateReport:
-                let report = try await Workflow.executeActivity(
+                let report = try await context.executeActivity(
                     SpaceMissionActivities.Activities.GenerateMissionReport.self,
                     options: activityOptions,
                     input: ReportRequest(includeHistory: false)

--- a/Examples/Signals/SignalWorkflow.swift
+++ b/Examples/Signals/SignalWorkflow.swift
@@ -20,9 +20,9 @@ import Temporal
 /// - Using signals to control workflow execution (pause/resume/cancel)
 /// - Using queries to inspect workflow state without mutation
 /// - Using updates to modify workflow state synchronously with validation
-/// - Waiting for conditions with Workflow.condition
+/// - Waiting for conditions with context.condition
 @Workflow
-final class SignalWorkflow {
+struct SignalWorkflow {
     // MARK: - Input/Output Types
 
     struct OrderInput: Codable {
@@ -58,12 +58,12 @@ final class SignalWorkflow {
 
     // MARK: - Workflow State
 
-    private var currentState: String = "pending"
-    private var isPaused: Bool = false
-    private var isCancelled: Bool = false
-    private var priority: String = "standard"
-    private var completedSteps: [String] = []
-    private let orderId: String
+    var currentState: String = "pending"
+    var isPaused: Bool = false
+    var isCancelled: Bool = false
+    var priority: String = "standard"
+    var completedSteps: [String] = []
+    var orderId: String = ""
 
     init(input: OrderInput) {
         self.orderId = input.orderId
@@ -71,20 +71,20 @@ final class SignalWorkflow {
 
     // MARK: - Workflow Implementation
 
-    func run(input: OrderInput) async throws -> OrderOutput {
-        currentState = "processing"
+    mutating func run(context: WorkflowContext<Self>, input: OrderInput) async throws -> OrderOutput {
+        self.currentState = "processing"
 
         // Step 1: Process the order
-        completedSteps.append("started")
+        self.completedSteps.append("started")
 
         // Wait if paused
-        try await waitIfPaused()
+        try await context.condition { !$0.isPaused || $0.isCancelled }
         if isCancelled {
             return cancelledOutput()
         }
 
-        currentState = "processing_order"
-        let processedId = try await Workflow.executeActivity(
+        self.currentState = "processing_order"
+        let processedId = try await context.executeActivity(
             SignalActivities.Activities.ProcessOrder.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: SignalActivities.ProcessOrderInput(
@@ -92,17 +92,17 @@ final class SignalWorkflow {
                 items: input.items
             )
         )
-        completedSteps.append("order_processed")
+        self.completedSteps.append("order_processed")
 
         // Wait if paused
-        try await waitIfPaused()
+        try await context.condition { !$0.isPaused || $0.isCancelled }
         if isCancelled {
             return cancelledOutput()
         }
 
         // Step 2: Ship the order
-        currentState = "shipping"
-        let trackingNumber = try await Workflow.executeActivity(
+        self.currentState = "shipping"
+        let trackingNumber = try await context.executeActivity(
             SignalActivities.Activities.ShipOrder.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: SignalActivities.ShipOrderInput(
@@ -110,24 +110,24 @@ final class SignalWorkflow {
                 priority: priority
             )
         )
-        completedSteps.append("order_shipped")
+        self.completedSteps.append("order_shipped")
 
         // Wait if paused
-        try await waitIfPaused()
+        try await context.condition { !$0.isPaused || $0.isCancelled }
         if isCancelled {
             return cancelledOutput()
         }
 
         // Step 3: Notify customer
-        currentState = "notifying"
-        try await Workflow.executeActivity(
+        self.currentState = "notifying"
+        try await context.executeActivity(
             SignalActivities.Activities.NotifyCustomer.self,
             options: .init(startToCloseTimeout: .seconds(30)),
             input: "Your order \(input.orderId) has shipped! Tracking: \(trackingNumber)"
         )
-        completedSteps.append("customer_notified")
+        self.completedSteps.append("customer_notified")
 
-        currentState = "completed"
+        self.currentState = "completed"
         return OrderOutput(
             orderId: input.orderId,
             status: "completed",
@@ -141,19 +141,19 @@ final class SignalWorkflow {
 
     /// Pauses the workflow execution.
     @WorkflowSignal
-    func pause(input: Void) async throws {
+    mutating func pause(input: Void) {
         isPaused = true
     }
 
     /// Resumes the workflow execution.
     @WorkflowSignal
-    func resume(input: Void) async throws {
+    mutating func resume(input: Void) {
         isPaused = false
     }
 
     /// Cancels the workflow.
     @WorkflowSignal
-    func cancel(input: Void) async throws {
+    mutating func cancel(input: Void) {
         isCancelled = true
         isPaused = false  // Unpause if paused to allow cancellation to proceed
     }
@@ -177,7 +177,7 @@ final class SignalWorkflow {
 
     /// Updates the priority of the order with validation.
     @WorkflowUpdate
-    func setPriority(input: SetPriorityInput) async throws -> String {
+    mutating func setPriority(input: SetPriorityInput) throws -> String {
         // Validate priority value
         let validPriorities = ["standard", "expedited", "overnight"]
         guard validPriorities.contains(input.priority) else {
@@ -206,13 +206,6 @@ final class SignalWorkflow {
     }
 
     // MARK: - Helper Methods
-
-    private func waitIfPaused() async throws {
-        if isPaused {
-            // Wait until either resumed or cancelled
-            try await Workflow.condition { !self.isPaused || self.isCancelled }
-        }
-    }
 
     private func cancelledOutput() -> OrderOutput {
         return OrderOutput(

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ dynamically, and maintain long-running business processes with confidence.
   workers
 - ⚡ **Swift Concurrency**: Native integration with Swift Structured Concurrency
 - 🎯 **Type Safety**: Compile-time type checking for workflow and activity
-  definitions
+  definitions, with struct-based workflows providing additional safety guarantees
+  (queries can't mutate state, validators can't mutate state)
 - 📊 **Observability**: Built-in support for logging, metrics and tracing
 - 🔧 **Macro-based APIs**: Simple `@Workflow` and `@Activity` macros to avoid
   boilerplate
@@ -130,9 +131,9 @@ struct GreetingActivities {
 
 // Define a workflow
 @Workflow
-final class GreetingWorkflow {
-    func run(input: String) async throws -> String {
-        let greeting = try await Workflow.executeActivity(
+struct GreetingWorkflow {
+    mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+        let greeting = try await context.executeActivity(
             GreetingActivities.Activities.SayHello.self,
             options: ActivityOptions(startToCloseTimeout: .seconds(30)),
             input: input

--- a/Sources/Temporal/Documentation.docc/GettingStarted.md
+++ b/Sources/Temporal/Documentation.docc/GettingStarted.md
@@ -70,16 +70,16 @@ Create a workflow that calls the activity and returns the generated greeting:
 
 ```swift
 @Workflow
-final class GreetingWorkflow {
-    func run(input: String) async throws -> String {
-        let greeting = try await Workflow.executeActivity(
+struct GreetingWorkflow {
+    mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+        let greeting = try await context.executeActivity(
             GreetingActivities.Activities.sayHello.self,
             options: ActivityOptions(
                 startToCloseTimeout: .seconds(30)
             ),
             input: input
         )
-        
+
         return greeting
     }
 }

--- a/Sources/Temporal/Documentation.docc/Temporal.md
+++ b/Sources/Temporal/Documentation.docc/Temporal.md
@@ -44,7 +44,8 @@ Build activities and workflows.
 
 Create workflows that orchestrate business logic and coordinate activities.
 
-- ``Workflow``
+- ``WorkflowContext``
+- ``WorkflowContextView``
 - ``WorkflowOptions``
 - ``WorkflowHandle``
 

--- a/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
@@ -16,10 +16,14 @@ to build workflows that survive failures and scale across distributed systems.
 
 ### Define a workflow with the Workflow macro
 
-Use the `@Workflow` macro on a `final class` to create a ``WorkflowDefinition``.
-The main entry point for a workflow is the `run` method, which returns the
-workflow result. Errors thrown from the `run` method are treated as to workflow
-failures.
+Use the `@Workflow` macro on a `struct` to create a ``WorkflowDefinition``.
+The main entry point for a workflow is the `run(context:input:)` method, which
+receives a ``WorkflowContext`` and returns the workflow result. Errors thrown from
+the `run` method are treated as workflow failures.
+
+The struct-based design provides compile-time safety guarantees: query handlers
+cannot mutate workflow state, and update validators cannot mutate state either.
+Signal handlers that modify state are declared as `mutating func`.
 
 The following example illustrates a register user workflow that accepts a user
 name and returns a user ID when complete:
@@ -28,7 +32,7 @@ name and returns a user ID when complete:
 import Temporal
 
 @Workflow
-final class RegisterUserWorkflow {
+struct RegisterUserWorkflow {
     struct Input: Codable {
         var userName: String
     }
@@ -36,14 +40,14 @@ final class RegisterUserWorkflow {
         var userID: String
     }
 
-    func run(input: Input) async throws -> Output {
+    mutating func run(context: WorkflowContext<Self>, input: Input) async throws -> Output {
         // Validate that the user name is not empty
         guard !input.userName.isEmpty else {
             throw ApplicationError(message: "Empty user name")
         }
-        
+
         // Check if a user with the name already exists
-        let existingUserID = try await Workflow.executeActivity(
+        let existingUserID = try await context.executeActivity(
             UserActivities.Activities.FindUserByName.self,
             options: ActivityOptions(
                 startToCloseTimeout: .minutes(5)
@@ -59,7 +63,7 @@ final class RegisterUserWorkflow {
         }
 
         // Register the new user
-        let userID = try await Workflow.executeActivity(
+        let userID = try await context.executeActivity(
             UserActivities.Activities.RegisterUser.self,
             options: ActivityOptions(
                 startToCloseTimeout: .minutes(5)
@@ -82,12 +86,12 @@ breaking existing workflows.
 
 #### Customizing workflow names
 
-By default, workflows use their class name as the workflow type. You can
+By default, workflows use their struct name as the workflow type. You can
 customize this by providing a `name` parameter in the `@Workflow` macro:
 
 ```swift
 @Workflow(name: "CustomRegisterUserWorkflow")
-final class RegisterUserWorkflow {
+struct RegisterUserWorkflow {
     // Implementation
 }
 ```
@@ -100,7 +104,7 @@ force-unwrapping.
 
 ```swift
 @Workflow
-final class RegisterUserWorkflow {
+struct RegisterUserWorkflow {
     struct Input: Codable {
         var userName: String
     }
@@ -114,7 +118,7 @@ final class RegisterUserWorkflow {
         self.userName = input.userName
     }
 
-    func run(input: Input) async throws -> Output {
+    mutating func run(context: WorkflowContext<Self>, input: Input) async throws -> Output {
         // Workflow implementation
     }
 }
@@ -136,63 +140,65 @@ that waits for approval:
 
 ```swift
 @Workflow
-final class RegisterUserWorkflow {
+struct RegisterUserWorkflow {
     struct Input: Codable {
         var userName: String
     }
-    
+
     struct Output: Codable {
         var userID: String
         var approverID: String
     }
-    
+
     // Signal input type
     struct ApprovalSignal: Codable {
         var approverID: String
     }
-    
+
     private var approverID: String?
-    
-    func run(input: Input) async throws -> Output {
+
+    mutating func run(context: WorkflowContext<Self>, input: Input) async throws -> Output {
         // Validate input
         guard !input.userName.isEmpty else {
             throw ApplicationError(message: "Empty user name")
         }
-        
+
         // Check if user already exists
-        let existingUserID = try await Workflow.executeActivity(
+        let existingUserID = try await context.executeActivity(
             UserActivities.Activities.FindUserByName.self,
             options: ActivityOptions(startToCloseTimeout: .minutes(5)),
             input: FindUserByNameInput(userName: input.userName)
         )
-        
+
         guard existingUserID == nil else {
             throw ApplicationError(message: "User already exists")
         }
-        
+
         // Wait for approval
-        try await Workflow.condition { self.approverID != nil }
-        
+        try await context.condition { $0.approverID != nil }
+
         // Register the approved user
-        let userID = try await Workflow.executeActivity(
+        let userID = try await context.executeActivity(
             UserActivities.Activities.RegisterUser.self,
             options: ActivityOptions(startToCloseTimeout: .minutes(5)),
             input: RegisterUserInput(userName: input.userName, email: input.email)
         )
-        
+
         return Output(userID: userID, approverID: self.approverID!)
     }
-    
+
     @WorkflowSignal
-    func approveRegistration(input: ApprovalSignal) async throws {
+    mutating func approveRegistration(input: ApprovalSignal) {
         self.approverID = input.approverID
     }
 }
 ```
 
-Signal handlers can be asynchronous and throw errors, but cannot return values.
-Follow the same best practice of using custom input types for signal handlers
-as you do for workflows to support backward compatibility.
+Signal handlers that modify workflow state are declared as `mutating func`.
+Because workflows are now value types, signal handlers that only mutate state
+do not need to be `async throws`. Follow the same best practice of using custom
+input types for signal handlers as you do for workflows to support backward
+compatibility.
 
 By default the signal name is the unqualified capitalized method name.
 You can customize the signal name using the `name` parameter, for example:
@@ -210,47 +216,45 @@ The following example illustrates how to add a query to check the registration s
 
 ```swift
 @Workflow
-final class RegisterUserWorkflow {
+struct RegisterUserWorkflow {
     // ... previous structs and properties ...
-    
+
     enum RegistrationState: String, Codable {
         case waitingForApproval = "waiting_for_approval"
         case approved = "approved"
         case registered = "registered"
     }
-    
+
     struct StateQuery: Codable {
         // Empty input for this query
     }
-    
+
     struct StateResponse: Codable {
         var state: RegistrationState
         var approverID: String?
     }
-    
+
     private var currentState: RegistrationState = .waitingForApproval
-    
-    func run(input: Input) async throws -> Output {
-        self.currentState = .waitingForApproval
-        
+
+    mutating func run(context: WorkflowContext<Self>, input: Input) async throws -> Output {
         // ... validation and user existence check ...
 
         // Wait for approval
-        try await Workflow.condition { self.approverID != nil }
-        
+        try await context.condition { $0.approverID != nil }
+
         self.currentState = .approved
-        
+
         // Register the user
-        let userID = try await Workflow.executeActivity(
+        let userID = try await context.executeActivity(
             UserActivities.Activities.RegisterUser.self,
             options: ActivityOptions(startToCloseTimeout: .minutes(5)),
             input: RegisterUserInput(userName: input.userName, email: input.email)
         )
-        
+
         self.currentState = .registered
         return Output(userID: userID, approverID: self.approverID!)
     }
-    
+
     @WorkflowQuery
     func getRegistrationState(input: StateQuery) throws -> StateResponse {
         return StateResponse(
@@ -258,13 +262,15 @@ final class RegisterUserWorkflow {
             approverID: approverID,
         )
     }
-    
+
     // ... signal handler ...
 }
 ```
 
 Query handlers must be synchronous, and can throw errors. They can't perform
-activities or other asynchronous operations. Use custom input and output types
+activities or other asynchronous operations. Because workflows are structs,
+query handlers provide compile-time safety: they are non-mutating by default,
+guaranteeing they cannot modify workflow state. Use custom input and output types
 for queries to maintain backward compatibility.
 
 By default, the signal name is the unqualified capitalized method name.
@@ -284,30 +290,30 @@ user registration details:
 
 ```swift
 @Workflow
-final class RegisterUserWorkflow {
+struct RegisterUserWorkflow {
     // ... previous structs and properties ...
-    
+
     struct UpdateUserNameInput: Codable {
         var userName: String
     }
-    
+
     struct UpdateUserNameOutput: Codable {
         var success: Bool
     }
-    
+
     private var currentState: RegistrationState = .waitingForApproval
     private var userName: String
 
     init(input: Input) {
         self.userName = input.userName
     }
-    
-    func run(input: Input) async throws -> Output {        
+
+    mutating func run(context: WorkflowContext<Self>, input: Input) async throws -> Output {
         // ... rest of workflow logic ...
     }
-    
+
     @WorkflowUpdate
-    func updateUserName(input: UpdateUserNameInput) async throws -> UpdateUserNameOutput {
+    mutating func updateUserName(input: UpdateUserNameInput) async throws -> UpdateUserNameOutput {
         // Can only update details while waiting for approval
         guard currentState == .waitingForApproval else {
             return UpdateUserDetailsOutput(
@@ -321,7 +327,7 @@ final class RegisterUserWorkflow {
             success: true
         )
     }
-    
+
     // ... other handlers ...
 }
 ```

--- a/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
@@ -39,20 +39,20 @@ Here's an example using a task group to run two child tasks concurrently:
 
 ```swift
 @Workflow
-final class DataProcessingWorkflow {
-    func run(input: Void) async throws -> String {
+struct DataProcessingWorkflow {
+    mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
         // Use task group to run two operations concurrently
         return try await withTaskGroup(of: String.self) { group in
             // First child task - validate data
             group.addTask {
                 return "First"
             }
-            
+
             // Second child task - fetch configuration
             group.addTask {
                 return "Second"
             }
-            
+
             // Collect results from both tasks
             var result = [String]()
             for try await string in group {
@@ -78,16 +78,16 @@ APIs inside your workflows:
 **Safe to use:**
 - `async let` bindings for concurrent operations.
 - Task group APIs (`withTaskGroup`, `withThrowingTaskGroup`, discarding variants).
-- All ``Workflow`` APIs for activities, timers, conditions, and more.
+- All ``WorkflowContext`` APIs for activities, timers, conditions, and more.
 - Swift's standard Task cancellation primitives.
 
 **Avoid these APIs:**
 - `Task.detached` - Instead use Structured Concurrency alternatives.
 - Actor isolation - Introduces potential executor hops.
-- `Task.sleep` or `Clock.sleep` - Instead, use ``Workflow/sleep(for:summary:)``.
+- `Task.sleep` or `Clock.sleep` - Instead, use ``WorkflowContext/sleep(for:summary:)``.
 - Direct I/O operations - Instead, use activities for any non-deterministic code.
 - Non-deterministic APIs like `RandomNumberGenerator` - Instead, use
-``Workflow/randomNumberGenerator``.
+``WorkflowContext/randomNumberGenerator``.
 
 ### Handle cancellation properly
 
@@ -95,7 +95,7 @@ Workflows support Swift's standard cancellation primitives, enabling graceful
 shutdown and cleanup. Use `Task.isCancelled`, `withTaskCancellationHandler`, and
 other cancellation APIs as you would in regular Swift code.
 
-When a workflow is cancelled, many ``Workflow`` operations throw
+When a workflow is cancelled, many ``WorkflowContext`` operations throw
 `CancellationError`, allowing your workflow to detect cancellation and perform
 cleanup. Cancellation propagates through structured concurrency patterns, such as
 task groups, ensuring that all child tasks are properly cancelled when the workflow

--- a/Sources/Temporal/Errors/ArgumentError.swift
+++ b/Sources/Temporal/Errors/ArgumentError.swift
@@ -14,7 +14,7 @@
 
 /// Error that is thrown when an argument is invalid.
 ///
-/// For example ``Workflow/sleep(for:summary:)`` throws this error
+/// For example ``WorkflowContext/sleep(for:summary:)`` throws this error
 /// when a negative duration is passed.
 public struct ArgumentError: TemporalError {
     /// The error's message.

--- a/Sources/Temporal/Errors/ContinueAsNewError.swift
+++ b/Sources/Temporal/Errors/ContinueAsNewError.swift
@@ -52,7 +52,7 @@ public struct ContinueAsNewError: TemporalError {
     var searchAttributes: SearchAttributeCollection?
 
     init(
-        workflowContext: WorkflowContext,
+        workflowContext: InternalWorkflowContext,
         workflowName: String,
         headers: [String: Api.Common.V1.Payload],
         inputs: [Api.Common.V1.Payload],

--- a/Sources/Temporal/Errors/ContinueAsNewError.swift
+++ b/Sources/Temporal/Errors/ContinueAsNewError.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Error thrown by a workflow out of the ``WorkflowDefinition/run(input:)``
+/// Error thrown by a workflow out of the ``WorkflowDefinition/run(context:input:)``
 /// method to issue a continue-as-new.
 public struct ContinueAsNewError: TemporalError {
     /// The error's message.

--- a/Sources/Temporal/Instrumentation/SpanAttributes/SpanAttributes+WorkerWorkflowOutboundAttributes.swift
+++ b/Sources/Temporal/Instrumentation/SpanAttributes/SpanAttributes+WorkerWorkflowOutboundAttributes.swift
@@ -107,7 +107,7 @@ extension Span {
         if let summary = sleepInput.summary {
             self.attributes[TemporalTracingKeys.workflowSleepSummary] = summary
         }
-        self.setWorkerExecuteWorkflowSpanAttributes(info: Workflow.info)
+        self.setWorkerExecuteWorkflowSpanAttributes(info: sleepInput.info)
     }
 
     func setWorkerExecuteActivityRequestSpanAttributes(

--- a/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+WorkflowInbound.swift
+++ b/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+WorkflowInbound.swift
@@ -36,10 +36,10 @@ extension TemporalWorkerTracingInterceptor {
             next: (ExecuteWorkflowInput<Workflow>) async throws -> Workflow.Output
         ) async throws -> Workflow.Output {
             try await self.traceRecording.recordInbound(
-                spanName: "RunWorkflow:\(Temporal.Workflow.info.workflowName)",
+                spanName: "RunWorkflow:\(input.info.workflowName)",
                 headers: input.headers,
                 setSpanAttributes: { span in
-                    span.setWorkerExecuteWorkflowSpanAttributes(info: Temporal.Workflow.info)
+                    span.setWorkerExecuteWorkflowSpanAttributes(info: input.info)
                 },
                 next: {
                     try await next(input)
@@ -55,7 +55,7 @@ extension TemporalWorkerTracingInterceptor {
                 spanName: "HandleSignal:\(input.name)",
                 headers: input.headers,
                 setSpanAttributes: { span in
-                    span.setWorkerHandleSignalSpanAttributes(signalName: input.name, workflowInfo: Workflow.info)
+                    span.setWorkerHandleSignalSpanAttributes(signalName: input.name, workflowInfo: input.info)
                 },
                 next: {
                     try await next(input)
@@ -71,7 +71,7 @@ extension TemporalWorkerTracingInterceptor {
                 spanName: "HandleQuery:\(input.name)",
                 headers: input.headers,
                 setSpanAttributes: { span in
-                    span.setWorkerHandleQuerySpanAttributes(queryId: input.id, queryName: input.name, workflowInfo: Workflow.info)
+                    span.setWorkerHandleQuerySpanAttributes(queryId: input.id, queryName: input.name, workflowInfo: input.info)
                 },
                 next: {
                     try next(input)
@@ -87,7 +87,7 @@ extension TemporalWorkerTracingInterceptor {
                 spanName: "HandleUpdate:\(input.name)",
                 headers: input.headers,
                 setSpanAttributes: { span in
-                    span.setWorkerHandleUpdateSpanAttributes(updateId: input.id, updateName: input.name, workflowInfo: Workflow.info)
+                    span.setWorkerHandleUpdateSpanAttributes(updateId: input.id, updateName: input.name, workflowInfo: input.info)
                 },
                 next: {
                     try await next(input)
@@ -103,7 +103,7 @@ extension TemporalWorkerTracingInterceptor {
                 spanName: "ValidateUpdate:\(input.name)",
                 headers: input.headers,
                 setSpanAttributes: { span in
-                    span.setWorkerHandleUpdateSpanAttributes(updateId: input.id, updateName: input.name, workflowInfo: Workflow.info)
+                    span.setWorkerHandleUpdateSpanAttributes(updateId: input.id, updateName: input.name, workflowInfo: input.info)
                 },
                 next: {
                     try next(input)

--- a/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+WorkflowOutbound.swift
+++ b/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+WorkflowOutbound.swift
@@ -54,7 +54,7 @@ extension TemporalWorkerTracingInterceptor {
                 headers: input.headers,
                 setRequestAttributes: { span in
                     span.setWorkerExecuteActivityRequestSpanAttributes(
-                        workflowInfo: Workflow.info,
+                        workflowInfo: input.info,
                         activityName: input.name,
                         activityOptions: input.options
                     )
@@ -76,7 +76,7 @@ extension TemporalWorkerTracingInterceptor {
                 headers: input.headers,
                 setRequestAttributes: { span in
                     span.setWorkerExecuteLocalActivityRequestSpanAttributes(
-                        workflowInfo: Workflow.info,
+                        workflowInfo: input.info,
                         activityName: input.name,
                         activityOptions: input.options
                     )
@@ -94,11 +94,11 @@ extension TemporalWorkerTracingInterceptor {
             next: (MakeContinueAsNewErrorInput<repeat each Input>) async throws -> ContinueAsNewError
         ) async throws -> ContinueAsNewError {
             try await self.traceRecording.recordOutbound(
-                spanName: "CreateContinuedAsNewError:\(Workflow.info.workflowName)",
+                spanName: "CreateContinuedAsNewError:\(input.info.workflowName)",
                 headers: input.headers,
                 setRequestAttributes: { span in
                     span.setWorkerContinueAsNewRequestSpanAttributes(
-                        workflowInfo: Workflow.info,
+                        workflowInfo: input.info,
                         options: input.options
                     )
                 },
@@ -124,7 +124,7 @@ extension TemporalWorkerTracingInterceptor {
                 headers: input.headers,
                 setRequestAttributes: { span in
                     span.setWorkerStartChildWorkflowRequestSpanAttributes(
-                        workflowInfo: Workflow.info,
+                        workflowInfo: input.info,
                         options: input.options
                     )
                 },

--- a/Sources/Temporal/Worker/Interceptors/Inputs/CancelExternalWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/CancelExternalWorkflowInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters for canceling an external workflow in interceptor chains.
 public struct CancelExternalWorkflowInput: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The workflow id of the external workflow to cancel.
     public var id: String
 

--- a/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteLocalActivityInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteLocalActivityInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for activity scheduling operations in interceptor chains.
 public struct ScheduleLocalActivityInput<each Input: Sendable>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The name identifying the type of activity to be scheduled for execution.
     public var name: String
 
@@ -29,16 +32,19 @@ public struct ScheduleLocalActivityInput<each Input: Sendable>: Sendable {
     /// Creates a new activity scheduling input with the specified parameters.
     ///
     /// - Parameters:
+    ///   - info: Information about the current workflow execution.
     ///   - name: The activity name identifying the activity type to execute.
     ///   - options: The configuration options controlling activity execution behavior.
     ///   - headers: The metadata and context headers for activity execution.
     ///   - input: The input parameters to pass to the activity, of varying types and counts.
     package init(
+        info: WorkflowInfo,
         name: String,
         options: LocalActivityOptions,
         headers: [String: Api.Common.V1.Payload],
         input: (repeat each Input)
     ) {
+        self.info = info
         self.name = name
         self.options = options
         self.headers = headers

--- a/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteWorkflowInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for workflow execution in interceptor chains.
 public struct ExecuteWorkflowInput<Workflow: WorkflowDefinition>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// Headers containing metadata and context information for workflow execution.
     public var headers: [String: Api.Common.V1.Payload]
 
@@ -23,9 +26,11 @@ public struct ExecuteWorkflowInput<Workflow: WorkflowDefinition>: Sendable {
     /// Creates workflow execution input with the specified information, headers, and parameters.
     ///
     /// - Parameters:
+    ///   - info: Information about the current workflow execution.
     ///   - headers: The headers containing metadata and context for execution.
     ///   - input: The input parameters for workflow execution.
-    package init(headers: [String: Api.Common.V1.Payload], input: Workflow.Input) {
+    package init(info: WorkflowInfo, headers: [String: Api.Common.V1.Payload], input: Workflow.Input) {
+        self.info = info
         self.headers = headers
         self.input = input
     }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/HandleQueryInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/HandleQueryInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for workflow query handling in interceptor chains.
 public struct HandleQueryInput<Query: WorkflowQueryDefinition>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The unique identifier for this specific query request.
     ///
     /// The query ID provides a unique identifier for individual query requests,

--- a/Sources/Temporal/Worker/Interceptors/Inputs/HandleSignalInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/HandleSignalInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for workflow signal handling in interceptor chains.
 public struct HandleSignalInput<Signal: WorkflowSignalDefinition>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The name identifying the type of signal being processed.
     public var name: String
 

--- a/Sources/Temporal/Worker/Interceptors/Inputs/HandleSleepInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/HandleSleepInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for workflow sleep operations in interceptor chains.
 public struct HandleSleepInput: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The duration of the sleep operation.
     public var duration: Duration
 

--- a/Sources/Temporal/Worker/Interceptors/Inputs/HandleUpdateInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/HandleUpdateInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for workflow update handling in interceptor chains.
 public struct HandleUpdateInput<Update: WorkflowUpdateDefinition>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The unique identifier for this specific update request.
     public var id: String
 

--- a/Sources/Temporal/Worker/Interceptors/Inputs/MakeContinueAsNewErrorInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/MakeContinueAsNewErrorInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for workflow continue-as-new error generation in interceptor chains.
 public struct MakeContinueAsNewErrorInput<each Input: Sendable>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The workflow name to continue as.
     public var workflowName: String
 

--- a/Sources/Temporal/Worker/Interceptors/Inputs/ScheduleActivityInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/ScheduleActivityInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for activity scheduling operations in interceptor chains.
 public struct ScheduleActivityInput<each Input: Sendable>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The name identifying the type of activity to be scheduled for execution.
     public var name: String
 
@@ -29,16 +32,19 @@ public struct ScheduleActivityInput<each Input: Sendable>: Sendable {
     /// Creates a new activity scheduling input with the specified parameters.
     ///
     /// - Parameters:
+    ///   - info: Information about the current workflow execution.
     ///   - name: The activity name identifying the activity type to execute.
     ///   - options: The configuration options controlling activity execution behavior.
     ///   - headers: The metadata and context headers for activity execution.
     ///   - input: The input parameters to pass to the activity, of varying types and counts.
     package init(
+        info: WorkflowInfo,
         name: String,
         options: ActivityOptions,
         headers: [String: Api.Common.V1.Payload],
         input: (repeat each Input)
     ) {
+        self.info = info
         self.name = name
         self.options = options
         self.headers = headers

--- a/Sources/Temporal/Worker/Interceptors/Inputs/SignalExternalWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/SignalExternalWorkflowInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for external workflow signaling operations in interceptor chains.
 public struct SignalExternalWorkflowInput<each Input: Sendable>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The workfliw id of the external workflow to signal.
     public var id: String
 

--- a/Sources/Temporal/Worker/Interceptors/Inputs/StartChildWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/StartChildWorkflowInput.swift
@@ -14,6 +14,9 @@
 
 /// Input structure containing parameters and context for child workflow startup operations in interceptor chains.
 public struct StartChildWorkflowInput<each Input: Sendable>: Sendable {
+    /// Information about the current workflow execution.
+    public var info: WorkflowInfo
+
     /// The name identifying the type of child workflow to be started.
     public var name: String
 

--- a/Sources/Temporal/Worker/Workflow/ArcBox.swift
+++ b/Sources/Temporal/Worker/Workflow/ArcBox.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+/// A reference-counted box that holds a value by reference.
+///
+/// `ArcBox` provides shared mutable state through reference semantics. When a struct
+/// containing an `ArcBox` is copied, all copies share the same underlying value.
+final class ArcBox<Value>: @unchecked Sendable {
+    /// The boxed value.
+    var value: Value
+
+    /// Creates a new box with the given value.
+    ///
+    /// - Parameter value: The value to box.
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    /// Reads the value through a closure.
+    ///
+    /// - Parameter body: A closure that receives the value.
+    /// - Returns: The value returned by the closure.
+    func withValue<R>(_ body: (Value) -> R) -> R {
+        body(value)
+    }
+
+    /// Mutates the value through a closure.
+    ///
+    /// - Parameter body: A closure that receives a mutable reference to the value.
+    func withMutableValue(_ body: (inout Value) -> Void) {
+        body(&value)
+    }
+
+    /// Mutates the value through a closure and returns a result.
+    ///
+    /// - Parameter body: A closure that receives a mutable reference to the value.
+    /// - Returns: The value returned by the closure.
+    func withMutableValue<R>(_ body: (inout Value) -> R) -> R {
+        body(&value)
+    }
+}

--- a/Sources/Temporal/Worker/Workflow/ArcBox.swift
+++ b/Sources/Temporal/Worker/Workflow/ArcBox.swift
@@ -31,22 +31,15 @@ final class ArcBox<Value>: @unchecked Sendable {
     ///
     /// - Parameter body: A closure that receives the value.
     /// - Returns: The value returned by the closure.
-    func withValue<R>(_ body: (Value) -> R) -> R {
+    func withValue<Return>(_ body: (Value) -> Return) -> Return {
         body(value)
-    }
-
-    /// Mutates the value through a closure.
-    ///
-    /// - Parameter body: A closure that receives a mutable reference to the value.
-    func withMutableValue(_ body: (inout Value) -> Void) {
-        body(&value)
     }
 
     /// Mutates the value through a closure and returns a result.
     ///
     /// - Parameter body: A closure that receives a mutable reference to the value.
     /// - Returns: The value returned by the closure.
-    func withMutableValue<R>(_ body: (inout Value) -> R) -> R {
+    func withMutableValue<Return>(_ body: (inout Value) -> Return) -> Return {
         body(&value)
     }
 }

--- a/Sources/Temporal/Worker/Workflow/InternalWorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/InternalWorkflowContext.swift
@@ -12,14 +12,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import Logging
+import Logging
 
 import struct Foundation.Date
 
-/// The execution context available during workflow execution.
-package struct WorkflowContext: Sendable {
+/// The internal execution context available during workflow execution.
+struct InternalWorkflowContext: Sendable {
+    @TaskLocal
+    static var current: InternalWorkflowContext?
+    @TaskLocal
+    static var currentUpdateInfo: WorkflowUpdateInfo?
+    @TaskLocal
+    static var currentExecutor: WorkflowTaskExecutor?
+
     /// Internal state machine for workflow execution.
-    private let stateMachine: WorkflowStateMachineStorage
+    let stateMachine: WorkflowStateMachineStorage
 
     /// Outbound interceptors for workflow operations.
     private let outboundInterceptors: [any WorkflowOutboundInterceptor]
@@ -80,10 +87,6 @@ package struct WorkflowContext: Sendable {
         }
     }
 
-    func ensureWorkflowStateModificationIsSafe() {
-        self.stateMachine.ensureWorkflowStateModificationIsSafe()
-    }
-
     /// Internal method to update current details when context is immutable.
     func updateCurrentDetails(_ newValue: String?) {
         self.stateMachine.setCurrentDetails(newValue)
@@ -131,6 +134,7 @@ package struct WorkflowContext: Sendable {
     func sleep(for duration: Duration, summary: String? = nil) async throws {
         try await self.implementation.sleep(
             input: .init(
+                info: self.info,
                 duration: duration,
                 summary: summary
             )
@@ -221,6 +225,7 @@ package struct WorkflowContext: Sendable {
     ) async throws -> Output {
         try await self.implementation.executeActivity(
             input: ScheduleActivityInput<repeat each Input>(
+                info: self.info,
                 name: name,
                 options: options,
                 headers: [:],
@@ -239,6 +244,7 @@ package struct WorkflowContext: Sendable {
     ) async throws -> Output {
         try await self.implementation.executeLocalActivity(
             input: ScheduleLocalActivityInput<repeat each Input>(
+                info: self.info,
                 name: name,
                 options: options,
                 headers: [:],
@@ -269,6 +275,7 @@ package struct WorkflowContext: Sendable {
     ) async throws -> UntypedChildWorkflowHandle {
         return try await self.implementation.startChildWorkflow(
             input: StartChildWorkflowInput<repeat each Input>(
+                info: self.info,
                 name: name,
                 options: options,
                 headers: [:],
@@ -286,6 +293,8 @@ package struct WorkflowContext: Sendable {
         UntypedExternalWorkflowHandle(
             id: id,
             runId: runId,
+            namespace: self.info.namespace,
+            info: self.info,
             stateMachine: self.stateMachine,
             interceptors: self.outboundInterceptors,
             payloadConverter: self.payloadConverter
@@ -343,6 +352,7 @@ package struct WorkflowContext: Sendable {
         try await self.implementation.makeContinueAsNewError(
             context: self,
             input: MakeContinueAsNewErrorInput<repeat each Input>(
+                info: self.info,
                 workflowName: workflowName,
                 options: options,
                 headers: [:],
@@ -352,7 +362,7 @@ package struct WorkflowContext: Sendable {
     }
 }
 
-extension WorkflowContext {
+extension InternalWorkflowContext {
     struct Implementation: InterceptorImplementation {
         let interceptors: [any WorkflowOutboundInterceptor]
         let stateMachine: WorkflowStateMachineStorage
@@ -360,7 +370,7 @@ extension WorkflowContext {
     }
 }
 
-extension WorkflowContext.Implementation {
+extension InternalWorkflowContext.Implementation {
     func sleep(
         input: HandleSleepInput
     ) async throws {
@@ -380,7 +390,7 @@ extension WorkflowContext.Implementation {
                 // TODO: Support dynamic activity
                 activityType: input.name,
                 options: .remote(input.options),
-                workflowTaskQueue: Workflow.info.taskQueue,
+                workflowTaskQueue: input.info.taskQueue,
                 headers: input.headers,
                 input: inputPayloads
             )
@@ -403,7 +413,7 @@ extension WorkflowContext.Implementation {
                 // TODO: Support dynamic activity
                 activityType: input.name,
                 options: .local(input.options),
-                workflowTaskQueue: Workflow.info.taskQueue,
+                workflowTaskQueue: input.info.taskQueue,
                 headers: input.headers,
                 input: inputPayloads
             )
@@ -429,8 +439,8 @@ extension WorkflowContext.Implementation {
             }
 
             return try await self.stateMachine.startChildWorkflow(
-                namespace: Workflow.info.namespace,
-                taskQueue: Workflow.info.taskQueue,
+                namespace: input.info.namespace,
+                taskQueue: input.info.taskQueue,
                 workflowName: input.name,
                 headers: input.headers,
                 inputs: inputPayloads,
@@ -441,7 +451,7 @@ extension WorkflowContext.Implementation {
     }
 
     func makeContinueAsNewError<each Input: Sendable>(
-        context: WorkflowContext,
+        context: InternalWorkflowContext,
         input: MakeContinueAsNewErrorInput<repeat each Input>
     ) async throws -> ContinueAsNewError {
         try await intercept(Interceptor.makeContinueAsNewError, input: input) { input in
@@ -470,7 +480,7 @@ extension WorkflowContext.Implementation {
             let payloads = try self.payloadConverter.convertValues(repeat each input.input)
 
             try await self.stateMachine.signalExternalWorkflow(
-                namespace: Workflow.info.namespace,
+                namespace: input.info.namespace,
                 workflowID: input.id,
                 runID: input.runId,
                 signalName: input.name,
@@ -485,7 +495,7 @@ extension WorkflowContext.Implementation {
     ) async throws {
         try await intercept((any WorkflowOutboundInterceptor).cancelExternalWorkflow, input: input) { input in
             try await self.stateMachine.cancelExternalWorkflow(
-                namespace: Workflow.info.namespace,
+                namespace: input.info.namespace,
                 workflowID: input.id,
                 runID: input.runId
             )

--- a/Sources/Temporal/Worker/Workflow/UntypedExternalWorkflowHandle.swift
+++ b/Sources/Temporal/Worker/Workflow/UntypedExternalWorkflowHandle.swift
@@ -50,19 +50,30 @@ public struct UntypedExternalWorkflowHandle: Sendable {
     /// The internal implementation handling interceptor chains and operations.
     private let implementation: Implementation
 
+    /// The namespace of the workflow that owns this handle.
+    private let namespace: String
+
+    /// The workflow info of the owning workflow.
+    private let info: WorkflowInfo
+
     package init(
         id: String,
         runId: String?,
+        namespace: String,
+        info: WorkflowInfo,
         stateMachine: WorkflowStateMachineStorage,
         interceptors: [any WorkflowOutboundInterceptor],
         payloadConverter: any PayloadConverter
     ) {
         self.id = id
         self.runId = runId
+        self.namespace = namespace
+        self.info = info
         self.implementation = .init(
             interceptors: interceptors,
             stateMachine: stateMachine,
-            payloadConverter: payloadConverter
+            payloadConverter: payloadConverter,
+            namespace: namespace
         )
     }
 
@@ -87,6 +98,7 @@ public struct UntypedExternalWorkflowHandle: Sendable {
     ) async throws {
         try await implementation.signalExternalWorkflow(
             input: SignalExternalWorkflowInput<repeat each Input>(
+                info: self.info,
                 id: self.id,
                 runId: self.runId,
                 name: signalName,
@@ -111,6 +123,7 @@ public struct UntypedExternalWorkflowHandle: Sendable {
     public func cancel() async throws {
         try await implementation.cancelExternalWorkflow(
             input: CancelExternalWorkflowInput(
+                info: self.info,
                 id: self.id,
                 runId: self.runId
             )
@@ -123,6 +136,7 @@ extension UntypedExternalWorkflowHandle {
         let interceptors: [any WorkflowOutboundInterceptor]
         let stateMachine: WorkflowStateMachineStorage
         let payloadConverter: any PayloadConverter
+        let namespace: String
     }
 }
 
@@ -134,7 +148,7 @@ extension UntypedExternalWorkflowHandle.Implementation {
             let payloads = try self.payloadConverter.convertValues(repeat each input.input)
 
             try await self.stateMachine.signalExternalWorkflow(
-                namespace: Workflow.info.namespace,
+                namespace: self.namespace,
                 workflowID: input.id,
                 runID: input.runId,
                 signalName: input.name,
@@ -149,7 +163,7 @@ extension UntypedExternalWorkflowHandle.Implementation {
     ) async throws {
         try await intercept((any WorkflowOutboundInterceptor).cancelExternalWorkflow, input: input) { input in
             try await self.stateMachine.cancelExternalWorkflow(
-                namespace: Workflow.info.namespace,
+                namespace: self.namespace,
                 workflowID: input.id,
                 runID: input.runId
             )

--- a/Sources/Temporal/Worker/Workflow/Workflow.swift
+++ b/Sources/Temporal/Worker/Workflow/Workflow.swift
@@ -64,15 +64,6 @@ public struct WorkflowContext<Workflow: WorkflowDefinition>: @unchecked Sendable
 
     // MARK: - State Access
 
-    /// Mutates the workflow state using a closure.
-    ///
-    /// The closure receives a mutable reference to the workflow struct.
-    ///
-    /// - Parameter mutator: A closure that receives a mutable reference to the workflow struct.
-    public func mutateState(_ mutator: (inout Workflow) -> Void) {
-        stateBox.withMutableValue(mutator)
-    }
-
     /// Mutates the workflow state using a closure and returns a value.
     ///
     /// - Parameter mutator: A closure that receives a mutable reference to the workflow struct

--- a/Sources/Temporal/Worker/Workflow/Workflow.swift
+++ b/Sources/Temporal/Worker/Workflow/Workflow.swift
@@ -16,55 +16,75 @@ public import Logging
 
 public import struct Foundation.Date
 
-/// Static workflow API that provides access to Temporal workflow operations.
+/// The workflow context providing access to Temporal workflow operations.
 ///
-/// The Workflow struct provides static methods for all workflow operations including activity execution,
-/// child workflow management, timers, conditions, and workflow state management. It serves as the primary
-/// interface through which workflows interact with the Temporal system.
+/// `WorkflowContext` is the primary interface through which workflows interact with the
+/// Temporal system. It provides instance methods for all workflow operations including
+/// activity execution, child workflow management, timers, conditions, and workflow state
+/// management.
 ///
 /// ## Deterministic execution
 ///
-/// All operations performed through the Workflow API are deterministic and replay-safe.
+/// All operations performed through the `WorkflowContext` API are deterministic and replay-safe.
 /// The API ensures that workflow executions are consistent across retries and replay scenarios.
 ///
 /// ## Usage
 ///
-/// The Workflow API uses task-local storage to access the current workflow context:
+/// The `WorkflowContext` is passed as a parameter to the workflow's `run` method and
+/// signal/update handlers:
 ///
 /// ```swift
-/// func run(input: MyInput) async throws -> MyOutput {
+/// mutating func run(context: WorkflowContext<Self>, input: MyInput) async throws -> MyOutput {
 ///     // Execute an activity
-///     let result = try await Workflow.executeActivity(
+///     let result = try await context.executeActivity(
 ///         MyActivity.self,
 ///         options: .init(startToCloseTimeout: .seconds(30)),
 ///         input: "hello"
 ///     )
 ///
 ///     // Sleep for a duration
-///     try await Workflow.sleep(for: .seconds(5))
+///     try await context.sleep(for: .seconds(5))
 ///
 ///     // Wait for a condition
-///     try await Workflow.condition { someState == expectedValue }
+///     try await context.condition { someState == expectedValue }
 ///
 ///     return result
 /// }
 /// ```
 ///
 /// - Important: This type is only valid for use within the scope of a workflow execution.
-public struct Workflow: Sendable {
-    @TaskLocal package static var context: WorkflowContext?
-    @TaskLocal package static var _currentUpdateInfo: WorkflowUpdateInfo?
+public struct WorkflowContext<Workflow: WorkflowDefinition>: @unchecked Sendable {
+    let internalContext: InternalWorkflowContext
+    let stateBox: ArcBox<Workflow>
 
-    private static var _context: WorkflowContext {
-        guard let context = context else {
-            fatalError("Workflow context is not available. This API can only be used within a workflow execution.")
-        }
-        return context
+    init(internalContext: InternalWorkflowContext, stateBox: ArcBox<Workflow>) {
+        self.internalContext = internalContext
+        self.stateBox = stateBox
+    }
+
+    // MARK: - State Access
+
+    /// Mutates the workflow state using a closure.
+    ///
+    /// The closure receives a mutable reference to the workflow struct.
+    ///
+    /// - Parameter mutator: A closure that receives a mutable reference to the workflow struct.
+    public func mutateState(_ mutator: (inout Workflow) -> Void) {
+        stateBox.withMutableValue(mutator)
+    }
+
+    /// Mutates the workflow state using a closure and returns a value.
+    ///
+    /// - Parameter mutator: A closure that receives a mutable reference to the workflow struct
+    ///   and returns a value.
+    /// - Returns: The value returned by the closure.
+    public func mutateState<Return>(_ mutator: (inout Workflow) -> Return) -> Return {
+        stateBox.withMutableValue(mutator)
     }
 
     /// A boolean value that indicates whether the current code is executing within a workflow context.
     public static var inWorkflow: Bool {
-        context != nil
+        InternalWorkflowContext.current != nil
     }
 
     /// Information about the currently executing update, if any.
@@ -73,7 +93,7 @@ public struct Workflow: Sendable {
     /// or update validator. Returns `nil` when called outside of an update context
     /// (e.g., from the main workflow run method, signal handlers, or query handlers).
     public static var currentUpdateInfo: WorkflowUpdateInfo? {
-        _currentUpdateInfo
+        InternalWorkflowContext.currentUpdateInfo
     }
 
     /// The current worker deployment version for this task.
@@ -82,24 +102,24 @@ public struct Workflow: Sendable {
     /// If this worker is the one executing this task for the first time and has a deployment version set,
     /// then its ID will be used. This value may change over the lifetime of the workflow run, but is
     /// deterministic and safe to use for branching.
-    public static var currentDeploymentVersion: DeploymentVersion? {
-        self._context.currentDeploymentVersion
+    public var currentDeploymentVersion: DeploymentVersion? {
+        self.internalContext.currentDeploymentVersion
     }
 
     /// Information about the current workflow execution.
     ///
     /// Provides access to workflow metadata including identifiers, timing information,
     /// configuration, and parent workflow details.
-    public static var info: WorkflowInfo {
-        self._context.info
+    public var info: WorkflowInfo {
+        self.internalContext.info
     }
 
     /// The data converter used for payload serialization and deserialization.
     ///
     /// This converter handles the transformation between Swift types and Temporal's
     /// internal payload format.
-    public static var payloadConverter: any PayloadConverter {
-        self._context.payloadConverter
+    public var payloadConverter: any PayloadConverter {
+        self.internalContext.payloadConverter
     }
 
     /// A deterministic random number generator for workflow use.
@@ -111,11 +131,11 @@ public struct Workflow: Sendable {
     /// ## Usage
     ///
     /// ```swift
-    /// var rng = Workflow.randomNumberGenerator
+    /// var rng = context.randomNumberGenerator
     /// let randomValue = Int.random(in: 1...100, using: &rng)
     /// ```
-    public static var randomNumberGenerator: any RandomNumberGenerator {
-        self._context.randomNumberGenerator
+    public var randomNumberGenerator: any RandomNumberGenerator {
+        self.internalContext.randomNumberGenerator
     }
 
     /// Indicates whether all update and signal handlers have finished executing.
@@ -127,30 +147,30 @@ public struct Workflow: Sendable {
     /// ## Usage
     ///
     /// ```swift
-    /// func run(input: Void) async throws {
+    /// mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
     ///     // Perform workflow logic...
     ///
     ///     // Wait for all handlers to finish before returning
-    ///     try await Workflow.condition { Workflow.allHandlersFinished }
+    ///     try await context.condition { context.allHandlersFinished }
     /// }
     /// ```
     ///
     /// - Returns: `true` if all handlers have finished, `false` otherwise.
-    public static var allHandlersFinished: Bool {
-        self._context.allHandlersFinished
+    public var allHandlersFinished: Bool {
+        self.internalContext.allHandlersFinished
     }
 
     /// The current date of the workflow.
     ///
     /// This value is deterministic and safe for replays.
     /// Do not use any other sources of system time in workflows.
-    public static var now: Date {
-        self._context.now
+    public var now: Date {
+        self.internalContext.now
     }
 
     /// Indicates whether the workflow is currently in replay mode.
-    package static var isReplaying: Bool {
-        self._context.isReplaying
+    package var isReplaying: Bool {
+        self.internalContext.isReplaying
     }
 
     /// The current search attributes for the workflow.
@@ -159,8 +179,8 @@ public struct Workflow: Sendable {
     /// workflow executions. They are searchable through Temporal's visibility APIs.
     ///
     /// - Returns: A collection of the current search attributes.
-    public static var searchAttributes: SearchAttributeCollection {
-        self._context.searchAttributes
+    public var searchAttributes: SearchAttributeCollection {
+        self.internalContext.searchAttributes
     }
 
     /// User specified details for this workflow that may appear in UI/CLI.
@@ -169,40 +189,32 @@ public struct Workflow: Sendable {
     /// This can be in Temporal markdown format and can span multiple lines.
     ///
     /// - Important: This is currently experimental.
-    public static var currentDetails: String? {
-        get { self._context.currentDetails }
-        set {
-            guard let context = context else {
-                fatalError("Workflow context is not available. This API can only be used within a workflow execution.")
-            }
+    public var currentDetails: String? {
+        get { self.internalContext.currentDetails }
+        nonmutating set {
             // Use the internal method since the context struct is immutable
-            context.updateCurrentDetails(newValue)
+            self.internalContext.updateCurrentDetails(newValue)
         }
     }
 
     /// A boolean value that indicates whether continue as new was suggested.
-    public static var continueAsNewSuggested: Bool {
-        self._context.continueAsNewSuggested
+    public var continueAsNewSuggested: Bool {
+        self.internalContext.continueAsNewSuggested
     }
 
     /// Current number of events in the history.
-    public static var currentHistoryLength: Int {
-        self._context.currentHistoryLength
+    public var currentHistoryLength: Int {
+        self.internalContext.currentHistoryLength
     }
 
     /// Current size of the history in bytes.
-    public static var currentHistorySize: Int {
-        self._context.currentHistorySize
+    public var currentHistorySize: Int {
+        self.internalContext.currentHistorySize
     }
 
     /// The logger used for the workflow execution.
-    public static var logger: Logger {
-        self._context.logger
-    }
-
-    /// Ensures that state modifications of the workflow are safe.
-    package static func ensureWorkflowStateModificationIsSafe() {
-        self._context.ensureWorkflowStateModificationIsSafe()
+    public var logger: Logger {
+        self.internalContext.logger
     }
 
     /// Updates or inserts the specified search attributes.
@@ -216,13 +228,13 @@ public struct Workflow: Sendable {
     /// var attributes = SearchAttributeCollection()
     /// attributes[.customStringField("order_status")] = "processing"
     /// attributes[.customIntField("priority")] = 5
-    /// Workflow.upsertSearchAttributes(attributes)
+    /// context.upsertSearchAttributes(attributes)
     /// ```
     ///
     /// - Parameter searchAttributes: The search attributes to update or insert.
     ///   Specify `nil` for a specific attribute to unset it.
-    public static func upsertSearchAttributes(_ searchAttributes: SearchAttributeCollection) {
-        self._context.upsertSearchAttributes(searchAttributes)
+    public func upsertSearchAttributes(_ searchAttributes: SearchAttributeCollection) {
+        self.internalContext.upsertSearchAttributes(searchAttributes)
     }
 
     /// Updates or inserts search attributes using a builder block.
@@ -235,13 +247,13 @@ public struct Workflow: Sendable {
     /// ## Usage
     ///
     /// ```swift
-    /// Workflow.upsertSearchAttributes { attributes in
+    /// context.upsertSearchAttributes { attributes in
     ///     attributes[.customStringField("status")] = "completed"
     ///     attributes[.customIntField("score")] = 100
     ///     attributes[.customStringField("old_field")] = nil // Unset
     /// }
     /// ```
-    public static func upsertSearchAttributes(builder: (inout SearchAttributeCollection) -> Void) {
+    public func upsertSearchAttributes(builder: (inout SearchAttributeCollection) -> Void) {
         var searchAttributes = SearchAttributeCollection()
         builder(&searchAttributes)
         upsertSearchAttributes(searchAttributes)
@@ -253,16 +265,16 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Sleep for 5 seconds
-    /// try await Workflow.sleep(for: .seconds(5))
+    /// try await context.sleep(for: .seconds(5))
     ///
     /// // Sleep with a summary for debugging
-    /// try await Workflow.sleep(for: .minutes(1), summary: "waiting for external system")
+    /// try await context.sleep(for: .minutes(1), summary: "waiting for external system")
     /// ```
     ///
     /// - Parameter duration: The duration to sleep for.
     /// - Parameter summary: A simple string identifying this timer.
-    public static func sleep(for duration: Duration, summary: String? = nil) async throws {
-        try await self._context.sleep(for: duration, summary: summary)
+    public func sleep(for duration: Duration, summary: String? = nil) async throws {
+        try await self.internalContext.sleep(for: duration, summary: summary)
     }
 
     /// Runs a closure until a timeout is reached.
@@ -278,12 +290,12 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Run an operation with a 30-second timeout
-    /// let result = try await Workflow.timeout(for: .seconds(30)) {
+    /// let result = try await context.timeout(for: .seconds(30)) {
     ///     return try await performLongRunningOperation()
     /// }
     ///
     /// // Handle timeout by catching cancellation in the body
-    /// let result = try await Workflow.timeout(for: .minutes(2)) {
+    /// let result = try await context.timeout(for: .minutes(2)) {
     ///     do {
     ///         return try await externalServiceCall()
     ///     } catch is CancellationError {
@@ -297,19 +309,23 @@ public struct Workflow: Sendable {
     ///   - duration: The duration for the timeout.
     ///   - body: The closure to run with a given timeout.
     /// - Returns: The result of the closure.
-    public static func timeout<Return: Sendable, Failure: Error>(
+    public func timeout<Return: Sendable, Failure: Error>(
         for duration: Duration,
         body: @Sendable @escaping () async throws(Failure) -> Return
     ) async throws(Failure) -> Return {
-        try await self._context.timeout(for: duration, body: body)
+        try await self.internalContext.timeout(for: duration, body: body)
     }
 
     /// Waits for the given closure to return `true`.
     ///
+    /// The closure receives the current workflow state and is re-evaluated each time the
+    /// executor runs (e.g., after a signal handler mutates state). Since the state is passed
+    /// as a parameter, there is no need to capture `self`.
+    ///
     /// The closure must be side-effect free since it may be invoked frequently during
     /// executor iteration.
     ///
-    /// This is very commonly used to wait on a value to be set by a handler. Special care was taken to only resume up a single wait
+    /// This is very commonly used to wait on a value to be set by a handler. Special care was taken to only resume a single wait
     /// condition when it evaluates to true. Therefore if multiple wait conditions are waiting on the same thing, only one
     /// is resumed at a time, which means the code immediately following that wait condition can change the variable before
     /// other wait conditions are evaluated. This is a useful property for building mutexes/semaphores.
@@ -318,22 +334,40 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Wait for a boolean flag to become true
-    /// var isReady = false
-    /// try await Workflow.condition { isReady }
+    /// try await context.condition { $0.approved }
     ///
     /// // Wait for a counter to reach a threshold
-    /// var processedItems = 0
-    /// try await Workflow.condition { processedItems >= 10 }
+    /// try await context.condition { $0.processedItems >= 10 }
     ///
     /// // Wait for an optional value to be set
-    /// var result: String?
-    /// try await Workflow.condition { result != nil }
+    /// try await context.condition { $0.result != nil }
     /// ```
     ///
-    /// - Parameter condition: The closure to run many times to test if the condition evaluates to `true`.
+    /// - Parameter condition: A closure that receives the workflow state and returns `true`
+    ///   when the condition is satisfied.
     /// - Throws: A `CanceledError` if the waiting was cancelled.
-    public static func condition(_ condition: @escaping () -> Bool) async throws {
-        try await self._context.condition(condition)
+    public func condition(_ condition: @escaping (Workflow) -> Bool) async throws {
+        try await self.internalContext.condition { [stateBox] in
+            stateBox.withValue { condition($0) }
+        }
+    }
+
+    /// Waits for the given closure to return `true`.
+    ///
+    /// Use this overload when the condition does not depend on workflow state properties,
+    /// for example when waiting on a value from the context itself.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// // Wait for all handlers to finish
+    /// try await context.condition { context.allHandlersFinished }
+    /// ```
+    ///
+    /// - Parameter condition: A closure that returns `true` when the condition is satisfied.
+    /// - Throws: A `CanceledError` if the waiting was cancelled.
+    public func condition(_ condition: @escaping () -> Bool) async throws {
+        try await self.internalContext.condition(condition)
     }
 
     /// Patches a workflow to support versioning and backward compatibility.
@@ -348,7 +382,7 @@ public struct Workflow: Sendable {
     /// ## Usage
     ///
     /// ```swift
-    /// if Workflow.patch("fix-bug-123") {
+    /// if context.patch("fix-bug-123") {
     ///     // New code path with the bug fix
     ///     return await newImplementation()
     /// } else {
@@ -359,8 +393,8 @@ public struct Workflow: Sendable {
     ///
     /// - Parameter id: A unique identifier for this patch.
     /// - Returns: A boolean value that indicates whether this should take the newer patch path.
-    public static func patch(_ id: String) -> Bool {
-        self._context.patch(id)
+    public func patch(_ id: String) -> Bool {
+        self.internalContext.patch(id)
     }
 
     /// Marks a patch as deprecated.
@@ -372,14 +406,14 @@ public struct Workflow: Sendable {
     /// ## Usage
     ///
     /// ```swift
-    /// Workflow.deprecatePatch("fix-bug-123")
+    /// context.deprecatePatch("fix-bug-123")
     /// // Old code path can now be safely removed
     /// return await newImplementation()
     /// ```
     ///
     /// - Parameter id: The patch identifier to deprecate.
-    public static func deprecatePatch(_ id: String) {
-        self._context.deprecatePatch(id)
+    public func deprecatePatch(_ id: String) {
+        self.internalContext.deprecatePatch(id)
     }
 
     /// Execute an operation with a cancellation shield.
@@ -388,8 +422,8 @@ public struct Workflow: Sendable {
     /// For example, you can use this to execute an activity as part of a cleanup operation when your Workflow is getting cancelled.
     ///
     /// - Parameter operation: The operation that should be executed.
-    public static func withCancellationShield<Result: Sendable>(_ operation: sending @escaping () async throws -> Result) async throws -> Result {
-        try await self._context.withCancellationShield(operation)
+    public func withCancellationShield<Result: Sendable>(_ operation: sending @escaping () async throws -> Result) async throws -> Result {
+        try await self.internalContext.withCancellationShield(operation)
     }
 
     // MARK: - Activity Execution
@@ -400,14 +434,14 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Execute an activity with input
-    /// let result = try await Workflow.executeActivity(
+    /// let result = try await context.executeActivity(
     ///     ProcessOrderActivity.self,
     ///     options: .init(startToCloseTimeout: .seconds(30)),
     ///     input: OrderRequest(id: "order-123", items: items)
     /// )
     ///
     /// // Execute with retry policy
-    /// let emailResult = try await Workflow.executeActivity(
+    /// let emailResult = try await context.executeActivity(
     ///     SendEmailActivity.self,
     ///     options: .init(
     ///         startToCloseTimeout: .seconds(60),
@@ -425,7 +459,7 @@ public struct Workflow: Sendable {
     ///   - options: The activity's execution options.
     ///   - input: The activity's input data.
     /// - Returns: The activity's output.
-    public static func executeActivity<Activity: ActivityDefinition>(
+    public func executeActivity<Activity: ActivityDefinition>(
         _ activityType: Activity.Type = Activity.self,
         options: ActivityOptions,
         input: Activity.Input
@@ -444,13 +478,13 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Execute an activity with no input parameters
-    /// let systemInfo = try await Workflow.executeActivity(
+    /// let systemInfo = try await context.executeActivity(
     ///     GetSystemInfoActivity.self,
     ///     options: .init(startToCloseTimeout: .seconds(15))
     /// )
     ///
     /// // Health check activity
-    /// let isHealthy = try await Workflow.executeActivity(
+    /// let isHealthy = try await context.executeActivity(
     ///     HealthCheckActivity.self,
     ///     options: .init(startToCloseTimeout: .seconds(10))
     /// )
@@ -460,7 +494,7 @@ public struct Workflow: Sendable {
     ///   - activityType: The activity's type.
     ///   - options: The activity's execution options.
     /// - Returns: The activity's output.
-    public static func executeActivity<Activity: ActivityDefinition>(
+    public func executeActivity<Activity: ActivityDefinition>(
         _ activityType: Activity.Type = Activity.self,
         options: ActivityOptions
     ) async throws -> Activity.Output where Activity.Input == Void {
@@ -472,7 +506,7 @@ public struct Workflow: Sendable {
     /// - Parameters:
     ///   - activityType: The activity's type.
     ///   - options: The activity's execution options.
-    public static func executeActivity<Activity: ActivityDefinition>(
+    public func executeActivity<Activity: ActivityDefinition>(
         _ activityType: Activity.Type = Activity.self,
         options: ActivityOptions
     ) async throws where Activity.Input == Void, Activity.Output == Void {
@@ -485,7 +519,7 @@ public struct Workflow: Sendable {
     ///   - activityType: The activity's type.
     ///   - options: The activity's execution options.
     ///   - input: The activity's input data.
-    public static func executeActivity<Activity: ActivityDefinition>(
+    public func executeActivity<Activity: ActivityDefinition>(
         _ activityType: Activity.Type = Activity.self,
         options: ActivityOptions,
         input: Activity.Input
@@ -504,7 +538,7 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Execute activity by string name
-    /// let result: String = try await Workflow.executeActivity(
+    /// let result: String = try await context.executeActivity(
     ///     name: "ProcessPayment",
     ///     options: .init(startToCloseTimeout: .seconds(45)),
     ///     input: PaymentRequest(amount: 100.00, currency: "USD"),
@@ -512,7 +546,7 @@ public struct Workflow: Sendable {
     /// )
     ///
     /// // Execute with multiple inputs
-    /// let summary: OrderSummary = try await Workflow.executeActivity(
+    /// let summary: OrderSummary = try await context.executeActivity(
     ///     name: "GenerateOrderSummary",
     ///     options: .init(startToCloseTimeout: .seconds(30)),
     ///     input: orderID, customerInfo, items,
@@ -526,13 +560,13 @@ public struct Workflow: Sendable {
     ///   - input: The activity's input values.
     ///   - outputType: The activity's output type.
     /// - Returns: The activity's output.
-    public static func executeActivity<each Input: Sendable, Output: Sendable>(
+    public func executeActivity<each Input: Sendable, Output: Sendable>(
         name: String,
         options: ActivityOptions,
         input: repeat each Input,
         outputType: Output.Type = Output.self
     ) async throws -> Output {
-        try await self._context.executeActivity(name: name, options: options, input: repeat each input, outputType: outputType)
+        try await self.internalContext.executeActivity(name: name, options: options, input: repeat each input, outputType: outputType)
     }
 
     // MARK: Local Activity Execution
@@ -543,14 +577,14 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Execute a local activity with input
-    /// let result = try await Workflow.executeLocalActivity(
+    /// let result = try await context.executeLocalActivity(
     ///     ProcessOrderActivity.self,
     ///     options: .init(startToCloseTimeout: .seconds(30)),
     ///     input: OrderRequest(id: "order-123", items: items)
     /// )
     ///
     /// // Execute with retry policy
-    /// let emailResult = try await Workflow.executeLocalActivity(
+    /// let emailResult = try await context.executeLocalActivity(
     ///     SendEmailActivity.self,
     ///     options: .init(
     ///         startToCloseTimeout: .seconds(60),
@@ -568,7 +602,7 @@ public struct Workflow: Sendable {
     ///   - options: The activity's execution options.
     ///   - input: The activity's input data.
     /// - Returns: The activity's output.
-    public static func executeLocalActivity<Activity: ActivityDefinition>(
+    public func executeLocalActivity<Activity: ActivityDefinition>(
         _ activityType: Activity.Type = Activity.self,
         options: LocalActivityOptions,
         input: Activity.Input
@@ -587,13 +621,13 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Execute a local activity with no input parameters
-    /// let systemInfo = try await Workflow.executeLocalActivity(
+    /// let systemInfo = try await context.executeLocalActivity(
     ///     GetSystemInfoActivity.self,
     ///     options: .init(startToCloseTimeout: .seconds(15))
     /// )
     ///
     /// // Health check local activity
-    /// let isHealthy = try await Workflow.executeLocalActivity(
+    /// let isHealthy = try await context.executeLocalActivity(
     ///     HealthCheckActivity.self,
     ///     options: .init(startToCloseTimeout: .seconds(10))
     /// )
@@ -603,7 +637,7 @@ public struct Workflow: Sendable {
     ///   - activityType: The activity's type.
     ///   - options: The activity's execution options.
     /// - Returns: The activity's output.
-    public static func executeLocalActivity<Activity: ActivityDefinition>(
+    public func executeLocalActivity<Activity: ActivityDefinition>(
         _ activityType: Activity.Type = Activity.self,
         options: LocalActivityOptions
     ) async throws -> Activity.Output where Activity.Input == Void {
@@ -619,7 +653,7 @@ public struct Workflow: Sendable {
     /// - Parameters:
     ///   - activityType: The activity's type.
     ///   - options: The local activity's execution options.
-    public static func executeLocalActivity<Activity: ActivityDefinition>(
+    public func executeLocalActivity<Activity: ActivityDefinition>(
         _ activityType: Activity.Type = Activity.self,
         options: LocalActivityOptions
     ) async throws where Activity.Input == Void, Activity.Output == Void {
@@ -636,7 +670,7 @@ public struct Workflow: Sendable {
     ///   - activityType: The activity's type.
     ///   - options: The local activity's execution options.
     ///   - input: The activity's input data.
-    public static func executeLocalActivity<Activity: ActivityDefinition>(
+    public func executeLocalActivity<Activity: ActivityDefinition>(
         _ activityType: Activity.Type = Activity.self,
         options: LocalActivityOptions,
         input: Activity.Input
@@ -655,7 +689,7 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Execute local activity by string name
-    /// let result: String = try await Workflow.executeLocalActivity(
+    /// let result: String = try await context.executeLocalActivity(
     ///     name: "ProcessPayment",
     ///     options: .init(startToCloseTimeout: .seconds(45)),
     ///     input: PaymentRequest(amount: 100.00, currency: "USD"),
@@ -663,7 +697,7 @@ public struct Workflow: Sendable {
     /// )
     ///
     /// // Execute with multiple inputs
-    /// let summary: OrderSummary = try await Workflow.executeLocalActivity(
+    /// let summary: OrderSummary = try await context.executeLocalActivity(
     ///     name: "GenerateOrderSummary",
     ///     options: .init(startToCloseTimeout: .seconds(30)),
     ///     input: orderID, customerInfo, items,
@@ -677,13 +711,13 @@ public struct Workflow: Sendable {
     ///   - input: The local activity's input values.
     ///   - outputType: The local activity's output type.
     /// - Returns: The local activity's output.
-    public static func executeLocalActivity<each Input: Sendable, Output: Sendable>(
+    public func executeLocalActivity<each Input: Sendable, Output: Sendable>(
         name: String,
         options: LocalActivityOptions,
         input: repeat each Input,
         outputType: Output.Type = Output.self
     ) async throws -> Output {
-        try await self._context.executeLocalActivity(
+        try await self.internalContext.executeLocalActivity(
             name: name,
             options: options,
             input: repeat each input,
@@ -702,7 +736,7 @@ public struct Workflow: Sendable {
     /// ## Usage
     ///
     /// ```swift
-    /// let handle = Workflow.getExternalWorkflowHandle(
+    /// let handle = context.getExternalWorkflowHandle(
     ///     ExternalTargetWorkflow.self,
     ///     id: "other-workflow-id"
     /// )
@@ -719,13 +753,13 @@ public struct Workflow: Sendable {
     ///   - id: The workflow ID of the external workflow.
     ///   - runId: The optional run ID of the external workflow. If `nil`, targets the latest run.
     /// - Returns: A typed handle to the external workflow.
-    public static func getExternalWorkflowHandle<W: WorkflowDefinition>(
-        _ type: W.Type,
+    public func getExternalWorkflowHandle<ExternalW: WorkflowDefinition>(
+        _ type: ExternalW.Type,
         id: String,
         runId: String? = nil
-    ) -> ExternalWorkflowHandle<W> {
+    ) -> ExternalWorkflowHandle<ExternalW> {
         ExternalWorkflowHandle(
-            untypedHandle: self._context.getExternalWorkflowHandle(id: id, runId: runId)
+            untypedHandle: self.internalContext.getExternalWorkflowHandle(id: id, runId: runId)
         )
     }
 
@@ -738,7 +772,7 @@ public struct Workflow: Sendable {
     /// ## Usage
     ///
     /// ```swift
-    /// let handle = Workflow.getExternalWorkflowHandle(id: "other-workflow-id")
+    /// let handle = context.getExternalWorkflowHandle(id: "other-workflow-id")
     ///
     /// // Signal the external workflow
     /// try await handle.signal(signalName: "mySignal", input: signalData)
@@ -751,11 +785,11 @@ public struct Workflow: Sendable {
     ///   - id: The workflow ID of the external workflow.
     ///   - runId: The optional run ID of the external workflow. If `nil`, targets the latest run.
     /// - Returns: An untyped handle to the external workflow.
-    public static func getExternalWorkflowHandle(
+    public func getExternalWorkflowHandle(
         id: String,
         runId: String? = nil
     ) -> UntypedExternalWorkflowHandle {
-        self._context.getExternalWorkflowHandle(id: id, runId: runId)
+        self.internalContext.getExternalWorkflowHandle(id: id, runId: runId)
     }
 
     // MARK: - Child Workflow
@@ -764,13 +798,13 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Start a child workflow and get a handle
-    /// let childHandle = try await Workflow.startChildWorkflow(
+    /// let childHandle = try await context.startChildWorkflow(
     ///     ProcessOrderWorkflow.self,
     ///     input: OrderData(id: "order-456", customerID: "customer-789")
     /// )
     ///
     /// // Start with custom task queue
-    /// let reportHandle = try await Workflow.startChildWorkflow(
+    /// let reportHandle = try await context.startChildWorkflow(
     ///     GenerateReportWorkflow.self,
     ///     options: .init(
     ///         taskQueue: "reports-task-queue"
@@ -787,12 +821,12 @@ public struct Workflow: Sendable {
     ///   - options: The child workflow options.
     ///   - input: The input to the workflow.
     /// - Returns: A handle to the child workflow.
-    public static func startChildWorkflow<ChildWorkflow: WorkflowDefinition>(
+    public func startChildWorkflow<ChildWorkflow: WorkflowDefinition>(
         _ workflowType: ChildWorkflow.Type = ChildWorkflow.self,
         options: ChildWorkflowOptions = .init(),
         input: ChildWorkflow.Input
     ) async throws -> ChildWorkflowHandle<ChildWorkflow> {
-        try await self._context.startChildWorkflow(workflowType: workflowType, options: options, input: input)
+        try await self.internalContext.startChildWorkflow(workflowType: workflowType, options: options, input: input)
     }
 
     /// Starts a child workflow by name.
@@ -802,12 +836,12 @@ public struct Workflow: Sendable {
     ///   - options: The child workflow options.
     ///   - inputs: The inputs to the child workflow.
     /// - Returns: A handle to the child workflow.
-    public static func startChildWorkflow<each Input: Sendable>(
+    public func startChildWorkflow<each Input: Sendable>(
         name: String,
         options: ChildWorkflowOptions = .init(),
         inputs: repeat each Input
     ) async throws -> UntypedChildWorkflowHandle {
-        try await self._context.startChildWorkflow(name: name, options: options, inputs: repeat each inputs)
+        try await self.internalContext.startChildWorkflow(name: name, options: options, inputs: repeat each inputs)
     }
 
     /// Starts a child workflow and awaits the result.
@@ -816,17 +850,17 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Execute child workflow and wait for result
-    /// let processedOrder = try await Workflow.executeChildWorkflow(
+    /// let processedOrder = try await context.executeChildWorkflow(
     ///     ProcessOrderWorkflow.self,
     ///     input: OrderData(id: orderID, items: items, customerID: customerID)
     /// )
     ///
     /// // Execute multiple child workflows in parallel
-    /// async let emailResult = Workflow.executeChildWorkflow(
+    /// async let emailResult = context.executeChildWorkflow(
     ///     SendEmailWorkflow.self,
     ///     input: EmailNotification(to: customer.email, template: "order-confirmation")
     /// )
-    /// async let smsResult = Workflow.executeChildWorkflow(
+    /// async let smsResult = context.executeChildWorkflow(
     ///     SendSmsWorkflow.self,
     ///     input: SmsNotification(to: customer.phone, message: "Order confirmed")
     /// )
@@ -839,7 +873,7 @@ public struct Workflow: Sendable {
     ///   - options: The child workflow options.
     ///   - input: The input to the workflow.
     /// - Returns: The child workflow's output.
-    public static func executeChildWorkflow<ChildWorkflow: WorkflowDefinition>(
+    public func executeChildWorkflow<ChildWorkflow: WorkflowDefinition>(
         _ workflowType: ChildWorkflow.Type = ChildWorkflow.self,
         options: ChildWorkflowOptions = .init(),
         input: ChildWorkflow.Input
@@ -855,7 +889,7 @@ public struct Workflow: Sendable {
     ///   - inputs: The inputs to the child workflow.
     ///   - resultType: The type of the workflow's result.
     /// - Returns: The child workflow's output.
-    public static func executeChildWorkflow<each Input: Sendable, Result: Sendable>(
+    public func executeChildWorkflow<each Input: Sendable, Result: Sendable>(
         name: String,
         options: ChildWorkflowOptions = .init(),
         inputs: repeat each Input,
@@ -872,17 +906,17 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Get a string memo value
-    /// let customerType: String? = try await Workflow.getMemoValue(for: "customer_type")
+    /// let customerType: String? = try await context.getMemoValue(for: "customer_type")
     ///
     /// // Get a custom struct memo value
-    /// let config: WorkflowConfig? = try await Workflow.getMemoValue(for: "workflow_config")
+    /// let config: WorkflowConfig? = try await context.getMemoValue(for: "workflow_config")
     ///
     /// // Handle optional memo values
-    /// let priority: Int? = try await Workflow.getMemoValue(for: "priority")
+    /// let priority: Int? = try await context.getMemoValue(for: "priority")
     /// let effectivePriority = priority ?? 1 // Default if not set
     ///
     /// // Check if memo exists and handle accordingly
-    /// if let experimentGroup: String = try await Workflow.getMemoValue(for: "experiment_group") {
+    /// if let experimentGroup: String = try await context.getMemoValue(for: "experiment_group") {
     ///     // Use experiment-specific logic
     ///     processExperimentalFeature(group: experimentGroup)
     /// } else {
@@ -894,11 +928,11 @@ public struct Workflow: Sendable {
     /// - Parameter key: The memo's key.
     /// - Parameter valueType: The memo's value's type.
     /// - Returns: The value if present, otherwise `nil`.
-    public static func getMemoValue<Value>(
+    public func getMemoValue<Value>(
         for key: String,
         as valueType: Value.Type = Value.self
     ) async throws -> Value? {
-        try await self._context.getMemoValue(for: key)
+        try await self.internalContext.getMemoValue(for: key)
     }
 
     /// Issues updates to the workflow memo.
@@ -907,7 +941,7 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Update memo with various data types
-    /// try await Workflow.upsertMemo([
+    /// try await context.upsertMemo([
     ///     "customer_id": "customer-123",
     ///     "order_total": 150.75,
     ///     "priority": 2,
@@ -915,13 +949,13 @@ public struct Workflow: Sendable {
     /// ])
     ///
     /// // Update specific memo fields
-    /// try await Workflow.upsertMemo([
+    /// try await context.upsertMemo([
     ///     "status": "processing",
     ///     "last_updated": Date().timeIntervalSince1970
     /// ])
     ///
     /// // Remove memo fields by setting to nil
-    /// try await Workflow.upsertMemo([
+    /// try await context.upsertMemo([
     ///     "temporary_flag": nil,  // Remove this field
     ///     "debug_info": nil       // Remove this field too
     /// ])
@@ -931,15 +965,15 @@ public struct Workflow: Sendable {
     ///     version: "2.1",
     ///     feature_flags: ["new_checkout": true]
     /// )
-    /// try await Workflow.upsertMemo([
+    /// try await context.upsertMemo([
     ///     "metadata": workflowMetadata
     /// ])
     /// ```
     ///
     /// - Parameter memo: Updates to apply. Value can be `nil` to effectively remove the
     ///   memo value.
-    public static func upsertMemo(_ memo: [String: (any Sendable)?]) async throws {
-        try await self._context.upsertMemo(memo)
+    public func upsertMemo(_ memo: [String: (any Sendable)?]) async throws {
+        try await self.internalContext.upsertMemo(memo)
     }
 
     // MARK: - Continue As New
@@ -950,8 +984,8 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Continue as new with updated input
-    /// if Workflow.continueAsNewSuggested {
-    ///     let continueError = try await Workflow.makeContinueAsNewError(
+    /// if context.continueAsNewSuggested {
+    ///     let continueError = try await context.makeContinueAsNewError(
     ///         options: .init(),
     ///         input: WorkflowInput(
     ///             processedItems: currentState.processedItems,
@@ -963,7 +997,7 @@ public struct Workflow: Sendable {
     ///
     /// // Continue with same input but different task queue
     /// if shouldMigrateToNewTaskQueue {
-    ///     let continueError = try await Workflow.makeContinueAsNewError(
+    ///     let continueError = try await context.makeContinueAsNewError(
     ///         options: .init(taskQueue: "new-task-queue-v2"),
     ///         input: currentInput
     ///     )
@@ -971,7 +1005,7 @@ public struct Workflow: Sendable {
     /// }
     ///
     /// // Continue with multiple parameters
-    /// let continueError = try await Workflow.makeContinueAsNewError(
+    /// let continueError = try await context.makeContinueAsNewError(
     ///     options: .init(),
     ///     input: newUserID, updatedConfig, processedCount
     /// )
@@ -983,11 +1017,11 @@ public struct Workflow: Sendable {
     ///   - input: The input values for the new workflow execution.
     /// - Returns: A continue-as-new error.
     /// - Throws: When the input, headers or memo fails to convert.
-    public static func makeContinueAsNewError<each Input: Sendable>(
+    public func makeContinueAsNewError<each Input: Sendable>(
         options: ContinueAsNewOptions,
         input: repeat each Input
     ) async throws -> ContinueAsNewError {
-        try await self._context.makeContinueAsNewError(
+        try await self.internalContext.makeContinueAsNewError(
             workflowName: self.info.workflowName,
             options: options,
             input: repeat each input
@@ -1002,7 +1036,7 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Continue as a different workflow type
-    /// throw try await Workflow.makeContinueAsNewError(
+    /// throw try await context.makeContinueAsNewError(
     ///     workflowType: ProcessingWorkflowV2.self,
     ///     options: .init(),
     ///     input: migratedInput
@@ -1015,13 +1049,13 @@ public struct Workflow: Sendable {
     ///   - input: The input values for the new workflow execution.
     /// - Returns: A continue-as-new error.
     /// - Throws: When the input, headers or memo fails to convert.
-    public static func makeContinueAsNewError<W: WorkflowDefinition, each Input: Sendable>(
-        workflowType: W.Type,
+    public func makeContinueAsNewError<OtherW: WorkflowDefinition, each Input: Sendable>(
+        workflowType: OtherW.Type,
         options: ContinueAsNewOptions = .init(),
         input: repeat each Input
     ) async throws -> ContinueAsNewError {
-        try await self._context.makeContinueAsNewError(
-            workflowName: W.name,
+        try await self.internalContext.makeContinueAsNewError(
+            workflowName: OtherW.name,
             options: options,
             input: repeat each input
         )
@@ -1036,7 +1070,7 @@ public struct Workflow: Sendable {
     ///
     /// ```swift
     /// // Continue as a different workflow by name
-    /// throw try await Workflow.makeContinueAsNewError(
+    /// throw try await context.makeContinueAsNewError(
     ///     workflowName: "ProcessingWorkflowV2",
     ///     options: .init(),
     ///     input: migratedInput
@@ -1049,12 +1083,12 @@ public struct Workflow: Sendable {
     ///   - input: The input values for the new workflow execution.
     /// - Returns: A continue-as-new error.
     /// - Throws: When the input, headers or memo fails to convert.
-    public static func makeContinueAsNewError<each Input: Sendable>(
+    public func makeContinueAsNewError<each Input: Sendable>(
         workflowName: String,
         options: ContinueAsNewOptions = .init(),
         input: repeat each Input
     ) async throws -> ContinueAsNewError {
-        try await self._context.makeContinueAsNewError(
+        try await self.internalContext.makeContinueAsNewError(
             workflowName: workflowName,
             options: options,
             input: repeat each input

--- a/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
@@ -66,6 +66,29 @@ public struct WorkflowContext<Workflow: WorkflowDefinition>: @unchecked Sendable
 
     /// Mutates the workflow state using a closure and returns a value.
     ///
+    /// Normally you can just mutate the state of the workflow by making you run method or the handler
+    /// mutating. However, you cannot capture `self` in escaping closures such as async let's or
+    /// child tasks. This method allows you to mutate the state safely in such closures.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// @WorkflowSignal
+    /// func addItem(context: WorkflowContext<Self>, input: Item) async throws {
+    ///     async let execute = {
+    ///         context.mutateState { workflow in
+    ///             workflow.items.append(input)
+    ///         }
+    ///         try await context.executeActivity(
+    ///             PersistItemActivity.self,
+    ///             options: .init(startToCloseTimeout: .seconds(10)),
+    ///             input: input
+    ///         )
+    ///     }
+    ///     try await execute
+    /// }
+    /// ```
+    ///
     /// - Parameter mutator: A closure that receives a mutable reference to the workflow struct
     ///   and returns a value.
     /// - Returns: The value returned by the closure.
@@ -83,7 +106,7 @@ public struct WorkflowContext<Workflow: WorkflowDefinition>: @unchecked Sendable
     /// Returns the update ID and name when called from within an update handler
     /// or update validator. Returns `nil` when called outside of an update context
     /// (e.g., from the main workflow run method, signal handlers, or query handlers).
-    public static var currentUpdateInfo: WorkflowUpdateInfo? {
+    public var currentUpdateInfo: WorkflowUpdateInfo? {
         InternalWorkflowContext.currentUpdateInfo
     }
 

--- a/Sources/Temporal/Worker/Workflow/WorkflowContextView.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowContextView.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+public import struct Foundation.Date
+
+/// A read-only context for queries, validators, and sync handlers.
+///
+/// `WorkflowContextView` provides access to live workflow metadata and state machine
+/// reads, but does not expose any command methods or state mutation capabilities.
+/// This ensures compile-time safety: queries and validators cannot issue commands
+/// or modify workflow state.
+///
+/// ## Available Information
+///
+/// - Static workflow metadata via ``info``
+/// - Live state machine reads: ``now``, ``isReplaying``, ``searchAttributes``, etc.
+/// - Raw randomness seed (but not the stateful RNG)
+///
+/// ## Not Available
+///
+/// - No command methods (sleep, executeActivity, etc.)
+/// - No state mutation
+/// - No stateful random number generator
+public struct WorkflowContextView: @unchecked Sendable {
+    /// The underlying state machine storage.
+    private let storage: WorkflowStateMachineStorage
+
+    /// Information about the current workflow execution.
+    public let info: WorkflowInfo
+
+    /// Creates a new workflow context view.
+    ///
+    /// - Parameters:
+    ///   - storage: The workflow state machine storage.
+    ///   - info: The workflow info.
+    package init(storage: WorkflowStateMachineStorage, info: WorkflowInfo) {
+        self.storage = storage
+        self.info = info
+    }
+
+    /// The current date of the workflow.
+    ///
+    /// This value is deterministic and safe for replays.
+    public var now: Date {
+        storage.now()
+    }
+
+    /// Indicates whether the workflow is currently in replay mode.
+    public var isReplaying: Bool {
+        storage.isReplaying()
+    }
+
+    /// The current search attributes for the workflow.
+    public var searchAttributes: SearchAttributeCollection {
+        storage.searchAttributes()
+    }
+
+    /// The current worker deployment version for this task.
+    public var currentDeploymentVersion: DeploymentVersion? {
+        storage.currentDeploymentVersion()
+    }
+
+    /// A boolean value that indicates whether continue as new was suggested.
+    public var continueAsNewSuggested: Bool {
+        storage.continueAsNewSuggested()
+    }
+
+    /// Current number of events in the history.
+    public var currentHistoryLength: Int {
+        storage.currentHistoryLength()
+    }
+
+    /// Current size of the history in bytes.
+    public var currentHistorySize: Int {
+        storage.currentHistorySize()
+    }
+
+    /// Indicates whether all update and signal handlers have finished executing.
+    public var allHandlersFinished: Bool {
+        storage.allHandlersFinished()
+    }
+
+    /// User specified details for this workflow that may appear in UI/CLI.
+    public var currentDetails: String? {
+        storage.currentDetails()
+    }
+
+    /// Information about the currently executing update, if any.
+    public var currentUpdateInfo: WorkflowUpdateInfo? {
+        InternalWorkflowContext.currentUpdateInfo
+    }
+}

--- a/Sources/Temporal/Worker/Workflow/WorkflowDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowDefinition.swift
@@ -28,17 +28,16 @@
 ///
 /// ```swift
 /// @Workflow
-/// final class OrderProcessingWorkflow: WorkflowDefinition {
-///     let orderRequest: OrderRequest
+/// struct OrderProcessingWorkflow {
+///     var orderRequest: OrderRequest?
 ///
 ///     init(input: OrderRequest) {
 ///         self.orderRequest = input
 ///     }
 ///
-///     func run(input: OrderRequest) async throws -> OrderResult {
-///         // Use Workflow static methods to perform workflow operations
-///         let result = try await Workflow.executeActivity(
-///             activityType: ProcessOrderActivity.self,
+///     mutating func run(context: WorkflowContext<Self>, input: OrderRequest) async throws -> OrderResult {
+///         let result = try await context.executeActivity(
+///             ProcessOrderActivity.self,
 ///             options: .init(startToCloseTimeout: .seconds(30)),
 ///             input: orderRequest
 ///         )
@@ -89,12 +88,14 @@ public protocol WorkflowDefinition: Sendable {
     ///
     /// This method contains the core workflow implementation and defines the orchestration
     /// of activities, child workflows, and other workflow operations.
-    /// Use ``Workflow`` to access the workflow execution context.
+    /// Use the provided ``WorkflowContext`` to access workflow operations.
     ///
-    /// - Parameter input: The workflow input.
+    /// - Parameters:
+    ///   - context: The workflow execution context providing access to all workflow operations.
+    ///   - input: The workflow input.
     /// - Returns: The workflow execution result.
     /// - Throws: Any error that causes the workflow to fail.
-    func run(input: Input) async throws -> Output
+    mutating func run(context: WorkflowContext<Self>, input: Input) async throws -> Output
 }
 
 extension WorkflowDefinition {

--- a/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
@@ -19,16 +19,6 @@ import SwiftProtobuf
 ///
 /// This type processes new workflow activations, handles the workflow's executor and sends any outbound commands.
 struct WorkflowInstance: Sendable {
-    /// Task local indicating whether the workflow state is currently frozen.
-    ///
-    /// When frozen, workflow operations are blocked to ensure deterministic execution. It is frozen in the following cases:
-    /// - Workflow initialization
-    /// - Query execution
-    /// - Update validation handler
-    /// - Intercepting calls
-    @TaskLocal
-    static var isWorkflowStateFrozen: Bool = false
-
     /// Task local indicating whether code is currently running on the WorkflowInstance.
     ///
     /// When true, ``WorkflowStateMachineStorage`` methods are allowed to be called from off the executor.
@@ -89,7 +79,7 @@ struct WorkflowInstance: Sendable {
                 outboundInterceptors.append(outbound)
             }
         }
-        self.implementation = .init(interceptors: inboundInterceptors)
+        self.implementation = .init(interceptors: inboundInterceptors, executor: self.executor)
         self.outboundInterceptors = outboundInterceptors
         self.logger = logger
     }
@@ -118,11 +108,12 @@ struct WorkflowInstance: Sendable {
         // 6. Continue from 4. until all wait conditions are checked
 
         // 1.
-        let workflow: WorkflowTaskExecutorIsolatedBox<Workflow>
+        let workflowStateBox: ArcBox<Workflow>
         let input: WorkflowTaskExecutorIsolatedBox<Workflow.Input>
-        let workflowContext: WorkflowContext
+        let workflowContext: InternalWorkflowContext
+        let publicContext: WorkflowContext<Workflow>
         do {
-            (workflow, input, workflowContext) = try await self.initializeWorkflow(
+            (workflowStateBox, input, workflowContext, publicContext) = try await self.initializeWorkflow(
                 activation,
                 workflowType: workflowType
             )
@@ -150,16 +141,18 @@ struct WorkflowInstance: Sendable {
             // 2.
             await self.applyJobs(
                 jobs: activation.jobs,
-                workflow: workflow,
+                workflowStateBox: workflowStateBox,
                 workflowContext: workflowContext,
+                publicContext: publicContext,
                 group: &group
             )
 
             // 3.
             self.startWorkflow(
-                workflow: workflow,
+                workflowStateBox: workflowStateBox,
                 input: input,
                 workflowContext: workflowContext,
+                publicContext: publicContext,
                 group: &group
             )
 
@@ -182,8 +175,9 @@ struct WorkflowInstance: Sendable {
                 // 2.
                 await self.applyJobs(
                     jobs: activation.jobs,
-                    workflow: workflow,
+                    workflowStateBox: workflowStateBox,
                     workflowContext: workflowContext,
+                    publicContext: publicContext,
                     group: &group
                 )
 
@@ -223,7 +217,7 @@ struct WorkflowInstance: Sendable {
     private func initializeWorkflow<Workflow: WorkflowDefinition>(
         _ activation: Coresdk.WorkflowActivation.WorkflowActivation,
         workflowType: Workflow.Type
-    ) async throws -> (WorkflowTaskExecutorIsolatedBox<Workflow>, WorkflowTaskExecutorIsolatedBox<Workflow.Input>, WorkflowContext) {
+    ) async throws -> (ArcBox<Workflow>, WorkflowTaskExecutorIsolatedBox<Workflow.Input>, InternalWorkflowContext, WorkflowContext<Workflow>) {
         guard case .initializeWorkflow(let initializeWorkflow) = activation.jobs.first?.variant else {
             throw ArgumentError(
                 message: "Expected first job to be initialize workflow job"
@@ -246,7 +240,7 @@ struct WorkflowInstance: Sendable {
             self.stateMachine.updateRandomnessSeed(initializeWorkflow.randomnessSeed)
         }
 
-        let workflowContext = WorkflowContext(
+        let workflowContext = InternalWorkflowContext(
             stateMachine: self.stateMachine,
             workflowInfo: WorkflowInfo(
                 initializeWorkflow: initializeWorkflow,
@@ -261,36 +255,37 @@ struct WorkflowInstance: Sendable {
             logger: self.logger,
         )
 
-        let workflowBox = WorkflowTaskExecutorIsolatedBox(
-            executor: self.executor,
-            wrapped: Self.$isWorkflowStateFrozen.withValue(true) {
-                // Context is available but frozen during initialization
-                // WorkflowContext.current will return nil due to frozen state
-                return Workflow(input: input)
-            }
-        )
+        let workflowStateBox = ArcBox(Workflow(input: input))
         let inputBox = WorkflowTaskExecutorIsolatedBox(
             executor: self.executor,
             wrapped: input
         )
-        return (workflowBox, inputBox, workflowContext)
+        let publicContext = WorkflowContext(
+            internalContext: workflowContext,
+            stateBox: workflowStateBox
+        )
+        return (workflowStateBox, inputBox, workflowContext, publicContext)
     }
 
     // Starts the workflows run method in a separate child task
     private func startWorkflow<Workflow: WorkflowDefinition>(
-        workflow: WorkflowTaskExecutorIsolatedBox<Workflow>,
+        workflowStateBox: ArcBox<Workflow>,
         input: WorkflowTaskExecutorIsolatedBox<Workflow.Input>,
-        workflowContext: WorkflowContext,
+        workflowContext: InternalWorkflowContext,
+        publicContext: WorkflowContext<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) {
         group.addTask(executorPreference: self.executor) {
             self.logger.trace("Intercepting workflow")
+            let workflow = workflowStateBox.value
             let workflowResult = await Result {
                 // Context is not frozen during normal workflow execution
                 try await self.implementation.executeWorkflow(
-                    workflow: workflow.wrapped,
+                    workflow: workflow,
                     context: workflowContext,
+                    publicContext: publicContext,
                     input: .init(
+                        info: workflowContext.info,
                         headers: workflowContext.info.headers,
                         input: input.wrapped
                     )
@@ -330,8 +325,9 @@ struct WorkflowInstance: Sendable {
     /// Applies the jobs of an activation.
     private func applyJobs<Workflow: WorkflowDefinition>(
         jobs: [Coresdk.WorkflowActivation.WorkflowActivationJob],
-        workflow: WorkflowTaskExecutorIsolatedBox<Workflow>,
-        workflowContext: WorkflowContext,
+        workflowStateBox: ArcBox<Workflow>,
+        workflowContext: InternalWorkflowContext,
+        publicContext: WorkflowContext<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) async {
         for job in jobs {
@@ -386,22 +382,24 @@ struct WorkflowInstance: Sendable {
             case .queryWorkflow(let queryWorkflow):
                 self.queryWorkflow(
                     queryWorkflow,
-                    workflow: workflow,
+                    workflowStateBox: workflowStateBox,
                     workflowContext: workflowContext,
                     group: &group
                 )
             case .signalWorkflow(let signalWorkflow):
                 self.signalWorkflow(
                     signalWorkflow,
-                    workflow: workflow,
+                    workflowStateBox: workflowStateBox,
                     workflowContext: workflowContext,
+                    publicContext: publicContext,
                     group: &group
                 )
             case .doUpdate(let updateWorkflow):
                 self.updateWorkflow(
                     updateWorkflow,
-                    workflow: workflow,
+                    workflowStateBox: workflowStateBox,
                     workflowContext: workflowContext,
+                    publicContext: publicContext,
                     group: &group
                 )
             case .resolveNexusOperation:
@@ -415,7 +413,7 @@ struct WorkflowInstance: Sendable {
     }
 
     /// Runs the executor until everything has yielded and all wait conditions have been processed.
-    private func runExecutor(context: WorkflowContext) {
+    private func runExecutor(context: InternalWorkflowContext) {
         while true {
             // 4.
             self.executor.run()
@@ -425,7 +423,7 @@ struct WorkflowInstance: Sendable {
             // executor again. This allows wait condition users to trust that the line after the
             // condition still has the condition satisfied.
             let continuationID = Self.$isOnWorkflowInstance.withValue(true) {
-                Workflow.$context.withValue(context) {
+                InternalWorkflowContext.$current.withValue(context) {
                     self.stateMachine.conditions().first(where: { $0.value() })?.key
                 }
             }
@@ -491,12 +489,13 @@ struct WorkflowInstance: Sendable {
 
     private func signalWorkflow<Workflow: WorkflowDefinition>(
         _ signalWorkflow: Coresdk.WorkflowActivation.SignalWorkflow,
-        workflow: WorkflowTaskExecutorIsolatedBox<Workflow>,
-        workflowContext: WorkflowContext,
+        workflowStateBox: ArcBox<Workflow>,
+        workflowContext: InternalWorkflowContext,
+        publicContext: WorkflowContext<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) {
         group.addTask(executorPreference: self.executor) {
-            let workflow = workflow.wrapped
+            let workflow = workflowStateBox.value
             guard let signal = Workflow.signals.first(where: { $0.name == signalWorkflow.signalName }) else {
                 self.logger.error(
                     "No signal handler found",
@@ -515,6 +514,7 @@ struct WorkflowInstance: Sendable {
                     workflow: workflow,
                     headers: signalWorkflow.headers,
                     context: workflowContext,
+                    publicContext: publicContext,
                     temporalPayloads: signalWorkflow.input
                 )
             }
@@ -525,7 +525,8 @@ struct WorkflowInstance: Sendable {
         signal: Signal,
         workflow: Signal.Workflow,
         headers: [String: Api.Common.V1.Payload],
-        context: WorkflowContext,
+        context: InternalWorkflowContext,
+        publicContext: WorkflowContext<Signal.Workflow>,
         temporalPayloads: [Api.Common.V1.Payload]
     ) async {
         let input: Signal.Input
@@ -548,7 +549,9 @@ struct WorkflowInstance: Sendable {
             try await implementation.handleSignal(
                 workflow: workflow,
                 context: context,
+                publicContext: publicContext,
                 input: .init(
+                    info: context.info,
                     name: signal.name,
                     definition: signal,
                     headers: headers,
@@ -576,12 +579,12 @@ struct WorkflowInstance: Sendable {
 
     private func queryWorkflow<Workflow: WorkflowDefinition>(
         _ queryWorkflow: Coresdk.WorkflowActivation.QueryWorkflow,
-        workflow: WorkflowTaskExecutorIsolatedBox<Workflow>,
-        workflowContext: WorkflowContext,
+        workflowStateBox: ArcBox<Workflow>,
+        workflowContext: InternalWorkflowContext,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) {
         group.addTask(executorPreference: self.executor) {
-            let workflow = workflow.wrapped
+            let workflow = workflowStateBox.value
             if queryWorkflow.queryType == "__temporal_workflow_metadata" {
                 await self.runMessageHandler(
                     name: queryWorkflow.queryType,
@@ -649,7 +652,7 @@ struct WorkflowInstance: Sendable {
         id: String,
         query: Query,
         workflow: Workflow,
-        context: WorkflowContext,
+        context: InternalWorkflowContext,
         headers: [String: Api.Common.V1.Payload],
         temporalPayloads: [Api.Common.V1.Payload]
     ) async where Query.Workflow == Workflow {
@@ -677,20 +680,18 @@ struct WorkflowInstance: Sendable {
                     LoggingKeys.workflowQueryName: "\(Query.name)",
                 ]
             )
-            let output = try Self.$isWorkflowStateFrozen.withValue(true) {
-                // Context is frozen during query execution to prevent side effects
-                try implementation.handleQuery(
-                    workflow: workflow,
-                    context: context,
-                    input: .init(
-                        id: id,
-                        name: Query.name,
-                        definition: query,
-                        headers: headers,
-                        input: input
-                    )
+            let output = try implementation.handleQuery(
+                workflow: workflow,
+                context: context,
+                input: .init(
+                    info: context.info,
+                    id: id,
+                    name: Query.name,
+                    definition: query,
+                    headers: headers,
+                    input: input
                 )
-            }
+            )
             self.logger.trace(
                 "Running query handler finished",
                 metadata: [
@@ -717,7 +718,7 @@ struct WorkflowInstance: Sendable {
 
     private func workflowMetadata<Workflow: WorkflowDefinition>(
         type: Workflow.Type,
-        context: WorkflowContext
+        context: InternalWorkflowContext
     ) -> Api.Sdk.V1.WorkflowMetadata {
         var definition = Api.Sdk.V1.WorkflowDefinition.with {
             $0.type = context.info.workflowType
@@ -765,12 +766,13 @@ struct WorkflowInstance: Sendable {
 
     private func updateWorkflow<Workflow: WorkflowDefinition>(
         _ updateWorkflow: Coresdk.WorkflowActivation.DoUpdate,
-        workflow: WorkflowTaskExecutorIsolatedBox<Workflow>,
-        workflowContext: WorkflowContext,
+        workflowStateBox: ArcBox<Workflow>,
+        workflowContext: InternalWorkflowContext,
+        publicContext: WorkflowContext<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) {
         group.addTask(executorPreference: self.executor) {
-            let workflow = workflow.wrapped
+            let workflow = workflowStateBox.value
             guard let update = Workflow.updates.first(where: { $0.name == updateWorkflow.name }) else {
                 self.logger.error(
                     "No update handler found",
@@ -799,6 +801,7 @@ struct WorkflowInstance: Sendable {
                     update: update,
                     workflow: workflow,
                     workflowContext: workflowContext,
+                    publicContext: publicContext,
                     headers: updateWorkflow.headers,
                     temporalPayloads: updateWorkflow.input
                 )
@@ -811,7 +814,8 @@ struct WorkflowInstance: Sendable {
         runValidator: Bool,
         update: Update,
         workflow: Workflow,
-        workflowContext: WorkflowContext,
+        workflowContext: InternalWorkflowContext,
+        publicContext: WorkflowContext<Workflow>,
         headers: [String: Api.Common.V1.Payload],
         temporalPayloads: [Api.Common.V1.Payload]
     ) async where Update.Workflow == Workflow {
@@ -848,20 +852,18 @@ struct WorkflowInstance: Sendable {
                     return
                 }
 
-                try Self.$isWorkflowStateFrozen.withValue(true) {
-                    // Context is frozen during update validation to prevent side effects
-                    try implementation.validateUpdate(
-                        workflow: workflow,
-                        context: workflowContext,
-                        input: .init(
-                            id: id,
-                            name: Update.name,
-                            definition: update,
-                            headers: headers,
-                            input: validatorInput
-                        )
+                try implementation.validateUpdate(
+                    workflow: workflow,
+                    context: workflowContext,
+                    input: .init(
+                        info: workflowContext.info,
+                        id: id,
+                        name: Update.name,
+                        definition: update,
+                        headers: headers,
+                        input: validatorInput
                     )
-                }
+                )
             } catch {
                 self.logger.debug(
                     "Update rejected",
@@ -897,7 +899,9 @@ struct WorkflowInstance: Sendable {
             let output = try await implementation.handleUpdate(
                 workflow: workflow,
                 context: workflowContext,
+                publicContext: publicContext,
                 input: .init(
+                    info: workflowContext.info,
                     id: id,
                     name: Update.name,
                     definition: update,
@@ -1036,21 +1040,22 @@ struct WorkflowInstance: Sendable {
 extension WorkflowInstance {
     struct Implementation: InterceptorImplementation {
         let interceptors: [any WorkflowInboundInterceptor]
+        let executor: WorkflowTaskExecutor
     }
 }
 
 extension WorkflowInstance.Implementation {
     func executeWorkflow<Workflow: WorkflowDefinition>(
         workflow: Workflow,
-        context: WorkflowContext,
+        context: InternalWorkflowContext,
+        publicContext: WorkflowContext<Workflow>,
         input: ExecuteWorkflowInput<Workflow>
     ) async throws -> Workflow.Output {
-        try await Temporal.Workflow.$context.withValue(context) {
-            try await WorkflowInstance.$isWorkflowStateFrozen.withValue(true) {
+        try await Temporal.InternalWorkflowContext.$currentExecutor.withValue(self.executor) {
+            try await Temporal.InternalWorkflowContext.$current.withValue(context) {
                 try await intercept((any WorkflowInboundInterceptor).executeWorkflow, input: input) { input in
-                    try await WorkflowInstance.$isWorkflowStateFrozen.withValue(false) {
-                        try await workflow.run(input: input.input)
-                    }
+                    var workflow = workflow
+                    return try await workflow.run(context: publicContext, input: input.input)
                 }
             }
         }
@@ -1058,18 +1063,18 @@ extension WorkflowInstance.Implementation {
 
     func handleSignal<Signal: WorkflowSignalDefinition>(
         workflow: Signal.Workflow,
-        context: WorkflowContext,
+        context: InternalWorkflowContext,
+        publicContext: WorkflowContext<Signal.Workflow>,
         input: HandleSignalInput<Signal>
     ) async throws {
-        try await Temporal.Workflow.$context.withValue(context) {
-            try await WorkflowInstance.$isWorkflowStateFrozen.withValue(true) {
+        try await Temporal.InternalWorkflowContext.$currentExecutor.withValue(self.executor) {
+            try await Temporal.InternalWorkflowContext.$current.withValue(context) {
                 try await intercept((any WorkflowInboundInterceptor).handleSignal, input: input) { input in
-                    try await WorkflowInstance.$isWorkflowStateFrozen.withValue(false) {
-                        try await input.definition.run(
-                            workflow: workflow,
-                            input: input.input
-                        )
-                    }
+                    try await input.definition.run(
+                        workflow: workflow,
+                        context: publicContext,
+                        input: input.input
+                    )
                 }
             }
         }
@@ -1077,18 +1082,16 @@ extension WorkflowInstance.Implementation {
 
     func handleQuery<Query: WorkflowQueryDefinition>(
         workflow: Query.Workflow,
-        context: WorkflowContext,
+        context: InternalWorkflowContext,
         input: HandleQueryInput<Query>
     ) throws -> Query.Output {
-        try Temporal.Workflow.$context.withValue(context) {
-            try WorkflowInstance.$isWorkflowStateFrozen.withValue(true) {
+        try Temporal.InternalWorkflowContext.$currentExecutor.withValue(self.executor) {
+            try Temporal.InternalWorkflowContext.$current.withValue(context) {
                 try intercept((any WorkflowInboundInterceptor).handleQuery, input: input) { input in
-                    try WorkflowInstance.$isWorkflowStateFrozen.withValue(false) {
-                        try input.definition.run(
-                            workflow: workflow,
-                            input: input.input
-                        )
-                    }
+                    try input.definition.run(
+                        workflow: workflow,
+                        input: input.input
+                    )
                 }
             }
         }
@@ -1096,21 +1099,21 @@ extension WorkflowInstance.Implementation {
 
     func handleUpdate<Update: WorkflowUpdateDefinition>(
         workflow: Update.Workflow,
-        context: WorkflowContext,
+        context: InternalWorkflowContext,
+        publicContext: WorkflowContext<Update.Workflow>,
         input: HandleUpdateInput<Update>
     ) async throws -> Update.Output {
-        try await Temporal.Workflow.$context.withValue(context) {
-            try await Temporal.Workflow.$_currentUpdateInfo.withValue(
-                WorkflowUpdateInfo(id: input.id, name: input.name)
-            ) {
-                try await WorkflowInstance.$isWorkflowStateFrozen.withValue(true) {
+        try await Temporal.InternalWorkflowContext.$currentExecutor.withValue(self.executor) {
+            try await Temporal.InternalWorkflowContext.$current.withValue(context) {
+                try await Temporal.InternalWorkflowContext.$currentUpdateInfo.withValue(
+                    WorkflowUpdateInfo(id: input.id, name: input.name)
+                ) {
                     try await intercept((any WorkflowInboundInterceptor).handleUpdate, input: input) { input in
-                        try await WorkflowInstance.$isWorkflowStateFrozen.withValue(false) {
-                            try await input.definition.run(
-                                workflow: workflow,
-                                input: input.input
-                            )
-                        }
+                        try await input.definition.run(
+                            workflow: workflow,
+                            context: publicContext,
+                            input: input.input
+                        )
                     }
                 }
             }
@@ -1119,18 +1122,16 @@ extension WorkflowInstance.Implementation {
 
     func validateUpdate<Update: WorkflowUpdateDefinition>(
         workflow: Update.Workflow,
-        context: WorkflowContext,
+        context: InternalWorkflowContext,
         input: HandleUpdateInput<Update>
     ) throws {
-        try Temporal.Workflow.$context.withValue(context) {
-            try Temporal.Workflow.$_currentUpdateInfo.withValue(
-                WorkflowUpdateInfo(id: input.id, name: input.name)
-            ) {
-                try WorkflowInstance.$isWorkflowStateFrozen.withValue(true) {
+        try Temporal.InternalWorkflowContext.$currentExecutor.withValue(self.executor) {
+            try Temporal.InternalWorkflowContext.$current.withValue(context) {
+                try Temporal.InternalWorkflowContext.$currentUpdateInfo.withValue(
+                    WorkflowUpdateInfo(id: input.id, name: input.name)
+                ) {
                     try intercept((any WorkflowInboundInterceptor).validateUpdate, input: input) { input in
-                        try WorkflowInstance.$isWorkflowStateFrozen.withValue(false) {
-                            try input.definition.validateInput(workflow: workflow, input.input)
-                        }
+                        try input.definition.validateInput(workflow: workflow, input.input)
                     }
                 }
             }

--- a/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
@@ -15,6 +15,19 @@
 import Logging
 import SwiftProtobuf
 
+/// Holds the state needed to drive a single workflow execution.
+struct WorkflowExecutionState<Workflow: WorkflowDefinition> {
+    /// The boxed workflow value, shared via `ArcBox` so mutations through
+    /// `@_WorkflowState` are visible across the workflow's run method and all handlers.
+    let workflowStateBox: ArcBox<Workflow>
+
+    /// The internal (package-level) workflow context used by the SDK internals.
+    let workflowContext: InternalWorkflowContext
+
+    /// The public workflow context passed to user-visible APIs (run, signal, update handlers).
+    let publicContext: WorkflowContext<Workflow>
+}
+
 /// A workflow runner is responsible for handling a single instance of a workflow.
 ///
 /// This type processes new workflow activations, handles the workflow's executor and sends any outbound commands.
@@ -108,12 +121,10 @@ struct WorkflowInstance: Sendable {
         // 6. Continue from 4. until all wait conditions are checked
 
         // 1.
-        let workflowStateBox: ArcBox<Workflow>
+        let executionState: WorkflowExecutionState<Workflow>
         let input: WorkflowTaskExecutorIsolatedBox<Workflow.Input>
-        let workflowContext: InternalWorkflowContext
-        let publicContext: WorkflowContext<Workflow>
         do {
-            (workflowStateBox, input, workflowContext, publicContext) = try await self.initializeWorkflow(
+            (executionState, input) = try await self.initializeWorkflow(
                 activation,
                 workflowType: workflowType
             )
@@ -141,23 +152,19 @@ struct WorkflowInstance: Sendable {
             // 2.
             await self.applyJobs(
                 jobs: activation.jobs,
-                workflowStateBox: workflowStateBox,
-                workflowContext: workflowContext,
-                publicContext: publicContext,
+                executionState: executionState,
                 group: &group
             )
 
             // 3.
             self.startWorkflow(
-                workflowStateBox: workflowStateBox,
+                executionState: executionState,
                 input: input,
-                workflowContext: workflowContext,
-                publicContext: publicContext,
                 group: &group
             )
 
             // 4.-6.
-            self.runExecutor(context: workflowContext)
+            self.runExecutor(context: executionState.workflowContext)
 
             // We are finished applying the very first activation
             // We have to send the activation completion now
@@ -175,14 +182,12 @@ struct WorkflowInstance: Sendable {
                 // 2.
                 await self.applyJobs(
                     jobs: activation.jobs,
-                    workflowStateBox: workflowStateBox,
-                    workflowContext: workflowContext,
-                    publicContext: publicContext,
+                    executionState: executionState,
                     group: &group
                 )
 
                 // 4.-6.
-                self.runExecutor(context: workflowContext)
+                self.runExecutor(context: executionState.workflowContext)
 
                 // If this throws we will tear everything down and exit since
                 // it indicates we failed to send the completion to the worker
@@ -209,7 +214,7 @@ struct WorkflowInstance: Sendable {
             // There might be outstanding continuations for wait conditions, activities, etc.. The cancel
             // should resume them but we have to run the executor one more time for the workflow run method
             // and any message handler to finish.
-            self.runExecutor(context: workflowContext)
+            self.runExecutor(context: executionState.workflowContext)
         }
     }
 
@@ -217,7 +222,7 @@ struct WorkflowInstance: Sendable {
     private func initializeWorkflow<Workflow: WorkflowDefinition>(
         _ activation: Coresdk.WorkflowActivation.WorkflowActivation,
         workflowType: Workflow.Type
-    ) async throws -> (ArcBox<Workflow>, WorkflowTaskExecutorIsolatedBox<Workflow.Input>, InternalWorkflowContext, WorkflowContext<Workflow>) {
+    ) async throws -> (WorkflowExecutionState<Workflow>, WorkflowTaskExecutorIsolatedBox<Workflow.Input>) {
         guard case .initializeWorkflow(let initializeWorkflow) = activation.jobs.first?.variant else {
             throw ArgumentError(
                 message: "Expected first job to be initialize workflow job"
@@ -264,29 +269,32 @@ struct WorkflowInstance: Sendable {
             internalContext: workflowContext,
             stateBox: workflowStateBox
         )
-        return (workflowStateBox, inputBox, workflowContext, publicContext)
+        let executionState = WorkflowExecutionState(
+            workflowStateBox: workflowStateBox,
+            workflowContext: workflowContext,
+            publicContext: publicContext
+        )
+        return (executionState, inputBox)
     }
 
     // Starts the workflows run method in a separate child task
     private func startWorkflow<Workflow: WorkflowDefinition>(
-        workflowStateBox: ArcBox<Workflow>,
+        executionState: WorkflowExecutionState<Workflow>,
         input: WorkflowTaskExecutorIsolatedBox<Workflow.Input>,
-        workflowContext: InternalWorkflowContext,
-        publicContext: WorkflowContext<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) {
         group.addTask(executorPreference: self.executor) {
             self.logger.trace("Intercepting workflow")
-            let workflow = workflowStateBox.value
+            let workflow = executionState.workflowStateBox.value
             let workflowResult = await Result {
                 // Context is not frozen during normal workflow execution
                 try await self.implementation.executeWorkflow(
                     workflow: workflow,
-                    context: workflowContext,
-                    publicContext: publicContext,
+                    context: executionState.workflowContext,
+                    publicContext: executionState.publicContext,
                     input: .init(
-                        info: workflowContext.info,
-                        headers: workflowContext.info.headers,
+                        info: executionState.workflowContext.info,
+                        headers: executionState.workflowContext.info.headers,
                         input: input.wrapped
                     )
                 )
@@ -325,9 +333,7 @@ struct WorkflowInstance: Sendable {
     /// Applies the jobs of an activation.
     private func applyJobs<Workflow: WorkflowDefinition>(
         jobs: [Coresdk.WorkflowActivation.WorkflowActivationJob],
-        workflowStateBox: ArcBox<Workflow>,
-        workflowContext: InternalWorkflowContext,
-        publicContext: WorkflowContext<Workflow>,
+        executionState: WorkflowExecutionState<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) async {
         for job in jobs {
@@ -382,24 +388,19 @@ struct WorkflowInstance: Sendable {
             case .queryWorkflow(let queryWorkflow):
                 self.queryWorkflow(
                     queryWorkflow,
-                    workflowStateBox: workflowStateBox,
-                    workflowContext: workflowContext,
+                    executionState: executionState,
                     group: &group
                 )
             case .signalWorkflow(let signalWorkflow):
                 self.signalWorkflow(
                     signalWorkflow,
-                    workflowStateBox: workflowStateBox,
-                    workflowContext: workflowContext,
-                    publicContext: publicContext,
+                    executionState: executionState,
                     group: &group
                 )
             case .doUpdate(let updateWorkflow):
                 self.updateWorkflow(
                     updateWorkflow,
-                    workflowStateBox: workflowStateBox,
-                    workflowContext: workflowContext,
-                    publicContext: publicContext,
+                    executionState: executionState,
                     group: &group
                 )
             case .resolveNexusOperation:
@@ -489,13 +490,11 @@ struct WorkflowInstance: Sendable {
 
     private func signalWorkflow<Workflow: WorkflowDefinition>(
         _ signalWorkflow: Coresdk.WorkflowActivation.SignalWorkflow,
-        workflowStateBox: ArcBox<Workflow>,
-        workflowContext: InternalWorkflowContext,
-        publicContext: WorkflowContext<Workflow>,
+        executionState: WorkflowExecutionState<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) {
         group.addTask(executorPreference: self.executor) {
-            let workflow = workflowStateBox.value
+            let workflow = executionState.workflowStateBox.value
             guard let signal = Workflow.signals.first(where: { $0.name == signalWorkflow.signalName }) else {
                 self.logger.error(
                     "No signal handler found",
@@ -513,8 +512,8 @@ struct WorkflowInstance: Sendable {
                     signal: signal,
                     workflow: workflow,
                     headers: signalWorkflow.headers,
-                    context: workflowContext,
-                    publicContext: publicContext,
+                    context: executionState.workflowContext,
+                    publicContext: executionState.publicContext,
                     temporalPayloads: signalWorkflow.input
                 )
             }
@@ -579,12 +578,11 @@ struct WorkflowInstance: Sendable {
 
     private func queryWorkflow<Workflow: WorkflowDefinition>(
         _ queryWorkflow: Coresdk.WorkflowActivation.QueryWorkflow,
-        workflowStateBox: ArcBox<Workflow>,
-        workflowContext: InternalWorkflowContext,
+        executionState: WorkflowExecutionState<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) {
         group.addTask(executorPreference: self.executor) {
-            let workflow = workflowStateBox.value
+            let workflow = executionState.workflowStateBox.value
             if queryWorkflow.queryType == "__temporal_workflow_metadata" {
                 await self.runMessageHandler(
                     name: queryWorkflow.queryType,
@@ -592,7 +590,7 @@ struct WorkflowInstance: Sendable {
                     unfinishedPolicy: .abandon
                 ) {
                     do {
-                        let metadata = workflowMetadata(type: Workflow.self, context: workflowContext)
+                        let metadata = workflowMetadata(type: Workflow.self, context: executionState.workflowContext)
                         // Use the default data converter as this query will be
                         // used for displaying information in the Temporal UI.
                         let payload = try await DataConverter.default.convertValue(metadata)
@@ -640,7 +638,7 @@ struct WorkflowInstance: Sendable {
                     id: queryWorkflow.queryID,
                     query: query,
                     workflow: workflow,
-                    context: workflowContext,
+                    context: executionState.workflowContext,
                     headers: queryWorkflow.headers,
                     temporalPayloads: queryWorkflow.arguments
                 )
@@ -766,13 +764,11 @@ struct WorkflowInstance: Sendable {
 
     private func updateWorkflow<Workflow: WorkflowDefinition>(
         _ updateWorkflow: Coresdk.WorkflowActivation.DoUpdate,
-        workflowStateBox: ArcBox<Workflow>,
-        workflowContext: InternalWorkflowContext,
-        publicContext: WorkflowContext<Workflow>,
+        executionState: WorkflowExecutionState<Workflow>,
         group: inout ThrowingTaskGroup<Void, any Error>
     ) {
         group.addTask(executorPreference: self.executor) {
-            let workflow = workflowStateBox.value
+            let workflow = executionState.workflowStateBox.value
             guard let update = Workflow.updates.first(where: { $0.name == updateWorkflow.name }) else {
                 self.logger.error(
                     "No update handler found",
@@ -800,8 +796,8 @@ struct WorkflowInstance: Sendable {
                     runValidator: updateWorkflow.runValidator,
                     update: update,
                     workflow: workflow,
-                    workflowContext: workflowContext,
-                    publicContext: publicContext,
+                    workflowContext: executionState.workflowContext,
+                    publicContext: executionState.publicContext,
                     headers: updateWorkflow.headers,
                     temporalPayloads: updateWorkflow.input
                 )
@@ -1090,6 +1086,7 @@ extension WorkflowInstance.Implementation {
                 try intercept((any WorkflowInboundInterceptor).handleQuery, input: input) { input in
                     try input.definition.run(
                         workflow: workflow,
+                        view: WorkflowContextView(storage: context.stateMachine, info: context.info),
                         input: input.input
                     )
                 }

--- a/Sources/Temporal/Worker/Workflow/WorkflowQueryDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowQueryDefinition.swift
@@ -29,18 +29,17 @@
 ///
 /// ```swift
 /// @Workflow
-/// final class OrderProcessingWorkflow {
+/// struct OrderProcessingWorkflow {
 ///     var currentStatus = "pending"
 ///
-///     func run(input: OrderInput) async throws -> Void {
-///         currentStatus = "processing"
-///         // Process order logic
-///         try await processOrder()
-///         currentStatus = "finished"
+///     mutating func run(context: WorkflowContext<Self>, input: OrderInput) async throws -> Void {
+///         self.currentStatus = "processing"
+///         try await context.executeActivity(ProcessOrderActivity.self, options: .init(startToCloseTimeout: .seconds(30)))
+///         self.currentStatus = "finished"
 ///     }
 ///
 ///     @WorkflowQuery
-///     func getOrderStatus() throws -> String {
+///     func getOrderStatus(input: Void) -> String {
 ///         return currentStatus
 ///     }
 /// }
@@ -72,7 +71,6 @@ public protocol WorkflowQueryDefinition<Workflow>: Sendable {
     /// Executes the query and returns the requested information.
     ///
     /// This method is called when a query request is received for the workflow.
-    /// Use ``Workflow`` to access the workflow execution context.
     ///
     /// - Parameters:
     ///   - workflow: The workflow instance being queried.

--- a/Sources/Temporal/Worker/Workflow/WorkflowQueryDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowQueryDefinition.swift
@@ -44,6 +44,17 @@
 ///     }
 /// }
 /// ```
+///
+/// You can also define a query that receives a read-only ``WorkflowContextView`` as its first
+/// parameter. This is useful when the query needs access to live workflow metadata such as
+/// the current time or search attributes:
+///
+/// ```swift
+/// @WorkflowQuery
+/// func getStatusWithTime(context: WorkflowContextView, input: Void) -> String {
+///     return "\(currentStatus) as of \(context.now)"
+/// }
+/// ```
 public protocol WorkflowQueryDefinition<Workflow>: Sendable {
     /// The input type for the query.
     associatedtype Input: Sendable
@@ -74,10 +85,11 @@ public protocol WorkflowQueryDefinition<Workflow>: Sendable {
     ///
     /// - Parameters:
     ///   - workflow: The workflow instance being queried.
+    ///   - view: The read-only workflow context view.
     ///   - input: The input data for the query.
     /// - Returns: The query result.
     /// - Throws: Any error that occurs during query processing.
-    func run(workflow: Workflow, input: Input) throws -> Output
+    func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output
 }
 
 extension WorkflowQueryDefinition {

--- a/Sources/Temporal/Worker/Workflow/WorkflowSignalDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowSignalDefinition.swift
@@ -43,6 +43,22 @@
 ///     }
 /// }
 /// ```
+///
+/// You can also define an async signal handler that receives a ``WorkflowContext`` as its
+/// first parameter. This is useful when the signal handler needs to issue commands such
+/// as executing activities or sleeping:
+///
+/// ```swift
+/// @WorkflowSignal
+/// mutating func processApproval(context: WorkflowContext<Self>, input: ApprovalData) async throws {
+///     self.approvalReceived = true
+///     try await context.executeActivity(
+///         NotifyApprovalActivity.self,
+///         options: .init(startToCloseTimeout: .seconds(10)),
+///         input: input
+///     )
+/// }
+/// ```
 public protocol WorkflowSignalDefinition<Workflow>: Sendable {
     /// The input type for the signal.
     associatedtype Input: Sendable

--- a/Sources/Temporal/Worker/Workflow/WorkflowSignalDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowSignalDefinition.swift
@@ -29,19 +29,16 @@
 ///
 /// ```swift
 /// @Workflow
-/// final class OrderProcessingWorkflow {
+/// struct OrderProcessingWorkflow {
 ///     var approvalReceived = false
 ///
-///     func run(input: OrderInput) async throws -> Void {
-///         // Wait for approval signal
-///         try await context.condition { approvalReceived }
-///
-///         // Process the order
-///         try await processOrder()
+///     mutating func run(context: WorkflowContext<Self>, input: OrderInput) async throws -> Void {
+///         try await context.condition { $0.approvalReceived }
+///         try await context.executeActivity(ProcessOrderActivity.self, options: .init(startToCloseTimeout: .seconds(30)))
 ///     }
 ///
 ///     @WorkflowSignal
-///     func approveOrder() async throws {
+///     mutating func approveOrder(input: Void) {
 ///         self.approvalReceived = true
 ///     }
 /// }
@@ -75,13 +72,13 @@ public protocol WorkflowSignalDefinition<Workflow>: Sendable {
     /// Executes the signal handler logic.
     ///
     /// This method is called when a signal is received by the workflow.
-    /// Use ``Workflow`` static methods to access workflow operations.
     ///
     /// - Parameters:
     ///   - workflow: The workflow instance receiving the signal.
+    ///   - context: The workflow execution context.
     ///   - input: The input data sent with the signal.
     /// - Throws: Any error that occurs during signal processing.
-    func run(workflow: Workflow, input: Input) async throws
+    func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws
 }
 
 extension WorkflowSignalDefinition {

--- a/Sources/Temporal/Worker/Workflow/WorkflowState.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowState.swift
@@ -18,25 +18,49 @@
 /// the workflow's execution context. It enforces that state can only be accessed and
 /// modified on the workflow's dedicated executor, preventing race conditions and ensuring
 /// deterministic execution during workflow replay.
-public struct _WorkflowState<Value>: @unchecked Sendable {
-    /// The wrapped value that is protected by the workflow's executor.
+public struct _WorkflowState<Value: Sendable>: @unchecked Sendable {
+    /// The reference-backed box holding the value.
+    private let box: ArcBox<Value>
+
+    /// The wrapped value.
+    ///
+    /// The getter is non-mutating and always callable, reading through the shared box.
+    /// The setter is implicitly mutating (struct default), so it can only be called
+    /// from mutating methods, providing compile-time mutation control.
     public var value: Value {
         get {
-            Workflow.ensureWorkflowStateModificationIsSafe()
-            return self._value
+            Self.ensureOnWorkflowExecutor()
+            return box.value
         }
         set {
-            Workflow.ensureWorkflowStateModificationIsSafe()
-            self._value = newValue
+            Self.ensureOnWorkflowExecutor()
+            box.value = newValue
         }
     }
 
-    private var _value: Value
+    private static func ensureOnWorkflowExecutor() {
+        // Allow access if the workflow instance itself is modifying the state
+        if WorkflowInstance.isOnWorkflowInstance {
+            return
+        }
+
+        guard let executor = InternalWorkflowContext.currentExecutor else {
+            fatalError("Workflow state can only be accessed from within a workflow execution")
+        }
+        withUnsafeCurrentTask { currentTask in
+            guard let currentTask else {
+                fatalError("Current task not found during workflow state access")
+            }
+            guard currentTask.unownedTaskExecutor == executor.asUnownedTaskExecutor() else {
+                fatalError("Workflow state can only be accessed from the workflow executor")
+            }
+        }
+    }
 
     /// Creates a new workflow state wrapper with the specified initial value.
     ///
     /// - Parameter initialValue: The initial value to be wrapped and managed by the workflow state.
     public init(initialValue: Value) {
-        self._value = initialValue
+        self.box = ArcBox(initialValue)
     }
 }

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
@@ -55,10 +55,6 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
         self.failureConverter = failureConverter
     }
 
-    func ensureWorkflowStateModificationIsSafe() {
-        self.ensureOnExecutor(access: .reading)
-    }
-
     func updateRandomnessSeed(_ seed: UInt64) {
         self.stateMachine.updateRandomnessSeed(seed)
     }
@@ -617,13 +613,6 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
         // Allow access if the workflow instance itself is modifying the state
         if WorkflowInstance.isOnWorkflowInstance {
             return
-        }
-
-        // Prevent any mutating state machine operations when context is frozen
-        if access == .mutating && WorkflowInstance.isWorkflowStateFrozen {
-            fatalError(
-                "WorkflowStateMachine operations are not allowed when context is frozen. This typically occurs during workflow initialization, query execution, or update validation."
-            )
         }
 
         // This is using custom logic instead of preconditionIsolated to ensure

--- a/Sources/Temporal/Worker/Workflow/WorkflowUpdateDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowUpdateDefinition.swift
@@ -29,27 +29,24 @@
 ///
 /// ```swift
 /// @Workflow
-/// final class OrderProcessingWorkflow {
+/// struct OrderProcessingWorkflow {
 ///     var orderItems: [OrderItem] = []
 ///     var currentStatus: OrderStatus = .pending
 ///
-///     func run(input: OrderInput) async throws -> OrderResult {
-///         // Process order logic
-///         currentStatus = .processing
-///         return try await processOrder()
+///     mutating func run(context: WorkflowContext<Self>, input: OrderInput) async throws -> OrderResult {
+///         self.currentStatus = .processing
+///         return try await context.executeActivity(
+///             ProcessOrderActivity.self,
+///             options: .init(startToCloseTimeout: .seconds(30)),
+///             input: input
+///         )
 ///     }
 ///
 ///     @WorkflowUpdate
-///     func changeStatus(newStatus: OrderStatus) async throws -> OrderStatus {
+///     mutating func changeStatus(context: WorkflowContext<Self>, input: OrderStatus) async throws -> OrderStatus {
 ///         let previousStatus = currentStatus
-///         currentStatus = newStatus
+///         self.currentStatus = input
 ///         return previousStatus
-///     }
-///
-///     @WorkflowUpdate
-///     func addOrderItem(item: OrderItem) async throws -> Int {
-///         orderItems.append(item)
-///         return orderItems.count
 ///     }
 /// }
 /// ```
@@ -97,14 +94,14 @@ public protocol WorkflowUpdateDefinition<Workflow>: Sendable {
     /// Executes the update and returns the result.
     ///
     /// This method is called when an update request is received for the workflow.
-    /// Use ``Workflow`` to access the workflow execution context.
     ///
     /// - Parameters:
     ///   - workflow: The workflow instance being updated.
+    ///   - context: The workflow execution context.
     ///   - input: The input data for the update.
     /// - Returns: The update result.
     /// - Throws: Any error that occurs during update processing.
-    func run(workflow: Workflow, input: Input) async throws -> Output
+    func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws -> Output
 }
 
 extension WorkflowUpdateDefinition {

--- a/Sources/TemporalMacros/WorkflowMacro.swift
+++ b/Sources/TemporalMacros/WorkflowMacro.swift
@@ -63,9 +63,12 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        guard let classDecl = declaration.as(ClassDeclSyntax.self) else {
-            throw MacroError(message: "Workflow macro can only be applied to classes")
+        // Only struct declarations are supported
+        let typeName: String
+        guard let structDecl = declaration.as(StructDeclSyntax.self) else {
+            throw MacroError(message: "@Workflow can only be applied to structs")
         }
+        typeName = structDecl.name.text
 
         var signalNames = [String]()
         var queryNames = [String]()
@@ -146,7 +149,7 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
 
                             // Check input type matches
                             let updateParams = functionDecl.signature.parameterClause.parameters
-                            if let updateParam = updateParams.first {
+                            if let updateParam = updateParams.first(where: { $0.firstName.text == "input" }) {
                                 let updateType = updateParam.type.description.trimmingCharacters(in: .whitespaces)
                                 let validatorType = validatorParam.type.description.trimmingCharacters(in: .whitespaces)
                                 if updateType != validatorType {
@@ -166,7 +169,7 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
                         context.diagnose(
                             Diagnostic(
                                 node: Syntax(updateAttribute),
-                                message: ValidatorError(message: "Validator method '\(validatorName)' not found in workflow class")
+                                message: ValidatorError(message: "Validator method '\(validatorName)' not found in workflow")
                             )
                         )
                     }
@@ -180,7 +183,7 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         if !signalNames.isEmpty {
             messageHandlerDecls.append(
                 """
-                \(accessModifier)static var signals: [any WorkflowSignalDefinition<\(raw: classDecl.name.text)>] {
+                \(accessModifier)static var signals: [any WorkflowSignalDefinition<\(raw: typeName)>] {
                     [\(raw: signalNames.lazy.map { "Self.\($0)" }.joined(separator: ", "))]
                 }
                 """
@@ -189,7 +192,7 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         if !queryNames.isEmpty {
             messageHandlerDecls.append(
                 """
-                \(accessModifier)static var queries: [any WorkflowQueryDefinition<\(raw: classDecl.name.text)>] {
+                \(accessModifier)static var queries: [any WorkflowQueryDefinition<\(raw: typeName)>] {
                     [\(raw: queryNames.lazy.map { "Self.\($0)" }.joined(separator: ", "))]
                 }
                 """
@@ -198,7 +201,7 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         if !updateNames.isEmpty {
             messageHandlerDecls.append(
                 """
-                \(accessModifier)static var updates: [any WorkflowUpdateDefinition<\(raw: classDecl.name.text)>] {
+                \(accessModifier)static var updates: [any WorkflowUpdateDefinition<\(raw: typeName)>] {
                     [\(raw: updateNames.lazy.map { "Self.\($0)" }.joined(separator: ", "))]
                 }
                 """
@@ -224,14 +227,12 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         }
 
         if !hasMatchingInitializer {
+            let modifiers: DeclModifierListSyntax = accessModifier
             emptyInitDecl = InitializerDeclSyntax(
-                modifiers: (accessModifier) + [
-                    .init(name: .keyword(.required))
-                ],
+                modifiers: modifiers,
                 signature: .init(
                     parameterClause: .init(parameters: [
                         FunctionParameterSyntax(firstName: .identifier("input"), type: IdentifierTypeSyntax(name: .identifier("Input")))
-                        // .init(firstName: "input", type: "Input")
                     ])
                 ),
                 bodyBuilder: {}

--- a/Sources/TemporalMacros/WorkflowMacro.swift
+++ b/Sources/TemporalMacros/WorkflowMacro.swift
@@ -227,9 +227,8 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         }
 
         if !hasMatchingInitializer {
-            let modifiers: DeclModifierListSyntax = accessModifier
             emptyInitDecl = InitializerDeclSyntax(
-                modifiers: modifiers,
+                modifiers: accessModifier,
                 signature: .init(
                     parameterClause: .init(parameters: [
                         FunctionParameterSyntax(firstName: .identifier("input"), type: IdentifierTypeSyntax(name: .identifier("Input")))

--- a/Sources/TemporalMacros/WorkflowQueryMacro.swift
+++ b/Sources/TemporalMacros/WorkflowQueryMacro.swift
@@ -22,7 +22,7 @@ public struct WorkflowQueryMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // Can only be used inside a workflow (struct or class)
+        // Can only be used inside a workflow struct
         guard let parent = context.lexicalContext.first else {
             throw MacroError(message: "@WorkflowQuery can only be used inside a workflow")
         }
@@ -55,19 +55,19 @@ public struct WorkflowQueryMacro: PeerMacro {
         let hasContextParam: Bool
         if parameters.count == 2 {
             guard parameters.first?.firstName.text == "context" else {
-                throw MacroError(message: "Workflow query first parameter must be called 'context'")
+                throw MacroError(message: "Workflow query first parameter must be called 'context' with type 'WorkflowContextView'")
             }
             guard parameters.dropFirst().first?.firstName.text == "input" else {
-                throw MacroError(message: "Workflow query second parameter must be called 'input'")
+                throw MacroError(message: "Workflow query second parameter must be called 'input' with a Sendable type")
             }
             hasContextParam = true
         } else if parameters.count == 1 {
             guard parameters.first?.firstName.text == "input" else {
-                throw MacroError(message: "Workflow query parameter must be called 'input'")
+                throw MacroError(message: "Workflow query parameter must be called 'input' with a Sendable type")
             }
             hasContextParam = false
         } else {
-            throw MacroError(message: "Workflow queries must have one or two parameters")
+            throw MacroError(message: "Workflow queries must have one parameter 'input' or two parameters 'context' and 'input'")
         }
 
         let input = hasContextParam ? parameters.dropFirst().first! : parameters.first!
@@ -86,6 +86,14 @@ public struct WorkflowQueryMacro: PeerMacro {
         }
 
         let queryName = functionDecl.name.text.capitalizingFirst()
+
+        let closureBody: String
+        if hasContextParam {
+            closureBody = "{ workflow, view, input in \(throwingQuery ? "try" : "") workflow.\(functionDecl.name.text)(context: view, input: input) }"
+        } else {
+            closureBody = "{ workflow, _, input in \(throwingQuery ? "try" : "") workflow.\(functionDecl.name.text)(input: input) }"
+        }
+
         return [
             """
             \(raw: rawAccessModifier)struct \(raw: queryName): WorkflowQueryDefinition {
@@ -93,12 +101,12 @@ public struct WorkflowQueryMacro: PeerMacro {
                 \(raw: rawAccessModifier)typealias Output = \(returnClause.type)
                 \(raw: rawAccessModifier)typealias Workflow = \(raw: parentName)
 
-                let _run: @Sendable (Workflow, Input) throws -> Output
-                init(run: @Sendable @escaping (Workflow, Input) throws -> Output) {
+                let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
                     self._run = run
                 }
-                \(raw: rawAccessModifier)func run(workflow: Workflow, input: Input) throws -> Output {
-                    try self._run(workflow, input)
+                \(raw: rawAccessModifier)func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output {
+                    try self._run(workflow, view, input)
                 }
                 \(nameDecl)
                 \(descriptionDecl)
@@ -106,7 +114,7 @@ public struct WorkflowQueryMacro: PeerMacro {
             """,
             """
             static var \(raw: functionDecl.name.text): \(raw: queryName) {
-                \(raw: queryName)(run: { \(raw: throwingQuery ? "try" : "") $0.\(raw: functionDecl.name.text)(input: $1) })
+                \(raw: queryName)(run: \(raw: closureBody))
             }
             """,
         ]

--- a/Sources/TemporalMacros/WorkflowQueryMacro.swift
+++ b/Sources/TemporalMacros/WorkflowQueryMacro.swift
@@ -22,15 +22,20 @@ public struct WorkflowQueryMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // Can only be used inside a workflow
-        guard let parent = context.lexicalContext.first,
-            let parentClass = parent.as(ClassDeclSyntax.self),
-            parentClass.attributes.contains(where: { element in
+        // Can only be used inside a workflow (struct or class)
+        guard let parent = context.lexicalContext.first else {
+            throw MacroError(message: "@WorkflowQuery can only be used inside a workflow")
+        }
+
+        let parentName: String
+        guard let structDecl = parent.as(StructDeclSyntax.self),
+            structDecl.attributes.contains(where: { element in
                 element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "Workflow"
             })
         else {
-            throw MacroError(message: "@WorkflowQuery can only be used inside a workflow class")
+            throw MacroError(message: "@WorkflowQuery can only be used inside a workflow struct")
         }
+        parentName = structDecl.name.text
 
         // Only methods can be queries
         guard let functionDecl = declaration.as(FunctionDeclSyntax.self) else {
@@ -46,17 +51,26 @@ public struct WorkflowQueryMacro: PeerMacro {
 
         let parameters = functionDecl.signature.parameterClause.parameters
 
-        // Queries must have one parameter (the input)
-        guard parameters.count == 1 else {
-            throw MacroError(message: "Workflow queries must have one parameter")
+        // Queries must have one or two parameters (input, and optionally context)
+        let hasContextParam: Bool
+        if parameters.count == 2 {
+            guard parameters.first?.firstName.text == "context" else {
+                throw MacroError(message: "Workflow query first parameter must be called 'context'")
+            }
+            guard parameters.dropFirst().first?.firstName.text == "input" else {
+                throw MacroError(message: "Workflow query second parameter must be called 'input'")
+            }
+            hasContextParam = true
+        } else if parameters.count == 1 {
+            guard parameters.first?.firstName.text == "input" else {
+                throw MacroError(message: "Workflow query parameter must be called 'input'")
+            }
+            hasContextParam = false
+        } else {
+            throw MacroError(message: "Workflow queries must have one or two parameters")
         }
 
-        // The parameter must be the input
-        guard parameters.first?.firstName.text == "input" else {
-            throw MacroError(message: "Workflow query parameter must be called 'input'")
-        }
-
-        let input = parameters.first!
+        let input = hasContextParam ? parameters.dropFirst().first! : parameters.first!
 
         let throwingQuery = functionDecl.signature.effectSpecifiers?.throwsClause?.throwsSpecifier.presence == .present
 
@@ -77,8 +91,8 @@ public struct WorkflowQueryMacro: PeerMacro {
             \(raw: rawAccessModifier)struct \(raw: queryName): WorkflowQueryDefinition {
                 \(raw: rawAccessModifier)typealias Input = \(input.type)
                 \(raw: rawAccessModifier)typealias Output = \(returnClause.type)
-                \(raw: rawAccessModifier)typealias Workflow = \(parentClass.name)
-                
+                \(raw: rawAccessModifier)typealias Workflow = \(raw: parentName)
+
                 let _run: @Sendable (Workflow, Input) throws -> Output
                 init(run: @Sendable @escaping (Workflow, Input) throws -> Output) {
                     self._run = run

--- a/Sources/TemporalMacros/WorkflowSignalMacro.swift
+++ b/Sources/TemporalMacros/WorkflowSignalMacro.swift
@@ -22,15 +22,20 @@ public struct WorkflowSignalMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // Can only be used inside a workflow
-        guard let parent = context.lexicalContext.first,
-            let parentClass = parent.as(ClassDeclSyntax.self),
-            parentClass.attributes.contains(where: { element in
+        // Can only be used inside a workflow (struct or class)
+        guard let parent = context.lexicalContext.first else {
+            throw MacroError(message: "@WorkflowSignal can only be used inside a workflow")
+        }
+
+        let parentName: String
+        guard let structDecl = parent.as(StructDeclSyntax.self),
+            structDecl.attributes.contains(where: { element in
                 element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "Workflow"
             })
         else {
-            throw MacroError(message: "@WorkflowSignal can only be used inside a workflow class")
+            throw MacroError(message: "@WorkflowSignal can only be used inside a workflow struct")
         }
+        parentName = structDecl.name.text
 
         // Only methods can be signals
         guard let functionDecl = declaration.as(FunctionDeclSyntax.self) else {
@@ -46,20 +51,30 @@ public struct WorkflowSignalMacro: PeerMacro {
 
         let parameters = functionDecl.signature.parameterClause.parameters
 
-        // Signals must have one parameter (the input)
-        guard parameters.count == 1 else {
-            throw MacroError(message: "Workflow signals must have one parameter")
+        // Signals must have one or two parameters (input, and optionally context)
+        let hasContextParam: Bool
+        if parameters.count == 2 {
+            guard parameters.first?.firstName.text == "context" else {
+                throw MacroError(message: "Workflow signal first parameter must be called 'context'")
+            }
+            guard parameters.dropFirst().first?.firstName.text == "input" else {
+                throw MacroError(message: "Workflow signal second parameter must be called 'input'")
+            }
+            hasContextParam = true
+        } else if parameters.count == 1 {
+            guard parameters.first?.firstName.text == "input" else {
+                throw MacroError(message: "Workflow signal parameter must be called 'input'")
+            }
+            hasContextParam = false
+        } else {
+            throw MacroError(message: "Workflow signals must have one or two parameters")
         }
 
-        // The parameter must be the input
-        guard parameters.first?.firstName.text == "input" else {
-            throw MacroError(message: "Workflow signal parameter must be called 'input'")
-        }
-
-        let input = parameters.first!
+        let input = hasContextParam ? parameters.dropFirst().first! : parameters.first!
 
         let throwingSignal = functionDecl.signature.effectSpecifiers?.throwsClause?.throwsSpecifier.presence == .present
         let asyncSignal = functionDecl.signature.effectSpecifiers?.asyncSpecifier?.presence == .present
+        let isMutating = functionDecl.modifiers.contains { $0.name.tokenKind == .keyword(.mutating) }
 
         let rawAccessModifier = functionDecl.modifiers.accessModifierPrefix(supportedModifiers: .allAccessModifiers)
 
@@ -77,18 +92,37 @@ public struct WorkflowSignalMacro: PeerMacro {
         }
 
         let signalName = functionDecl.name.text.capitalizingFirst()
+
+        // For mutating signals, the closure needs a mutable copy of the workflow.
+        // Since @_WorkflowState uses reference-backed boxes, mutations on the copy
+        // are visible through the shared boxes.
+        let closureBody: String
+        if isMutating && hasContextParam {
+            closureBody =
+                "{ workflow, context, input in var workflow = workflow; \(throwingSignal ? "try" : "") \(asyncSignal ? "await" : "") workflow.\(functionDecl.name.text)(context: context, input: input) }"
+        } else if isMutating {
+            closureBody =
+                "{ workflow, _, input in var workflow = workflow; \(throwingSignal ? "try" : "") \(asyncSignal ? "await" : "") workflow.\(functionDecl.name.text)(input: input) }"
+        } else if hasContextParam {
+            closureBody =
+                "{ workflow, context, input in \(throwingSignal ? "try" : "") \(asyncSignal ? "await" : "") workflow.\(functionDecl.name.text)(context: context, input: input) }"
+        } else {
+            closureBody =
+                "{ workflow, _, input in \(throwingSignal ? "try" : "") \(asyncSignal ? "await" : "") workflow.\(functionDecl.name.text)(input: input) }"
+        }
+
         return [
             """
             \(raw: rawAccessModifier)struct \(raw: signalName): WorkflowSignalDefinition {
                 \(raw: rawAccessModifier)typealias Input = \(input.type)
-                \(raw: rawAccessModifier)typealias Workflow = \(parentClass.name)
+                \(raw: rawAccessModifier)typealias Workflow = \(raw: parentName)
 
-                let _run: @Sendable (Workflow, Input) async throws -> Void
-                init(run: @Sendable @escaping (Workflow, Input) async throws -> Void) {
+                let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void
+                init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void) {
                     self._run = run
                 }
-                \(raw: rawAccessModifier)func run(workflow: Workflow, input: Input) async throws {
-                    try await self._run(workflow, input)
+                \(raw: rawAccessModifier)func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws {
+                    try await self._run(workflow, context, input)
                 }
                 \(nameDecl)
                 \(descriptionDecl)
@@ -97,7 +131,7 @@ public struct WorkflowSignalMacro: PeerMacro {
             """,
             """
             static var \(raw: functionDecl.name.text): \(raw: signalName) {
-                \(raw: signalName)(run: { \(raw: throwingSignal ? "try" : "") \(raw: asyncSignal ? "await" : "") $0.\(raw: functionDecl.name.text)(input: $1) })
+                \(raw: signalName)(run: \(raw: closureBody))
             }
             """,
         ]

--- a/Sources/TemporalMacros/WorkflowSignalMacro.swift
+++ b/Sources/TemporalMacros/WorkflowSignalMacro.swift
@@ -22,7 +22,7 @@ public struct WorkflowSignalMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // Can only be used inside a workflow (struct or class)
+        // Can only be used inside a workflow struct
         guard let parent = context.lexicalContext.first else {
             throw MacroError(message: "@WorkflowSignal can only be used inside a workflow")
         }
@@ -55,19 +55,19 @@ public struct WorkflowSignalMacro: PeerMacro {
         let hasContextParam: Bool
         if parameters.count == 2 {
             guard parameters.first?.firstName.text == "context" else {
-                throw MacroError(message: "Workflow signal first parameter must be called 'context'")
+                throw MacroError(message: "Workflow signal first parameter must be called 'context' with type 'WorkflowContext<Self>'")
             }
             guard parameters.dropFirst().first?.firstName.text == "input" else {
-                throw MacroError(message: "Workflow signal second parameter must be called 'input'")
+                throw MacroError(message: "Workflow signal second parameter must be called 'input' with a Sendable type")
             }
             hasContextParam = true
         } else if parameters.count == 1 {
             guard parameters.first?.firstName.text == "input" else {
-                throw MacroError(message: "Workflow signal parameter must be called 'input'")
+                throw MacroError(message: "Workflow signal parameter must be called 'input' with a Sendable type")
             }
             hasContextParam = false
         } else {
-            throw MacroError(message: "Workflow signals must have one or two parameters")
+            throw MacroError(message: "Workflow signals must have one parameter 'input' or two parameters 'context' and 'input'")
         }
 
         let input = hasContextParam ? parameters.dropFirst().first! : parameters.first!
@@ -96,20 +96,17 @@ public struct WorkflowSignalMacro: PeerMacro {
         // For mutating signals, the closure needs a mutable copy of the workflow.
         // Since @_WorkflowState uses reference-backed boxes, mutations on the copy
         // are visible through the shared boxes.
-        let closureBody: String
-        if isMutating && hasContextParam {
-            closureBody =
+        let closureBody: String =
+            switch (isMutating, hasContextParam) {
+            case (true, true):
                 "{ workflow, context, input in var workflow = workflow; \(throwingSignal ? "try" : "") \(asyncSignal ? "await" : "") workflow.\(functionDecl.name.text)(context: context, input: input) }"
-        } else if isMutating {
-            closureBody =
+            case (true, false):
                 "{ workflow, _, input in var workflow = workflow; \(throwingSignal ? "try" : "") \(asyncSignal ? "await" : "") workflow.\(functionDecl.name.text)(input: input) }"
-        } else if hasContextParam {
-            closureBody =
+            case (false, true):
                 "{ workflow, context, input in \(throwingSignal ? "try" : "") \(asyncSignal ? "await" : "") workflow.\(functionDecl.name.text)(context: context, input: input) }"
-        } else {
-            closureBody =
+            case (false, false):
                 "{ workflow, _, input in \(throwingSignal ? "try" : "") \(asyncSignal ? "await" : "") workflow.\(functionDecl.name.text)(input: input) }"
-        }
+            }
 
         return [
             """

--- a/Sources/TemporalMacros/WorkflowStateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowStateMacro.swift
@@ -44,7 +44,10 @@ public struct WorkflowStateMacro: AccessorMacro, PeerMacro {
             return []
         }
 
-        guard context.lexicalContext[0].as(ClassDeclSyntax.self) != nil else {
+        guard
+            context.lexicalContext[0].as(ClassDeclSyntax.self) != nil
+                || context.lexicalContext[0].as(StructDeclSyntax.self) != nil
+        else {
             return []
         }
 
@@ -86,7 +89,10 @@ public struct WorkflowStateMacro: AccessorMacro, PeerMacro {
             return []
         }
 
-        guard context.lexicalContext[0].as(ClassDeclSyntax.self) != nil else {
+        guard
+            context.lexicalContext[0].as(ClassDeclSyntax.self) != nil
+                || context.lexicalContext[0].as(StructDeclSyntax.self) != nil
+        else {
             return []
         }
 

--- a/Sources/TemporalMacros/WorkflowUpdateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowUpdateMacro.swift
@@ -22,7 +22,7 @@ public struct WorkflowUpdateMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // Can only be used inside a workflow (struct or class)
+        // Can only be used inside a workflow struct
         guard let parent = context.lexicalContext.first else {
             throw MacroError(message: "@WorkflowUpdate can only be used inside a workflow")
         }
@@ -50,22 +50,26 @@ public struct WorkflowUpdateMacro: PeerMacro {
         let hasContextParam: Bool
         if parameters.count == 2 {
             guard parameters.first?.firstName.text == "context" else {
-                throw MacroError(message: "Workflow update first parameter must be called 'context'")
+                throw MacroError(message: "Workflow update first parameter must be called 'context' with type 'WorkflowContext<Self>'")
             }
             guard parameters.dropFirst().first?.firstName.text == "input" else {
-                throw MacroError(message: "Workflow update second parameter must be called 'input'")
+                throw MacroError(message: "Workflow update second parameter must be called 'input' with a Sendable type")
             }
             hasContextParam = true
         } else if parameters.count == 1 {
             guard parameters.first?.firstName.text == "input" else {
-                throw MacroError(message: "Workflow update parameter must be called 'input'")
+                throw MacroError(message: "Workflow update parameter must be called 'input' with a Sendable type")
             }
             hasContextParam = false
         } else {
-            throw MacroError(message: "Workflow updates must have one or two parameters")
+            throw MacroError(message: "Workflow updates must have one parameter 'input' or two parameters 'context' and 'input'")
         }
 
         let input = hasContextParam ? parameters.dropFirst().first! : parameters.first!
+
+        let throwingUpdate = functionDecl.signature.effectSpecifiers?.throwsClause?.throwsSpecifier.presence == .present
+        let asyncUpdate = functionDecl.signature.effectSpecifiers?.asyncSpecifier?.presence == .present
+        let isMutating = functionDecl.modifiers.contains { $0.name.tokenKind == .keyword(.mutating) }
 
         let rawAccessModifier = functionDecl.modifiers.accessModifierPrefix(supportedModifiers: .allAccessModifiers)
 
@@ -84,7 +88,6 @@ public struct WorkflowUpdateMacro: PeerMacro {
 
         let validatorName = node.stringValueForArgument(named: "validator")
         let updateName = functionDecl.name.text.capitalizingFirst()
-        let isMutating = functionDecl.modifiers.contains { $0.name.tokenKind == .keyword(.mutating) }
 
         let initParams: String
         let initBody: String
@@ -110,16 +113,24 @@ public struct WorkflowUpdateMacro: PeerMacro {
         // For mutating updates, the closure needs a mutable copy of the workflow.
         // Since @_WorkflowState uses reference-backed boxes, mutations on the copy
         // are visible through the shared boxes.
+        let tryKeyword = throwingUpdate ? "try " : ""
+        let awaitKeyword = asyncUpdate ? "await " : ""
+        let returnKeyword = returnType != "Void" ? "return " : ""
+
         let runClosureBody: String
-        if isMutating && hasContextParam {
+        switch (isMutating, hasContextParam) {
+        case (true, true):
             runClosureBody =
-                "{ workflow, context, input in var workflow = workflow; return try await workflow.\(functionDecl.name.text)(context: context, input: input) }"
-        } else if isMutating {
-            runClosureBody = "{ workflow, _, input in var workflow = workflow; return try await workflow.\(functionDecl.name.text)(input: input) }"
-        } else if hasContextParam {
-            runClosureBody = "{ workflow, context, input in try await workflow.\(functionDecl.name.text)(context: context, input: input) }"
-        } else {
-            runClosureBody = "{ workflow, _, input in try await workflow.\(functionDecl.name.text)(input: input) }"
+                "{ workflow, context, input in var workflow = workflow; \(returnKeyword)\(tryKeyword)\(awaitKeyword)workflow.\(functionDecl.name.text)(context: context, input: input) }"
+        case (true, false):
+            runClosureBody =
+                "{ workflow, _, input in var workflow = workflow; \(returnKeyword)\(tryKeyword)\(awaitKeyword)workflow.\(functionDecl.name.text)(input: input) }"
+        case (false, true):
+            runClosureBody =
+                "{ workflow, context, input in \(returnKeyword)\(tryKeyword)\(awaitKeyword)workflow.\(functionDecl.name.text)(context: context, input: input) }"
+        case (false, false):
+            runClosureBody =
+                "{ workflow, _, input in \(returnKeyword)\(tryKeyword)\(awaitKeyword)workflow.\(functionDecl.name.text)(input: input) }"
         }
 
         let staticVarBody: String

--- a/Sources/TemporalMacros/WorkflowUpdateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowUpdateMacro.swift
@@ -22,15 +22,20 @@ public struct WorkflowUpdateMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // Can only be used inside a workflow
-        guard let parent = context.lexicalContext.first,
-            let parentClass = parent.as(ClassDeclSyntax.self),
-            parentClass.attributes.contains(where: { element in
+        // Can only be used inside a workflow (struct or class)
+        guard let parent = context.lexicalContext.first else {
+            throw MacroError(message: "@WorkflowUpdate can only be used inside a workflow")
+        }
+
+        let parentName: String
+        guard let structDecl = parent.as(StructDeclSyntax.self),
+            structDecl.attributes.contains(where: { element in
                 element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "Workflow"
             })
         else {
-            throw MacroError(message: "@WorkflowUpdate can only be used inside a workflow class")
+            throw MacroError(message: "@WorkflowUpdate can only be used inside a workflow struct")
         }
+        parentName = structDecl.name.text
 
         // Only methods can be updates
         guard let functionDecl = declaration.as(FunctionDeclSyntax.self) else {
@@ -41,17 +46,26 @@ public struct WorkflowUpdateMacro: PeerMacro {
         let returnType = functionDecl.signature.returnClause?.type.description ?? "Void"
         let parameters = functionDecl.signature.parameterClause.parameters
 
-        // Updates must have one parameter (the input)
-        guard parameters.count == 1 else {
-            throw MacroError(message: "Workflow updates must have one parameter")
+        // Updates must have one or two parameters (input, and optionally context)
+        let hasContextParam: Bool
+        if parameters.count == 2 {
+            guard parameters.first?.firstName.text == "context" else {
+                throw MacroError(message: "Workflow update first parameter must be called 'context'")
+            }
+            guard parameters.dropFirst().first?.firstName.text == "input" else {
+                throw MacroError(message: "Workflow update second parameter must be called 'input'")
+            }
+            hasContextParam = true
+        } else if parameters.count == 1 {
+            guard parameters.first?.firstName.text == "input" else {
+                throw MacroError(message: "Workflow update parameter must be called 'input'")
+            }
+            hasContextParam = false
+        } else {
+            throw MacroError(message: "Workflow updates must have one or two parameters")
         }
 
-        // The parameter must be the input
-        guard parameters.first?.firstName.text == "input" else {
-            throw MacroError(message: "Workflow update parameter must be called 'input'")
-        }
-
-        let input = parameters.first!
+        let input = hasContextParam ? parameters.dropFirst().first! : parameters.first!
 
         let rawAccessModifier = functionDecl.modifiers.accessModifierPrefix(supportedModifiers: .allAccessModifiers)
 
@@ -70,13 +84,14 @@ public struct WorkflowUpdateMacro: PeerMacro {
 
         let validatorName = node.stringValueForArgument(named: "validator")
         let updateName = functionDecl.name.text.capitalizingFirst()
+        let isMutating = functionDecl.modifiers.contains { $0.name.tokenKind == .keyword(.mutating) }
 
         let initParams: String
         let initBody: String
         var validatorDecl: DeclSyntax?
         if validatorName != nil {
             initParams =
-                "run: @Sendable @escaping (Workflow, Input) async throws -> Output, validate: @Sendable @escaping (Workflow, Input) throws -> Void"
+                "run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output, validate: @Sendable @escaping (Workflow, Input) throws -> Void"
             initBody = """
                 self._run = run
                             self._validate = validate
@@ -88,16 +103,31 @@ public struct WorkflowUpdateMacro: PeerMacro {
                         }
                 """
         } else {
-            initParams = "run: @Sendable @escaping (Workflow, Input) async throws -> Output"
+            initParams = "run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output"
             initBody = "self._run = run"
+        }
+
+        // For mutating updates, the closure needs a mutable copy of the workflow.
+        // Since @_WorkflowState uses reference-backed boxes, mutations on the copy
+        // are visible through the shared boxes.
+        let runClosureBody: String
+        if isMutating && hasContextParam {
+            runClosureBody =
+                "{ workflow, context, input in var workflow = workflow; return try await workflow.\(functionDecl.name.text)(context: context, input: input) }"
+        } else if isMutating {
+            runClosureBody = "{ workflow, _, input in var workflow = workflow; return try await workflow.\(functionDecl.name.text)(input: input) }"
+        } else if hasContextParam {
+            runClosureBody = "{ workflow, context, input in try await workflow.\(functionDecl.name.text)(context: context, input: input) }"
+        } else {
+            runClosureBody = "{ workflow, _, input in try await workflow.\(functionDecl.name.text)(input: input) }"
         }
 
         let staticVarBody: String
         if let validatorName = validatorName {
             staticVarBody =
-                "\(updateName)(run: { try await $0.\(functionDecl.name.text)(input: $1) }, validate: { try $0.\(validatorName)(input: $1) })"
+                "\(updateName)(run: \(runClosureBody), validate: { try $0.\(validatorName)(input: $1) })"
         } else {
-            staticVarBody = "\(updateName)(run: { try await $0.\(functionDecl.name.text)(input: $1) })"
+            staticVarBody = "\(updateName)(run: \(runClosureBody))"
         }
 
         return [
@@ -105,14 +135,14 @@ public struct WorkflowUpdateMacro: PeerMacro {
             \(raw: rawAccessModifier)struct \(raw: updateName): WorkflowUpdateDefinition {
                 \(raw: rawAccessModifier)typealias Input = \(input.type)
                 \(raw: rawAccessModifier)typealias Output = \(raw: returnType)
-                \(raw: rawAccessModifier)typealias Workflow = \(parentClass.name)
+                \(raw: rawAccessModifier)typealias Workflow = \(raw: parentName)
 
-                let _run: @Sendable (Workflow, Input) async throws -> Output
+                let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output
                 init(\(raw: initParams)) {
                     \(raw: initBody)
                 }
-                \(raw: rawAccessModifier)func run(workflow: Workflow, input: Input) async throws -> Output{
-                    try await self._run(workflow, input)
+                \(raw: rawAccessModifier)func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws -> Output{
+                    try await self._run(workflow, context, input)
                 }
                 \(nameDecl)
                 \(descriptionDecl)

--- a/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
+++ b/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
@@ -870,7 +870,7 @@ struct WorkflowMacrosTests {
             """
         )
         #expect(diagnostics.count == 1)
-        #expect(diagnostics.first?.message == "Validator method 'doesNotExist' not found in workflow class")
+        #expect(diagnostics.first?.message == "Validator method 'doesNotExist' not found in workflow")
         // Diagnostic should be on the @WorkflowUpdate attribute
         #expect(diagnostics.first?.node.description.contains("WorkflowUpdate") == true)
     }

--- a/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
+++ b/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
@@ -75,18 +75,18 @@ struct WorkflowMacrosTests {
                     typealias Output = String
                     typealias Workflow = Foo
 
-                    let _run: @Sendable (Workflow, Input) throws -> Output
-                    init(run: @Sendable @escaping (Workflow, Input) throws -> Output) {
+                    let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
                         self._run = run
                     }
-                    func run(workflow: Workflow, input: Input) throws -> Output {
-                        try self._run(workflow, input)
+                    func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output {
+                        try self._run(workflow, view, input)
                     }
                 }
 
                 static var fooQuery: FooQuery {
-                    FooQuery(run: {
-                            try $0.fooQuery(input: $1)
+                    FooQuery(run: { workflow, _, input in
+                            try workflow.fooQuery(input: input)
                         })
                 }
                 func fooUpdate(input: String) async throws -> Int {}
@@ -107,7 +107,7 @@ struct WorkflowMacrosTests {
 
                 static var fooUpdate: FooUpdate {
                     FooUpdate(run: { workflow, _, input in
-                            try await workflow.fooUpdate(input: input)
+                            return try await workflow.fooUpdate(input: input)
                         })
                 }
 
@@ -268,18 +268,18 @@ struct WorkflowMacrosTests {
                     \(modifierPrefix)typealias Output = String
                     \(modifierPrefix)typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) throws -> Output
-                    init(run: @Sendable @escaping (Workflow, Input) throws -> Output) {
+                    let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
                         self._run = run
                     }
-                    \(modifierPrefix)func run(workflow: Workflow, input: Input) throws -> Output{
-                        try self._run(workflow, input)
+                    \(modifierPrefix)func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output{
+                        try self._run(workflow, view, input)
                     }
                 }
 
                 static var foo: Foo {
-                    Foo(run: {
-                            try $0.foo(input: $1)
+                    Foo(run: { workflow, _, input in
+                            try workflow.foo(input: input)
                         })
                 }
                 \(modifierPrefix)func bar(input: Void) throws -> Int {
@@ -290,12 +290,12 @@ struct WorkflowMacrosTests {
                     \(modifierPrefix)typealias Output = Int
                     \(modifierPrefix)typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) throws -> Output
-                    init(run: @Sendable @escaping (Workflow, Input) throws -> Output) {
+                    let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
                         self._run = run
                     }
-                    \(modifierPrefix)func run(workflow: Workflow, input: Input) throws -> Output{
-                        try self._run(workflow, input)
+                    \(modifierPrefix)func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output{
+                        try self._run(workflow, view, input)
                     }
                     \(modifierPrefix)static var name: String {
                         "MyQuery"
@@ -306,8 +306,8 @@ struct WorkflowMacrosTests {
                 }
 
                 static var bar: Bar {
-                    Bar(run: {
-                            try $0.bar(input: $1)
+                    Bar(run: { workflow, _, input in
+                            try workflow.bar(input: input)
                         })
                 }
 
@@ -363,7 +363,7 @@ struct WorkflowMacrosTests {
 
                 static var foo: Foo {
                     Foo(run: { workflow, _, input in
-                            try await workflow.foo(input: input)
+                            return try await workflow.foo(input: input)
                         })
                 }
                 \(modifierPrefix)func bar(input: Void) throws -> String {
@@ -391,7 +391,7 @@ struct WorkflowMacrosTests {
 
                 static var bar: Bar {
                     Bar(run: { workflow, _, input in
-                            try await workflow.bar(input: input)
+                            return try workflow.bar(input: input)
                         })
                 }
 
@@ -707,7 +707,7 @@ struct WorkflowMacrosTests {
 
                 static var foo: Foo {
                     Foo(run: { workflow, _, input in
-                            try await workflow.foo(input: input)
+                            return try await workflow.foo(input: input)
                         })
                 }
 
@@ -767,7 +767,7 @@ struct WorkflowMacrosTests {
 
                 static var foo: Foo {
                     Foo(run: { workflow, _, input in
-                            try await workflow.foo(input: input)
+                            return try await workflow.foo(input: input)
                         }, validate: {
                             try $0.validateFoo(input: $1)
                         })

--- a/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
+++ b/Tests/TemporalMacrosTests/WorfklowMacrosTests.swift
@@ -25,9 +25,9 @@ struct WorkflowMacrosTests {
     func simple() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class Foo {
+            struct Foo {
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension Foo: WorkflowDefinition {
@@ -37,7 +37,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class Foo {}
+            struct Foo {}
             """
         )
         #expect(expectedOutput == actualOutput)
@@ -47,25 +47,25 @@ struct WorkflowMacrosTests {
     func accessModifier(modifier: String) throws {
         let (expectedOutput, _) = try parse(
             """
-            \(modifier) final class Foo {
+            \(modifier) struct Foo {
                 func fooSignal(input: String) async throws {}
 
                 struct FooSignal: WorkflowSignalDefinition {
                     typealias Input = String
                     typealias Workflow = Foo
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Void
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Void) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void) {
                         self._run = run
                     }
-                    func run(workflow: Workflow, input: Input) async throws {
-                        try await self._run(workflow, input)
+                    func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws {
+                        try await self._run(workflow, context, input)
                     }
                 }
 
                 static var fooSignal: FooSignal {
-                    FooSignal(run: {
-                            try await $0.fooSignal(input: $1)
+                    FooSignal(run: { workflow, _, input in
+                            try await workflow.fooSignal(input: input)
                         })
                 }
                 func fooQuery(input: String) throws -> String {}
@@ -96,18 +96,18 @@ struct WorkflowMacrosTests {
                     typealias Output = Int
                     typealias Workflow = Foo
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Output
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Output) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output) {
                         self._run = run
                     }
-                    func run(workflow: Workflow, input: Input) async throws -> Output {
-                        try await self._run(workflow, input)
+                    func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws -> Output{
+                        try await self._run(workflow, context, input)
                     }
                 }
 
                 static var fooUpdate: FooUpdate {
-                    FooUpdate(run: {
-                            try await $0.fooUpdate(input: $1)
+                    FooUpdate(run: { workflow, _, input in
+                            try await workflow.fooUpdate(input: input)
                         })
                 }
 
@@ -123,7 +123,7 @@ struct WorkflowMacrosTests {
                     [Self.fooUpdate]
                 }
 
-                \(modifier) required init(input: Input) {}
+                \(modifier) init(input: Input) {}
             }
 
             extension Foo: WorkflowDefinition {
@@ -135,7 +135,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow(name: "CustomName")
-            \(modifier) final class Foo {
+            \(modifier) struct Foo {
                 @WorkflowSignal
                 func fooSignal(input: String) async throws {}
                 @WorkflowQuery
@@ -153,9 +153,9 @@ struct WorkflowMacrosTests {
     func namedWorkflow() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class Foo {
+            struct Foo {
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension Foo: WorkflowDefinition {
@@ -166,7 +166,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow(name: "CustomName")
-            final class Foo {}
+            struct Foo {}
             """
         )
         #expect(expectedOutput == actualOutput)
@@ -178,25 +178,25 @@ struct WorkflowMacrosTests {
 
         let (expectedOutput, _) = try parse(
             """
-            final class FooWorkflow {
-                \(modifierPrefix)func foo(input: String) async throws {} 
+            struct FooWorkflow {
+                \(modifierPrefix)func foo(input: String) async throws {}
 
                 \(modifierPrefix)struct Foo: WorkflowSignalDefinition {
                     \(modifierPrefix)typealias Input = String
                     \(modifierPrefix)typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Void
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Void) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void) {
                         self._run = run
                     }
-                    \(modifierPrefix)func run(workflow: Workflow, input: Input) async throws {
-                        try await self._run(workflow, input)
+                    \(modifierPrefix)func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws {
+                        try await self._run(workflow, context, input)
                     }
                 }
 
                 static var foo: Foo {
-                    Foo(run: {
-                            try await $0.foo(input: $1)
+                    Foo(run: { workflow, _, input in
+                            try await workflow.foo(input: input)
                         })
                 }
                 \(modifierPrefix)func bar(input: Void) async throws {
@@ -206,12 +206,12 @@ struct WorkflowMacrosTests {
                     \(modifierPrefix)typealias Input = Void
                     \(modifierPrefix)typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Void
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Void) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void) {
                         self._run = run
                     }
-                    \(modifierPrefix)func run(workflow: Workflow, input: Input) async throws {
-                        try await self._run(workflow, input)
+                    \(modifierPrefix)func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws {
+                        try await self._run(workflow, context, input)
                     }
                     \(modifierPrefix)static var name: String {
                         "MySignal"
@@ -222,8 +222,8 @@ struct WorkflowMacrosTests {
                 }
 
                 static var bar: Bar {
-                    Bar(run: {
-                            try await $0.bar(input: $1)
+                    Bar(run: { workflow, _, input in
+                            try await workflow.bar(input: input)
                         })
                 }
 
@@ -231,7 +231,7 @@ struct WorkflowMacrosTests {
                     [Self.foo, Self.bar]
                 }
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension FooWorkflow: WorkflowDefinition {
@@ -242,7 +242,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowSignal
                 \(modifierPrefix)func foo(input: String) async throws {}
                 @WorkflowSignal(name: "MySignal", description: "This is a description.")
@@ -260,7 +260,7 @@ struct WorkflowMacrosTests {
 
         let (expectedOutput, _) = try parse(
             """
-            final class FooWorkflow {
+            struct FooWorkflow {
                 \(modifierPrefix)func foo(input: String) throws -> String {} 
 
                 \(modifierPrefix)struct Foo: WorkflowQueryDefinition {
@@ -315,7 +315,7 @@ struct WorkflowMacrosTests {
                     [Self.foo, Self.bar]
                 }
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension FooWorkflow: WorkflowDefinition {
@@ -326,7 +326,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowQuery
                 \(modifierPrefix)func foo(input: String) throws -> String {}
                 @WorkflowQuery(name: "MyQuery", description: "This is a description.")
@@ -344,26 +344,26 @@ struct WorkflowMacrosTests {
 
         let (expectedOutput, _) = try parse(
             """
-            final class FooWorkflow {
-                \(modifierPrefix)func foo(input: String) async throws -> Int {} 
+            struct FooWorkflow {
+                \(modifierPrefix)func foo(input: String) async throws -> Int {}
 
                 \(modifierPrefix)struct Foo: WorkflowUpdateDefinition {
                     \(modifierPrefix)typealias Input = String
                     \(modifierPrefix)typealias Output = Int
                     \(modifierPrefix)typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Output
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Output) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output) {
                         self._run = run
                     }
-                    \(modifierPrefix)func run(workflow: Workflow, input: Input) async throws -> Output {
-                        try await self._run(workflow, input)
+                    \(modifierPrefix)func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws -> Output{
+                        try await self._run(workflow, context, input)
                     }
                 }
 
                 static var foo: Foo {
-                    Foo(run: {
-                            try await $0.foo(input: $1)
+                    Foo(run: { workflow, _, input in
+                            try await workflow.foo(input: input)
                         })
                 }
                 \(modifierPrefix)func bar(input: Void) throws -> String {
@@ -374,12 +374,12 @@ struct WorkflowMacrosTests {
                     \(modifierPrefix)typealias Output = String
                     \(modifierPrefix)typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Output
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Output) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output) {
                         self._run = run
                     }
-                    \(modifierPrefix)func run(workflow: Workflow, input: Input) async throws -> Output {
-                        try await self._run(workflow, input)
+                    \(modifierPrefix)func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws -> Output{
+                        try await self._run(workflow, context, input)
                     }
                     \(modifierPrefix)static var name: String {
                         "MyUpdate"
@@ -390,8 +390,8 @@ struct WorkflowMacrosTests {
                 }
 
                 static var bar: Bar {
-                    Bar(run: {
-                            try await $0.bar(input: $1)
+                    Bar(run: { workflow, _, input in
+                            try await workflow.bar(input: input)
                         })
                 }
 
@@ -399,7 +399,7 @@ struct WorkflowMacrosTests {
                     [Self.foo, Self.bar]
                 }
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension FooWorkflow: WorkflowDefinition {
@@ -410,7 +410,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate
                 \(modifierPrefix)func foo(input: String) async throws -> Int {}
                 @WorkflowUpdate(name: "MyUpdate", description: "This is a description.")
@@ -428,10 +428,10 @@ struct WorkflowMacrosTests {
     func emptyInitGeneration(type: String) throws {
         let (expectedOutput, _) = try parse(
             """
-            final class Foo {
+            struct Foo {
                 func run(input: \(type)) async throws {}
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension Foo: WorkflowDefinition {
@@ -441,7 +441,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class Foo {
+            struct Foo {
                 func run(input: \(type)) async throws {}
             }
             """
@@ -453,12 +453,12 @@ struct WorkflowMacrosTests {
     func typealiasInitGeneration() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class Foo {
+            struct Foo {
                 typealias Input = String
 
                 func run(input: Input) async throws {}
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension Foo: WorkflowDefinition {
@@ -468,7 +468,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class Foo {
+            struct Foo {
                 typealias Input = String
 
                 func run(input: Input) async throws {}
@@ -482,14 +482,14 @@ struct WorkflowMacrosTests {
     func structInitGeneration() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class Foo {
+            struct Foo {
                 struct Input {
                     let test: Int
                 }
 
                 func run(input: Input) async throws {}
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension Foo: WorkflowDefinition {
@@ -499,7 +499,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class Foo {
+            struct Foo {
                 struct Input {
                     let test: Int
                 }
@@ -515,7 +515,7 @@ struct WorkflowMacrosTests {
     func existingInit() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class Foo {
+            struct Foo {
                 init(input: Void) {}
 
                 func run(input: Void) async throws {}
@@ -528,7 +528,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class Foo {
+            struct Foo {
                 init(input: Void) {}
 
                 func run(input: Void) async throws {}
@@ -542,7 +542,7 @@ struct WorkflowMacrosTests {
     func workflowState() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class Foo {
+            struct Foo {
                 var state {
                     @storageRestrictions(initializes: _state)
                     init(initialValue) {
@@ -561,7 +561,7 @@ struct WorkflowMacrosTests {
                 func run(input: Void) async throws {
                 }
 
-                required init(input: Input) {
+                init(input: Input) {
                 }
             }
 
@@ -572,7 +572,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class Foo {
+            struct Foo {
                 var state = 0
 
                 func run(input: Void) async throws {}
@@ -586,7 +586,7 @@ struct WorkflowMacrosTests {
     func workflowStateCustomName() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class Foo {
+            struct Foo {
                 var state {
                     @storageRestrictions(initializes: _state)
                     init(initialValue) {
@@ -605,7 +605,7 @@ struct WorkflowMacrosTests {
                 func run(input: Void) async throws {
                 }
 
-                required init(input: Input) {
+                init(input: Input) {
                 }
             }
 
@@ -619,7 +619,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow(name: "CustomName")
-            final class Foo {
+            struct Foo {
                 var state = 0
 
                 func run(input: Void) async throws {}
@@ -633,27 +633,27 @@ struct WorkflowMacrosTests {
     func signalWithUnfinishedPolicy() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class FooWorkflow {
+            struct FooWorkflow {
                 func foo(input: String) async throws {}
 
                 struct Foo: WorkflowSignalDefinition {
                     typealias Input = String
                     typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Void
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Void) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Void) {
                         self._run = run
                     }
-                    func run(workflow: Workflow, input: Input) async throws {
-                        try await self._run(workflow, input)
+                    func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws {
+                        try await self._run(workflow, context, input)
                     }
 
                     static var unfinishedPolicy: HandlerUnfinishedPolicy { .abandon }
                 }
 
                 static var foo: Foo {
-                    Foo(run: {
-                            try await $0.foo(input: $1)
+                    Foo(run: { workflow, _, input in
+                            try await workflow.foo(input: input)
                         })
                 }
 
@@ -661,7 +661,7 @@ struct WorkflowMacrosTests {
                     [Self.foo]
                 }
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension FooWorkflow: WorkflowDefinition {
@@ -672,7 +672,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowSignal(unfinishedPolicy: .abandon)
                 func foo(input: String) async throws {}
             }
@@ -686,7 +686,7 @@ struct WorkflowMacrosTests {
     func updateWithUnfinishedPolicy() throws {
         let (expectedOutput, _) = try parse(
             """
-            final class FooWorkflow {
+            struct FooWorkflow {
                 func foo(input: String) async throws -> Int {}
 
                 struct Foo: WorkflowUpdateDefinition {
@@ -694,20 +694,20 @@ struct WorkflowMacrosTests {
                     typealias Output = Int
                     typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Output
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Output) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output) {
                         self._run = run
                     }
-                    func run(workflow: Workflow, input: Input) async throws -> Output {
-                        try await self._run(workflow, input)
+                    func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws -> Output{
+                        try await self._run(workflow, context, input)
                     }
 
                     static var unfinishedPolicy: HandlerUnfinishedPolicy { .abandon }
                 }
 
                 static var foo: Foo {
-                    Foo(run: {
-                            try await $0.foo(input: $1)
+                    Foo(run: { workflow, _, input in
+                            try await workflow.foo(input: input)
                         })
                 }
 
@@ -715,7 +715,7 @@ struct WorkflowMacrosTests {
                     [Self.foo]
                 }
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension FooWorkflow: WorkflowDefinition {
@@ -726,7 +726,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(unfinishedPolicy: .abandon)
                 func foo(input: String) async throws -> Int {}
             }
@@ -742,7 +742,7 @@ struct WorkflowMacrosTests {
 
         let (expectedOutput, _) = try parse(
             """
-            final class FooWorkflow {
+            struct FooWorkflow {
                 \(modifierPrefix)func foo(input: String) async throws -> Int {}
 
                 \(modifierPrefix)struct Foo: WorkflowUpdateDefinition {
@@ -750,13 +750,13 @@ struct WorkflowMacrosTests {
                     \(modifierPrefix)typealias Output = Int
                     \(modifierPrefix)typealias Workflow = FooWorkflow
 
-                    let _run: @Sendable (Workflow, Input) async throws -> Output
-                    init(run: @Sendable @escaping (Workflow, Input) async throws -> Output, validate: @Sendable @escaping (Workflow, Input) throws -> Void) {
+                    let _run: @Sendable (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContext<Workflow>, Input) async throws -> Output, validate: @Sendable @escaping (Workflow, Input) throws -> Void) {
                         self._run = run
                         self._validate = validate
                     }
-                    \(modifierPrefix)func run(workflow: Workflow, input: Input) async throws -> Output {
-                        try await self._run(workflow, input)
+                    \(modifierPrefix)func run(workflow: Workflow, context: WorkflowContext<Workflow>, input: Input) async throws -> Output{
+                        try await self._run(workflow, context, input)
                     }
 
                     let _validate: @Sendable (Workflow, Input) throws -> Void
@@ -766,8 +766,8 @@ struct WorkflowMacrosTests {
                 }
 
                 static var foo: Foo {
-                    Foo(run: {
-                            try await $0.foo(input: $1)
+                    Foo(run: { workflow, _, input in
+                            try await workflow.foo(input: input)
                         }, validate: {
                             try $0.validateFoo(input: $1)
                         })
@@ -779,7 +779,7 @@ struct WorkflowMacrosTests {
                     [Self.foo]
                 }
 
-                required init(input: Input) {}
+                init(input: Input) {}
             }
 
             extension FooWorkflow: WorkflowDefinition {
@@ -790,7 +790,7 @@ struct WorkflowMacrosTests {
         let (actualOutput, _) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "validateFoo")
                 \(modifierPrefix)func foo(input: String) async throws -> Int {}
 
@@ -809,7 +809,7 @@ struct WorkflowMacrosTests {
         let (_, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "validateFoo")
                 func foo(input: String) async throws -> Int {}
 
@@ -826,7 +826,7 @@ struct WorkflowMacrosTests {
         let (output, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate
                 func foo(input: String) async throws -> Int {}
             }
@@ -843,7 +843,7 @@ struct WorkflowMacrosTests {
         let (output, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "validateFoo")
                 func foo(input: String) async throws -> Int {}
 
@@ -863,7 +863,7 @@ struct WorkflowMacrosTests {
         let (_, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "doesNotExist")
                 func foo(input: String) async throws -> Int {}
             }
@@ -880,7 +880,7 @@ struct WorkflowMacrosTests {
         let (_, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "validateFoo")
                 func foo(input: String) async throws -> Int {}
 
@@ -899,7 +899,7 @@ struct WorkflowMacrosTests {
         let (_, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "validateFoo")
                 func foo(input: String) async throws -> Int {}
 
@@ -918,7 +918,7 @@ struct WorkflowMacrosTests {
         let (_, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "validateFoo")
                 func foo(input: String) async throws -> Int {}
 
@@ -940,7 +940,7 @@ struct WorkflowMacrosTests {
         let (_, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "validateFoo")
                 func foo(input: String) async throws -> Int {}
 
@@ -959,7 +959,7 @@ struct WorkflowMacrosTests {
         let (_, diagnostics) = try parse(
             """
             @Workflow
-            final class FooWorkflow {
+            struct FooWorkflow {
                 @WorkflowUpdate(validator: "validateFoo")
                 func foo(input: String) async throws -> Int {}
 

--- a/Tests/TemporalTests/Client/AsyncActivityHandleTests.swift
+++ b/Tests/TemporalTests/Client/AsyncActivityHandleTests.swift
@@ -94,10 +94,10 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class AsyncCompletionWorkflow {
-            func run(input: String) async throws -> String {
+        struct AsyncCompletionWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
                 let activity = CompleteExternalContainer.Activities.ActivityDefault.self
-                return try await Workflow.executeActivity(
+                return try await context.executeActivity(
                     activity,
                     options: .init(scheduleToCloseTimeout: .seconds(30)),
                     input: input
@@ -217,10 +217,10 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class AsyncCompletionCancellationWaitingWorkflow {
-            func run(input: String) async throws -> String {
+        struct AsyncCompletionCancellationWaitingWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
                 let activity = CompleteExternalContainer.Activities.ActivityDefault.self
-                return try await Workflow.executeActivity(
+                return try await context.executeActivity(
                     activity,
                     options: .init(scheduleToCloseTimeout: .seconds(30), cancellationType: .waitCancellationCompleted),
                     input: input
@@ -230,10 +230,10 @@ extension TestServerDependentTests {
 
         /// Workflow with a short timeout specifically for testing timeout behavior.
         @Workflow
-        final class AsyncCompletionShortTimeoutWorkflow {
-            func run(input: String) async throws -> String {
+        struct AsyncCompletionShortTimeoutWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
                 let activity = CompleteExternalContainer.Activities.ActivityDefault.self
-                return try await Workflow.executeActivity(
+                return try await context.executeActivity(
                     activity,
                     options: .init(scheduleToCloseTimeout: .seconds(1), cancellationType: .waitCancellationCompleted),
                     input: input

--- a/Tests/TemporalTests/Client/ClientOutboundInterceptorTests.swift
+++ b/Tests/TemporalTests/Client/ClientOutboundInterceptorTests.swift
@@ -40,14 +40,14 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SimpleWorkflow {
+        struct SimpleWorkflow {
             var signal = 0
-            func run(input: Void) async throws {
-                try await Workflow.sleep(for: .seconds(1))
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.sleep(for: .seconds(1))
             }
 
             @WorkflowSignal
-            func signal(input: Int) async throws {
+            mutating func signal(input: Int) {
                 signal = input
             }
 

--- a/Tests/TemporalTests/Client/InterceptedOperationsTests+Schedules.swift
+++ b/Tests/TemporalTests/Client/InterceptedOperationsTests+Schedules.swift
@@ -136,8 +136,8 @@ extension TestServerDependentTests.InterceptedOperationsTests {
     }
 
     @Workflow
-    final class HelloInputScheduleWorkflow {
-        func run(input: String) async -> String {
+    struct HelloInputScheduleWorkflow {
+        mutating func run(context: WorkflowContext<Self>, input: String) async -> String {
             input
         }
     }

--- a/Tests/TemporalTests/Client/InterceptedOperationsTests+Workflows.swift
+++ b/Tests/TemporalTests/Client/InterceptedOperationsTests+Workflows.swift
@@ -127,16 +127,16 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class HelloWorldUntypedOperationsWorkflow {
-            func run(input: String) async -> String {
+        struct HelloWorldUntypedOperationsWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async -> String {
                 "Hello World, \(input)!"
             }
         }
 
         @Workflow
-        final class ForeverWaitingWorkflow {
-            func run(input: String) async throws {
-                try await Workflow.condition { false }
+        struct ForeverWaitingWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws {
+                try await context.condition { false }
             }
         }
 
@@ -205,22 +205,22 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SignalUntypedOperationsWorkflow {
+        struct SignalUntypedOperationsWorkflow {
             private var received: String?
 
-            func run(input: Void) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
                 // wait until a signal sets `received`
-                try await Workflow.condition { self.received != nil }
+                try await context.condition { $0.received != nil }
                 return self.received ?? "no signal received"
             }
 
             @WorkflowSignal
-            func signal(input: String) async throws {
+            mutating func signal(input: String) {
                 self.received = input
             }
 
             @WorkflowSignal(name: "NoInputSignal")
-            func signalNoInput(input: Void) async throws {
+            mutating func signalNoInput(input: Void) {
                 self.received = "No input signal"
             }
         }
@@ -316,12 +316,12 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class QueryUntypedOperationsWorkflow {
+        struct QueryUntypedOperationsWorkflow {
             private var state = "initial"
 
-            func run(input: Void) async throws {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
                 // simulate some work before updating state
-                try await Workflow.sleep(for: .milliseconds(100))
+                try await context.sleep(for: .milliseconds(100))
                 self.state = "finished"
             }
 
@@ -431,22 +431,22 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class UpdateUntypedOperationsWorkflow {
+        struct UpdateUntypedOperationsWorkflow {
             private var state = ""
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { self.state == "updated" }
-                try await Workflow.condition { Workflow.allHandlersFinished }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.state == "updated" }
+                try await context.condition { context.allHandlersFinished }
             }
 
             @WorkflowUpdate
-            func update(input: String) async throws -> String {
+            mutating func update(input: String) throws -> String {
                 self.state = "updated"
                 return "Hello from update, \(input)"
             }
 
             @WorkflowUpdate(name: "NoInputUpdate")
-            func updateNoInput(input: Void) async throws -> String {
+            mutating func updateNoInput(input: Void) throws -> String {
                 self.state = "updated"
                 return "Hello from update"
             }

--- a/Tests/TemporalTests/Client/ScheduleTests.swift
+++ b/Tests/TemporalTests/Client/ScheduleTests.swift
@@ -24,15 +24,15 @@ extension TestServerDependentTests {
     @Suite(.tags(.clientTests))
     struct ScheduleTests {
         @Workflow
-        final class HelloWorldScheduleWorkflow {
-            func run(input: Void) async -> String {
+        struct HelloWorldScheduleWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async -> String {
                 "Hello, World!"
             }
         }
 
         @Workflow
-        final class HelloInputScheduleWorkflow {
-            func run(input: String) async -> String {
+        struct HelloInputScheduleWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async -> String {
                 input
             }
         }

--- a/Tests/TemporalTests/Client/UntypedScheduleHandleTests.swift
+++ b/Tests/TemporalTests/Client/UntypedScheduleHandleTests.swift
@@ -23,8 +23,8 @@ extension TestServerDependentTests {
     @Suite(.tags(.clientTests))
     struct UntypedScheduleHandleTests {
         @Workflow
-        final class HelloInputScheduleWorkflow {
-            func run(input: String) async -> String {
+        struct HelloInputScheduleWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async -> String {
                 input
             }
         }

--- a/Tests/TemporalTests/Client/UntypedWorfklowHandleTests.swift
+++ b/Tests/TemporalTests/Client/UntypedWorfklowHandleTests.swift
@@ -21,16 +21,16 @@ extension TestServerDependentTests {
     @Suite(.tags(.clientTests))
     struct UntypedWorkflowHandleTests {
         @Workflow
-        final class HelloWorldUntypedOperationsWorkflow {
-            func run(input: String) async -> String {
+        struct HelloWorldUntypedOperationsWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async -> String {
                 "Hello World, \(input)!"
             }
         }
 
         @Workflow
-        final class ForeverWaitingWorkflow {
-            func run(input: String) async throws {
-                try await Workflow.condition { false }
+        struct ForeverWaitingWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws {
+                try await context.condition { false }
             }
         }
 
@@ -94,22 +94,22 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SignalUntypedOperationsWorkflow {
+        struct SignalUntypedOperationsWorkflow {
             private var received: String?
 
-            func run(input: Void) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
                 // wait until a signal sets `received`
-                try await Workflow.condition { self.received != nil }
+                try await context.condition { $0.received != nil }
                 return self.received ?? "no signal received"
             }
 
             @WorkflowSignal
-            func signal(input: String) async throws {
+            mutating func signal(input: String) {
                 self.received = input
             }
 
             @WorkflowSignal(name: "NoInputSignal")
-            func signalNoInput(input: Void) async throws {
+            mutating func signalNoInput(input: Void) {
                 self.received = "No input signal"
             }
         }
@@ -195,12 +195,12 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class QueryUntypedOperationsWorkflow {
+        struct QueryUntypedOperationsWorkflow {
             private var state = "initial"
 
-            func run(input: Void) async throws {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
                 // simulate some work before updating state
-                try await Workflow.sleep(for: .milliseconds(100))
+                try await context.sleep(for: .milliseconds(100))
                 self.state = "finished"
             }
 
@@ -298,22 +298,22 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class UpdateUntypedOperationsWorkflow {
+        struct UpdateUntypedOperationsWorkflow {
             private var state = ""
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { self.state == "updated" }
-                try await Workflow.condition { Workflow.allHandlersFinished }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.state == "updated" }
+                try await context.condition { context.allHandlersFinished }
             }
 
             @WorkflowUpdate
-            func update(input: String) async throws -> String {
+            mutating func update(input: String) throws -> String {
                 self.state = "updated"
                 return "Hello from update, \(input)"
             }
 
             @WorkflowUpdate(name: "NoInputUpdate")
-            func updateNoInput(input: Void) async throws -> String {
+            mutating func updateNoInput(input: Void) throws -> String {
                 self.state = "updated"
                 return "Hello from update"
             }

--- a/Tests/TemporalTests/Client/WorkflowExecutionDescriptionTests.swift
+++ b/Tests/TemporalTests/Client/WorkflowExecutionDescriptionTests.swift
@@ -20,9 +20,9 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowExecutionDescriptionTests {
         @Workflow
-        final class SimpleWorkflow {
-            func run(input: Void) async throws {
-                try await Workflow.condition { false }
+        struct SimpleWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { false }
             }
         }
 

--- a/Tests/TemporalTests/Client/WorkflowExecutionStatusTests.swift
+++ b/Tests/TemporalTests/Client/WorkflowExecutionStatusTests.swift
@@ -22,16 +22,16 @@ extension TestServerDependentTests {
     @Suite(.tags(.clientTests))
     struct WorkflowExecutionStatusTests {
         @Workflow
-        final class SimpleStatusWorkflow {
-            func run(input: Void) async -> String {
+        struct SimpleStatusWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async -> String {
                 "done"
             }
         }
 
         @Workflow
-        final class WaitingStatusWorkflow {
-            func run(input: Void) async throws {
-                try await Workflow.condition { false }
+        struct WaitingStatusWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { false }
             }
         }
 

--- a/Tests/TemporalTests/Client/WorkflowHandleTests.swift
+++ b/Tests/TemporalTests/Client/WorkflowHandleTests.swift
@@ -20,15 +20,15 @@ extension TestServerDependentTests {
     @Suite(.tags(.clientTests))
     struct WorkflowHandleTests {
         @Workflow
-        final class HelloWorldWorkflow {
-            func run(input: Void) async -> String {
+        struct HelloWorldWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async -> String {
                 "Hello, World!"
             }
         }
 
         @Workflow
-        final class HelloInputWorkflow {
-            func run(input: String) async -> String {
+        struct HelloInputWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async -> String {
                 input
             }
         }

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalClientOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalClientOutboundTracingInterceptorTests.swift
@@ -25,8 +25,8 @@ import Tracing
 @Suite(.tags(.instrumentationTests))
 struct TemporalClientOutboundTracingInterceptorTests {
     @Workflow
-    final class VoidWorkflow {
-        func run(input: Void) async {}
+    struct VoidWorkflow {
+        mutating func run(context: WorkflowContext<Self>, input: Void) async {}
     }
 
     struct TemporalTraceID: Decodable {

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
@@ -22,8 +22,8 @@ import Tracing
 @Suite(.tags(.instrumentationTests))
 struct TemporalWorkerInboundTracingInterceptorTests {
     @Workflow
-    final class VoidWorkflow {
-        func run(input: Void) async {}
+    struct VoidWorkflow {
+        mutating func run(context: WorkflowContext<Self>, input: Void) async {}
     }
 
     struct TemporalTraceID: Encodable {
@@ -39,19 +39,28 @@ struct TemporalWorkerInboundTracingInterceptorTests {
     private static let runID = UUID().uuidString
     private static let taskQueue = "TestTaskQueue"
     private static let namespace = "TestNamespace"
-    private static let workflowContext = WorkflowContext.makeTestContext(
-        info: .init(
-            attempt: Self.attempt,
-            startTime: Self.startTime,
-            workflowName: Self.workflowName,
-            workflowID: Self.workflowID,
-            workflowType: Self.workflowType,
-            runID: Self.runID,
-            taskQueue: Self.taskQueue,
-            namespace: Self.namespace,
-            headers: [:]
-        )
+    private static let testWorkflowInfo = WorkflowInfo(
+        attempt: Self.attempt,
+        startTime: Self.startTime,
+        workflowName: Self.workflowName,
+        workflowID: Self.workflowID,
+        workflowType: Self.workflowType,
+        runID: Self.runID,
+        taskQueue: Self.taskQueue,
+        namespace: Self.namespace,
+        headers: [:]
     )
+    //    private static let internalWorkflowContext = InternalWorkflowContext(
+    //        stateMachine: .init(
+    //            executor: .init(),
+    //            payloadConverter: DefaultPayloadConverter(),
+    //            failureConverter: DefaultFailureConverter()
+    //        ),
+    //        workflowInfo: Self.testWorkflowInfo,
+    //        payloadConverter: DefaultPayloadConverter(),
+    //        outboundInterceptors: [],
+    //        logger: .init(label: "TestWorkflowContext")
+    //    )
 
     // only test one inbound workflow worker interceptor, as logic is the same (except for the setting of span attributes)
     @Test
@@ -71,17 +80,18 @@ struct TemporalWorkerInboundTracingInterceptorTests {
                 TemporalTraceID(traceparent: traceID)
             )
         ]
-        try await Workflow.$context.withValue(Self.workflowContext) {
-            _ = try await interceptor.executeWorkflow(
-                input: ExecuteWorkflowInput<VoidWorkflow>(
-                    headers: mockIncomingHeaders,
-                    input: ()
-                )
-            ) { input in
-                // Make sure we get the metadata injected into our service context
-                #expect(ServiceContext.current?.traceID == traceID.uuidString)
-            }
+        //        try await InternalWorkflowContext.$current.withValue(Self.internalWorkflowContext) {
+        _ = try await interceptor.executeWorkflow(
+            input: ExecuteWorkflowInput<VoidWorkflow>(
+                info: Self.testWorkflowInfo,
+                headers: mockIncomingHeaders,
+                input: ()
+            )
+        ) { input in
+            // Make sure we get the metadata injected into our service context
+            #expect(ServiceContext.current?.traceID == traceID.uuidString)
         }
+        //        }
 
         assertTestSpanComponents(
             forSpan: "RunWorkflow:\(Self.workflowName)",
@@ -124,20 +134,21 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         ]
 
         do {
-            try await Workflow.$context.withValue(Self.workflowContext) {
-                _ = try await interceptor.executeWorkflow(
-                    input: ExecuteWorkflowInput<VoidWorkflow>(
-                        headers: mockIncomingHeaders,
-                        input: ()
-                    )
-                ) { input in
-                    // Make sure we get the metadata injected into our service context
-                    #expect(ServiceContext.current?.traceID == traceID.uuidString)
+            //            try await InternalWorkflowContext.$current.withValue(Self.internalWorkflowContext) {
+            _ = try await interceptor.executeWorkflow(
+                input: ExecuteWorkflowInput<VoidWorkflow>(
+                    info: Self.testWorkflowInfo,
+                    headers: mockIncomingHeaders,
+                    input: ()
+                )
+            ) { input in
+                // Make sure we get the metadata injected into our service context
+                #expect(ServiceContext.current?.traceID == traceID.uuidString)
 
-                    // Simulates an error within the RPC
-                    throw TracingInterceptorTestError.testError
-                }
+                // Simulates an error within the RPC
+                throw TracingInterceptorTestError.testError
             }
+            //            }
 
             Issue.record("Should have thrown")
         } catch {
@@ -256,21 +267,5 @@ struct TemporalWorkerInboundTracingInterceptorTests {
                 #expect(errors == [.testError])
             }
         }
-    }
-}
-
-extension WorkflowContext {
-    static func makeTestContext(info: WorkflowInfo) -> WorkflowContext {
-        .init(
-            stateMachine: .init(
-                executor: .init(),
-                payloadConverter: DefaultPayloadConverter(),
-                failureConverter: DefaultFailureConverter()
-            ),
-            workflowInfo: info,
-            payloadConverter: DefaultPayloadConverter(),
-            outboundInterceptors: [],
-            logger: .init(label: "TestWorkflowContext")
-        )
     }
 }

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
@@ -50,17 +50,6 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         namespace: Self.namespace,
         headers: [:]
     )
-    //    private static let internalWorkflowContext = InternalWorkflowContext(
-    //        stateMachine: .init(
-    //            executor: .init(),
-    //            payloadConverter: DefaultPayloadConverter(),
-    //            failureConverter: DefaultFailureConverter()
-    //        ),
-    //        workflowInfo: Self.testWorkflowInfo,
-    //        payloadConverter: DefaultPayloadConverter(),
-    //        outboundInterceptors: [],
-    //        logger: .init(label: "TestWorkflowContext")
-    //    )
 
     // only test one inbound workflow worker interceptor, as logic is the same (except for the setting of span attributes)
     @Test
@@ -80,7 +69,6 @@ struct TemporalWorkerInboundTracingInterceptorTests {
                 TemporalTraceID(traceparent: traceID)
             )
         ]
-        //        try await InternalWorkflowContext.$current.withValue(Self.internalWorkflowContext) {
         _ = try await interceptor.executeWorkflow(
             input: ExecuteWorkflowInput<VoidWorkflow>(
                 info: Self.testWorkflowInfo,
@@ -91,7 +79,6 @@ struct TemporalWorkerInboundTracingInterceptorTests {
             // Make sure we get the metadata injected into our service context
             #expect(ServiceContext.current?.traceID == traceID.uuidString)
         }
-        //        }
 
         assertTestSpanComponents(
             forSpan: "RunWorkflow:\(Self.workflowName)",
@@ -134,7 +121,6 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         ]
 
         do {
-            //            try await InternalWorkflowContext.$current.withValue(Self.internalWorkflowContext) {
             _ = try await interceptor.executeWorkflow(
                 input: ExecuteWorkflowInput<VoidWorkflow>(
                     info: Self.testWorkflowInfo,
@@ -148,7 +134,6 @@ struct TemporalWorkerInboundTracingInterceptorTests {
                 // Simulates an error within the RPC
                 throw TracingInterceptorTestError.testError
             }
-            //            }
 
             Issue.record("Should have thrown")
         } catch {

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Logging
 import SwiftProtobuf
 import Temporal
 import Testing
@@ -21,8 +22,8 @@ import Tracing
 @Suite(.tags(.instrumentationTests))
 struct TemporalWorkerOutboundTracingInterceptorTests {
     @Workflow
-    final class VoidWorkflow {
-        func run(input: Void) async {}
+    struct VoidWorkflow {
+        mutating func run(context: WorkflowContext<Self>, input: Void) async {}
     }
 
     struct TemporalTraceID: Decodable {
@@ -44,19 +45,28 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
     private static let runID = UUID().uuidString
     private static let taskQueue = "TestTaskQueue"
     private static let namespace = "TestNamespace"
-    private static let workflowContext = WorkflowContext.makeTestContext(
-        info: .init(
-            attempt: Self.attempt,
-            startTime: Self.startTime,
-            workflowName: Self.workflowName,
-            workflowID: Self.workflowID,
-            workflowType: Self.workflowType,
-            runID: Self.runID,
-            taskQueue: Self.taskQueue,
-            namespace: Self.namespace,
-            headers: [:]
-        )
+    private static let testWorkflowInfo = WorkflowInfo(
+        attempt: Self.attempt,
+        startTime: Self.startTime,
+        workflowName: Self.workflowName,
+        workflowID: Self.workflowID,
+        workflowType: Self.workflowType,
+        runID: Self.runID,
+        taskQueue: Self.taskQueue,
+        namespace: Self.namespace,
+        headers: [:]
     )
+    //    private static let internalWorkflowContext = InternalWorkflowContext(
+    //        stateMachine: .init(
+    //            executor: .init(),
+    //            payloadConverter: DefaultPayloadConverter(),
+    //            failureConverter: DefaultFailureConverter()
+    //        ),
+    //        workflowInfo: Self.testWorkflowInfo,
+    //        payloadConverter: DefaultPayloadConverter(),
+    //        outboundInterceptors: [],
+    //        logger: .init(label: "TestWorkflowContext")
+    //    )
 
     // only test one outbound workflow worker interceptor, as logic is the same (except for the setting of span attributes)
     @Test
@@ -66,15 +76,100 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
         let traceIDString = UUID().uuidString
         serviceContext.traceID = traceIDString
 
-        try await Workflow.$context.withValue(Self.workflowContext) {
-            try await ServiceContext.withValue(serviceContext) {
-                let interceptor = try #require(
-                    TemporalWorkerTracingInterceptor(
-                        tracer: tracer
-                    ).workflowOutboundInterceptor
-                )
+        //        try await InternalWorkflowContext.$current.withValue(Self.internalWorkflowContext) {
+        try await ServiceContext.withValue(serviceContext) {
+            let interceptor = try #require(
+                TemporalWorkerTracingInterceptor(
+                    tracer: tracer
+                ).workflowOutboundInterceptor
+            )
 
+            let input = ScheduleActivityInput<Void>(
+                info: Self.testWorkflowInfo,
+                name: Self.activityInfo.name,
+                options: ActivityOptions(
+                    scheduleToCloseTimeout: Self.scheduleToCloseTimeout,
+                    disableEagerActivityExecution: Self.disableEagerActivityExecution,
+                    cancellationType: Self.cancellationType,
+                    versioningIntent: Self.versioningIntent
+                ),
+                headers: [:],
+                input: ()
+            )
+
+            _ = try await interceptor.executeActivity(
+                input: input,
+                next: { input in
+                    // Assert that headers contain the injected traceID
+                    let traceHeaderPayload = try #require(
+                        input.headers.first(where: { key, value in
+                            key == "_tracer-data"  // default Temporal tracing header key
+                        })?.1 as? Api.Common.V1.Payload
+                    )
+
+                    let traceHeader: TemporalTraceID = try DataConverter.default.payloadConverter.convertPayloadHandlingVoid(
+                        traceHeaderPayload
+                    )
+                    #expect(traceHeader.traceparent.uuidString == traceIDString)
+
+                    return ()
+                }
+            )
+
+            assertTestSpanComponents(
+                forSpan: "StartActivity:\(Self.activityInfo.name)",
+                tracer: tracer
+            ) { events in
+                // No events are recorded
+                #expect(events.isEmpty)
+            } assertAttributes: { attributes in
+                #expect(attributes[TemporalTracingKeys.activityName]?.toSpanAttribute() == .string(Self.activityInfo.name))
+                #expect(attributes[TemporalTracingKeys.activityCancellationType]?.toSpanAttribute() == .string(Self.cancellationType.description))
+                #expect(
+                    attributes[TemporalTracingKeys.activityScheduleToCloseTimeout]?.toSpanAttribute()
+                        == .string(Self.scheduleToCloseTimeout.description)
+                )
+                #expect(
+                    attributes[TemporalTracingKeys.activityDisableEagerExecution]?.toSpanAttribute()
+                        == .string(Self.disableEagerActivityExecution.description)
+                )
+                #expect(attributes[TemporalTracingKeys.activityVersioningIntent]?.toSpanAttribute() == .string(Self.versioningIntent.description))
+
+                #expect(attributes[TemporalTracingKeys.workflowType]?.toSpanAttribute() == .string(Self.workflowType))
+                #expect(attributes[TemporalTracingKeys.workflowRunId]?.toSpanAttribute() == .string(Self.runID))
+                #expect(attributes[TemporalTracingKeys.workflowId]?.toSpanAttribute() == .string(Self.workflowID))
+                #expect(attributes[TemporalTracingKeys.workflowStartTime]?.toSpanAttribute() == .string(Self.startTime.description))
+                #expect(attributes[TemporalTracingKeys.workflowName]?.toSpanAttribute() == .string(Self.workflowName))
+                #expect(attributes[TemporalTracingKeys.workflowTaskQueue]?.toSpanAttribute() == .string(Self.taskQueue))
+                #expect(attributes[TemporalTracingKeys.workflowNamespace]?.toSpanAttribute() == .string(Self.namespace))
+                #expect(attributes[TemporalTracingKeys.workflowAttempt]?.toSpanAttribute() == .int64(Int64(Self.attempt)))
+            } assertStatus: { status in
+                #expect(status == nil)
+            } assertErrors: { errors in
+                #expect(errors == [])
+            }
+        }
+        //        }
+    }
+
+    @Test
+    func outboundTracingWorkflowWorkerFailure() async throws {
+        let tracer = TestTracer()
+        var serviceContext = ServiceContext.topLevel
+        let traceIDString = UUID().uuidString
+        serviceContext.traceID = traceIDString
+
+        //        try await InternalWorkflowContext.$current.withValue(Self.internalWorkflowContext) {
+        try await ServiceContext.withValue(serviceContext) {
+            let interceptor = try #require(
+                TemporalWorkerTracingInterceptor(
+                    tracer: tracer
+                ).workflowOutboundInterceptor
+            )
+
+            do {
                 let input = ScheduleActivityInput<Void>(
+                    info: Self.testWorkflowInfo,
                     name: Self.activityInfo.name,
                     options: ActivityOptions(
                         scheduleToCloseTimeout: Self.scheduleToCloseTimeout,
@@ -101,110 +196,27 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
                         )
                         #expect(traceHeader.traceparent.uuidString == traceIDString)
 
-                        return ()
+                        // Simulates an error within the RPC
+                        throw TracingInterceptorTestError.testError
                     }
                 )
-
+                Issue.record("Should have thrown")
+            } catch {
                 assertTestSpanComponents(
                     forSpan: "StartActivity:\(Self.activityInfo.name)",
                     tracer: tracer
                 ) { events in
                     // No events are recorded
                     #expect(events.isEmpty)
-                } assertAttributes: { attributes in
-                    #expect(attributes[TemporalTracingKeys.activityName]?.toSpanAttribute() == .string(Self.activityInfo.name))
-                    #expect(attributes[TemporalTracingKeys.activityCancellationType]?.toSpanAttribute() == .string(Self.cancellationType.description))
-                    #expect(
-                        attributes[TemporalTracingKeys.activityScheduleToCloseTimeout]?.toSpanAttribute()
-                            == .string(Self.scheduleToCloseTimeout.description)
-                    )
-                    #expect(
-                        attributes[TemporalTracingKeys.activityDisableEagerExecution]?.toSpanAttribute()
-                            == .string(Self.disableEagerActivityExecution.description)
-                    )
-                    #expect(attributes[TemporalTracingKeys.activityVersioningIntent]?.toSpanAttribute() == .string(Self.versioningIntent.description))
-
-                    #expect(attributes[TemporalTracingKeys.workflowType]?.toSpanAttribute() == .string(Self.workflowType))
-                    #expect(attributes[TemporalTracingKeys.workflowRunId]?.toSpanAttribute() == .string(Self.runID))
-                    #expect(attributes[TemporalTracingKeys.workflowId]?.toSpanAttribute() == .string(Self.workflowID))
-                    #expect(attributes[TemporalTracingKeys.workflowStartTime]?.toSpanAttribute() == .string(Self.startTime.description))
-                    #expect(attributes[TemporalTracingKeys.workflowName]?.toSpanAttribute() == .string(Self.workflowName))
-                    #expect(attributes[TemporalTracingKeys.workflowTaskQueue]?.toSpanAttribute() == .string(Self.taskQueue))
-                    #expect(attributes[TemporalTracingKeys.workflowNamespace]?.toSpanAttribute() == .string(Self.namespace))
-                    #expect(attributes[TemporalTracingKeys.workflowAttempt]?.toSpanAttribute() == .int64(Int64(Self.attempt)))
+                } assertAttributes: { _ in
+                    // don't recheck attributes from test above
                 } assertStatus: { status in
-                    #expect(status == nil)
+                    #expect(status == .some(.init(code: .error)))
                 } assertErrors: { errors in
-                    #expect(errors == [])
+                    #expect(errors == [.testError])
                 }
             }
         }
-    }
-
-    @Test
-    func outboundTracingWorkflowWorkerFailure() async throws {
-        let tracer = TestTracer()
-        var serviceContext = ServiceContext.topLevel
-        let traceIDString = UUID().uuidString
-        serviceContext.traceID = traceIDString
-
-        try await Workflow.$context.withValue(Self.workflowContext) {
-            try await ServiceContext.withValue(serviceContext) {
-                let interceptor = try #require(
-                    TemporalWorkerTracingInterceptor(
-                        tracer: tracer
-                    ).workflowOutboundInterceptor
-                )
-
-                do {
-                    let input = ScheduleActivityInput<Void>(
-                        name: Self.activityInfo.name,
-                        options: ActivityOptions(
-                            scheduleToCloseTimeout: Self.scheduleToCloseTimeout,
-                            disableEagerActivityExecution: Self.disableEagerActivityExecution,
-                            cancellationType: Self.cancellationType,
-                            versioningIntent: Self.versioningIntent
-                        ),
-                        headers: [:],
-                        input: ()
-                    )
-
-                    _ = try await interceptor.executeActivity(
-                        input: input,
-                        next: { input in
-                            // Assert that headers contain the injected traceID
-                            let traceHeaderPayload = try #require(
-                                input.headers.first(where: { key, value in
-                                    key == "_tracer-data"  // default Temporal tracing header key
-                                })?.1 as? Api.Common.V1.Payload
-                            )
-
-                            let traceHeader: TemporalTraceID = try DataConverter.default.payloadConverter.convertPayloadHandlingVoid(
-                                traceHeaderPayload
-                            )
-                            #expect(traceHeader.traceparent.uuidString == traceIDString)
-
-                            // Simulates an error within the RPC
-                            throw TracingInterceptorTestError.testError
-                        }
-                    )
-                    Issue.record("Should have thrown")
-                } catch {
-                    assertTestSpanComponents(
-                        forSpan: "StartActivity:\(Self.activityInfo.name)",
-                        tracer: tracer
-                    ) { events in
-                        // No events are recorded
-                        #expect(events.isEmpty)
-                    } assertAttributes: { _ in
-                        // don't recheck attributes from test above
-                    } assertStatus: { status in
-                        #expect(status == .some(.init(code: .error)))
-                    } assertErrors: { errors in
-                        #expect(errors == [.testError])
-                    }
-                }
-            }
-        }
+        //        }
     }
 }

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
@@ -56,17 +56,6 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
         namespace: Self.namespace,
         headers: [:]
     )
-    //    private static let internalWorkflowContext = InternalWorkflowContext(
-    //        stateMachine: .init(
-    //            executor: .init(),
-    //            payloadConverter: DefaultPayloadConverter(),
-    //            failureConverter: DefaultFailureConverter()
-    //        ),
-    //        workflowInfo: Self.testWorkflowInfo,
-    //        payloadConverter: DefaultPayloadConverter(),
-    //        outboundInterceptors: [],
-    //        logger: .init(label: "TestWorkflowContext")
-    //    )
 
     // only test one outbound workflow worker interceptor, as logic is the same (except for the setting of span attributes)
     @Test
@@ -76,7 +65,6 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
         let traceIDString = UUID().uuidString
         serviceContext.traceID = traceIDString
 
-        //        try await InternalWorkflowContext.$current.withValue(Self.internalWorkflowContext) {
         try await ServiceContext.withValue(serviceContext) {
             let interceptor = try #require(
                 TemporalWorkerTracingInterceptor(
@@ -149,7 +137,6 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
                 #expect(errors == [])
             }
         }
-        //        }
     }
 
     @Test
@@ -159,7 +146,6 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
         let traceIDString = UUID().uuidString
         serviceContext.traceID = traceIDString
 
-        //        try await InternalWorkflowContext.$current.withValue(Self.internalWorkflowContext) {
         try await ServiceContext.withValue(serviceContext) {
             let interceptor = try #require(
                 TemporalWorkerTracingInterceptor(
@@ -217,6 +203,5 @@ struct TemporalWorkerOutboundTracingInterceptorTests {
                 }
             }
         }
-        //        }
     }
 }

--- a/Tests/TemporalTests/Macros/MacroNameTests.swift
+++ b/Tests/TemporalTests/Macros/MacroNameTests.swift
@@ -62,12 +62,13 @@ extension TestServerDependentTests {
         /// Has a default workflow name, invokes an activity
         /// with a default name.
         @Workflow
-        final class ExampleWorkflowDefaultName {
-            func run(
+        struct ExampleWorkflowDefaultName {
+            mutating func run(
+                context: WorkflowContext<Self>,
                 input: String
             ) async throws -> String {
                 let activity = ExampleActivityContainer.Activities.ActivityDefault.self
-                return try await Workflow.executeActivity(
+                return try await context.executeActivity(
                     activity,
                     options: .init(startToCloseTimeout: .seconds(3)),
                     input: input
@@ -78,12 +79,13 @@ extension TestServerDependentTests {
         /// Has a custom workflow name, invokes an activity
         /// with a custom name.
         @Workflow(name: "MyCustomWorkflowName")
-        final class ExampleWorkflowCustomName {
-            func run(
+        struct ExampleWorkflowCustomName {
+            mutating func run(
+                context: WorkflowContext<Self>,
                 input: String
             ) async throws -> String {
                 let activity = ExampleActivityContainer.Activities.ActivityCustom.self
-                return try await Workflow.executeActivity(
+                return try await context.executeActivity(
                     activity,
                     options: .init(startToCloseTimeout: .seconds(3)),
                     input: input

--- a/Tests/TemporalTests/Worker/Activities/ActivityInterceptorTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityInterceptorTests.swift
@@ -31,9 +31,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class VoidWorkflow {
-            func run(input: Void) async -> Int {
-                try! await Workflow.executeActivity(
+        struct VoidWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async -> Int {
+                try! await context.executeActivity(
                     Tests.Activities.Constant.self,
                     options: .init(scheduleToCloseTimeout: .seconds(5)),
                     input: ()
@@ -42,9 +42,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class HeartbeatingWorkflow {
-            func run(input: Void) async {
-                try! await Workflow.executeActivity(
+        struct HeartbeatingWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async {
+                try! await context.executeActivity(
                     Tests.Activities.Heartbeat.self,
                     options: .init(scheduleToCloseTimeout: .seconds(5)),
                     input: ()

--- a/Tests/TemporalTests/Worker/Activities/ActivityRetryTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityRetryTests.swift
@@ -46,7 +46,7 @@ extension TestServerDependentTests {
         struct NeverError: Error {}
 
         @Workflow
-        final class RetryTestWorkflow {
+        struct RetryTestWorkflow {
             enum Scenario: String, Codable, Hashable {
                 case defaultRetryPolicy
                 case noRetryPolicy
@@ -54,7 +54,7 @@ extension TestServerDependentTests {
                 case nonRetryableErrorTypesPolicy
             }
 
-            func run(input: Scenario) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 let options: ActivityOptions
                 switch input {
                 case .defaultRetryPolicy:
@@ -86,7 +86,7 @@ extension TestServerDependentTests {
                     )
                 }
 
-                try await Workflow.executeActivity(
+                try await context.executeActivity(
                     RetryTrackingActivity.self,
                     options: options,
                     input: input

--- a/Tests/TemporalTests/Worker/TemporalWorkerCancellationTests.swift
+++ b/Tests/TemporalTests/Worker/TemporalWorkerCancellationTests.swift
@@ -21,9 +21,9 @@ extension TestServerDependentTests {
     @Suite
     struct TemporalWorkerCancellationTests {
         @Workflow
-        final class SimpleWorkflow {
-            func run(input: Void) async throws {
-                try await Workflow.sleep(for: .seconds(1000))
+        struct SimpleWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.sleep(for: .seconds(1000))
             }
         }
 

--- a/Tests/TemporalTests/Worker/TemporalWorkerErrorTests.swift
+++ b/Tests/TemporalTests/Worker/TemporalWorkerErrorTests.swift
@@ -30,8 +30,8 @@ extension TestServerDependentTests {
     }
 
     @Workflow
-    final class VoidWorkflow {
-        func run(input: Void) async {}
+    struct VoidWorkflow {
+        mutating func run(context: WorkflowContext<Self>, input: Void) async {}
     }
 
     @Suite(.timeLimit(.minutes(1)))

--- a/Tests/TemporalTests/Worker/Tuning/WorkerTunerTests.swift
+++ b/Tests/TemporalTests/Worker/Tuning/WorkerTunerTests.swift
@@ -21,8 +21,8 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkerTunerTests {
         @Workflow
-        final class SimpleWorkflow {
-            func run(input: String) async -> String {
+        struct SimpleWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async -> String {
                 return "Hello, \(input)!"
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowActivityTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowActivityTests.swift
@@ -29,7 +29,7 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SimpleActivityWorkflow {
+        struct SimpleActivityWorkflow {
             enum Scenario: String, Codable, CaseIterable {
                 case remoteSymbol
                 case remoteStringName
@@ -43,29 +43,29 @@ extension TestServerDependentTests {
                 self.scenario = input
             }
 
-            func run(input: Scenario) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 switch input {
                 case .remoteSymbol:
-                    return try await Workflow.executeActivity(
+                    return try await context.executeActivity(
                         SimpleActivity.self,
                         options: .init(startToCloseTimeout: .seconds(1)),
                         input: scenario.rawValue
                     )
                 case .remoteStringName:
-                    return try await Workflow.executeActivity(
+                    return try await context.executeActivity(
                         name: "SimpleActivity",
                         options: .init(scheduleToCloseTimeout: .seconds(10)),
                         input: scenario.rawValue,
                         outputType: String.self
                     )
                 case .localSymbol:
-                    return try await Workflow.executeLocalActivity(
+                    return try await context.executeLocalActivity(
                         SimpleActivity.self,
                         options: .init(startToCloseTimeout: .seconds(1)),
                         input: scenario.rawValue
                     )
                 case .localStringName:
-                    return try await Workflow.executeLocalActivity(
+                    return try await context.executeLocalActivity(
                         name: "SimpleActivity",
                         options: .init(scheduleToCloseTimeout: .seconds(10)),
                         input: scenario.rawValue,
@@ -145,7 +145,7 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SelfCancellingActivityWorkflow {
+        struct SelfCancellingActivityWorkflow {
             enum Scenario: Codable {
                 case preCancel(Int)
                 case postCancel(Int)
@@ -160,7 +160,7 @@ extension TestServerDependentTests {
                 }
             }
 
-            func run(input scenario: Scenario) async throws {
+            mutating func run(context: WorkflowContext<Self>, input scenario: Scenario) async throws {
                 try await withThrowingTaskGroup(of: Void.self) { taskGroup in
                     if case .preCancel = scenario {
                         taskGroup.cancelAll()
@@ -171,7 +171,7 @@ extension TestServerDependentTests {
                         activityOptions.heartbeatTimeout = .seconds(10)
                         activityOptions.cancellationType = scenario.cancellationType
                         let error = try await #require(throws: (any Error).self) {
-                            try await Workflow.executeActivity(
+                            try await context.executeActivity(
                                 InfiniteActivity.self,
                                 options: activityOptions,
                                 input: ()
@@ -181,7 +181,7 @@ extension TestServerDependentTests {
                     }
 
                     if case .postCancel = scenario {
-                        try await Workflow.sleep(for: .seconds(1))
+                        try await context.sleep(for: .seconds(1))
                         taskGroup.cancelAll()
                     }
                 }
@@ -229,9 +229,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class DynamicActivityWorkflow {
-            func run(input: String) async throws -> String {
-                try await Workflow.executeActivity(
+        struct DynamicActivityWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                try await context.executeActivity(
                     name: "SomeUnregisteredActivity",
                     options: .init(startToCloseTimeout: .seconds(10)),
                     input: input,

--- a/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowCancelActivityTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowCancelActivityTests.swift
@@ -55,19 +55,19 @@ extension TestServerDependentTests {
             }
         }
         @Workflow
-        final class CancellationWorkflow {
+        struct CancellationWorkflow {
             enum Scenario: String, Codable, CaseIterable {
                 case tryCancel
                 case waitCancellationCompleted
                 case abandon
             }
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { false }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { false }
             }
 
             @WorkflowUpdate
-            func update(input: Scenario) async throws -> String {
+            func update(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 let cancellationType =
                     switch input {
                     case .tryCancel:
@@ -77,8 +77,8 @@ extension TestServerDependentTests {
                     case .abandon:
                         ActivityOptions.CancellationType.abandon
                     }
-                return try await Workflow.timeout(for: .seconds(0.1)) {
-                    try await Workflow.executeActivity(
+                return try await context.timeout(for: .seconds(0.1)) {
+                    try await context.executeActivity(
                         CancellationActivity.self,
                         options: .init(
                             scheduleToCloseTimeout: .seconds(10),
@@ -90,15 +90,15 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class CancellationShieldWorkflow {
-            func run(input: Void) async throws -> String {
+        struct CancellationShieldWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
                 do {
-                    try await Workflow.condition { false }
+                    try await context.condition { false }
                     Issue.record("Condition finished unexpectedly.")
                     return "condition became true"
                 } catch is CanceledError {
-                    return try await Workflow.withCancellationShield {
-                        try await Workflow.executeActivity(
+                    return try await context.withCancellationShield {
+                        try await context.executeActivity(
                             CancellationActivity.self,
                             options: .init(scheduleToCloseTimeout: .seconds(10)),
                         )
@@ -111,9 +111,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SimpleActivityWorkflow {
-            func run(input: Void) async throws {
-                _ = try await Workflow.executeActivity(SimpleActivity.self, options: .init(scheduleToCloseTimeout: .seconds(60)))
+        struct SimpleActivityWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                _ = try await context.executeActivity(SimpleActivity.self, options: .init(scheduleToCloseTimeout: .seconds(60)))
             }
         }
 

--- a/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowFailingActivityTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowFailingActivityTests.swift
@@ -25,7 +25,7 @@ extension TestServerDependentTests {
             }
         }
         @Workflow
-        final class FailureWorkflow {
+        struct FailureWorkflow {
             enum Scenario: String, Codable, CaseIterable {
                 case local
                 case remote
@@ -37,15 +37,15 @@ extension TestServerDependentTests {
                 self.scenario = input
             }
 
-            func run(input: Scenario) async throws {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws {
                 switch input {
                 case .local:
-                    try await Workflow.executeLocalActivity(
+                    try await context.executeLocalActivity(
                         FailureActivity.self,
                         options: .init(startToCloseTimeout: .seconds(10), retryPolicy: .init(maximumAttempts: 1))
                     )
                 case .remote:
-                    try await Workflow.executeActivity(
+                    try await context.executeActivity(
                         FailureActivity.self,
                         options: .init(startToCloseTimeout: .seconds(10), retryPolicy: .init(maximumAttempts: 1))
                     )

--- a/Tests/TemporalTests/Worker/Workflow/HandlerUnfinishedPolicyTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/HandlerUnfinishedPolicyTests.swift
@@ -23,45 +23,45 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct HandlerUnfinishedPolicyIntegrationTests {
         @Workflow
-        final class UnfinishedSignalWorkflow {
+        struct UnfinishedSignalWorkflow {
             private var signalReceived = false
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { self.signalReceived }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.signalReceived }
             }
 
             @WorkflowSignal
-            func warnSignal(input: Void) async throws {
+            mutating func warnSignal(context: WorkflowContext<Self>, input: Void) async throws {
                 self.signalReceived = true
-                try await Workflow.sleep(for: .seconds(999_999))
+                try await context.sleep(for: .seconds(999_999))
             }
 
             @WorkflowSignal(unfinishedPolicy: .abandon)
-            func abandonSignal(input: Void) async throws {
+            mutating func abandonSignal(context: WorkflowContext<Self>, input: Void) async throws {
                 self.signalReceived = true
-                try await Workflow.sleep(for: .seconds(999_999))
+                try await context.sleep(for: .seconds(999_999))
             }
         }
 
         @Workflow
-        final class UnfinishedUpdateWorkflow {
+        struct UnfinishedUpdateWorkflow {
             private var updateReceived = false
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { self.updateReceived }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.updateReceived }
             }
 
             @WorkflowUpdate
-            func warnUpdate(input: Void) async throws -> String {
+            mutating func warnUpdate(context: WorkflowContext<Self>, input: Void) async throws -> String {
                 self.updateReceived = true
-                try await Workflow.sleep(for: .seconds(999_999))
+                try await context.sleep(for: .seconds(999_999))
                 return "done"
             }
 
             @WorkflowUpdate(unfinishedPolicy: .abandon)
-            func abandonUpdate(input: Void) async throws -> String {
+            mutating func abandonUpdate(context: WorkflowContext<Self>, input: Void) async throws -> String {
                 self.updateReceived = true
-                try await Workflow.sleep(for: .seconds(999_999))
+                try await context.sleep(for: .seconds(999_999))
                 return "done"
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/Interceptors/WorkflowInboundInterceptorsTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/Interceptors/WorkflowInboundInterceptorsTests.swift
@@ -22,10 +22,10 @@ extension TestServerDependentTests {
     struct WorkflowInboundInterceptorTests {
         // The intent is to eventually make this use enough features to test all interception methods.
         @Workflow
-        final class InterceptorTestingWorkflow {
-            func run(input: Void) async throws {
+        struct InterceptorTestingWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
                 // ...although currently it doesn't do anything interesting
-                try await Workflow.sleep(for: .seconds(1))
+                try await context.sleep(for: .seconds(1))
             }
         }
 
@@ -43,7 +43,7 @@ extension TestServerDependentTests {
                     input: ExecuteWorkflowInput<Workflow>,
                     next: (ExecuteWorkflowInput<Workflow>) async throws -> Workflow.Output
                 ) async throws -> Workflow.Output {
-                    #expect(Temporal.Workflow.info.workflowName == "\(InterceptorTestingWorkflow.self)")
+                    #expect(Temporal.WorkflowContext<InterceptorTestingWorkflow>.inWorkflow)
                     interceptor.counter.withLock { $0 += 1 }
                     return try await next(input)
                 }

--- a/Tests/TemporalTests/Worker/Workflow/TimeSkippingInterceptorTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/TimeSkippingInterceptorTests.swift
@@ -21,10 +21,10 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct TimeSkippingInterceptorTests {
         @Workflow
-        final class LongTimerWorkflow {
-            func run(input: Void) async throws -> String {
+        struct LongTimerWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
                 // Sleep for 1 hour in workflow time
-                try await Workflow.sleep(for: .seconds(3600))
+                try await context.sleep(for: .seconds(3600))
                 return "completed"
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowCancellationTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowCancellationTests.swift
@@ -36,25 +36,25 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class CancellationWorkflow {
-            func run(input: Scenario) async throws {
+        struct CancellationWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws {
                 switch input {
                 case .swiftCancellationError:
                     do {
-                        try await Workflow.condition { false }
+                        try await context.condition { false }
                     } catch {
                         // ignore cancellation handling from Workflow/condition(_:)
                         try Task.checkCancellation()
                     }
                 case .cancelledError:
-                    try await Workflow.sleep(for: .seconds(40))
+                    try await context.sleep(for: .seconds(40))
                 case .activityCancelled:
-                    try await Workflow.executeActivity(
+                    try await context.executeActivity(
                         CancellationActivities.Activities.ActivityCancellation.self,
                         options: ActivityOptions(scheduleToCloseTimeout: .seconds(60))
                     )
                 case .childWorkflowCancelled:
-                    try await Workflow.executeChildWorkflow(
+                    try await context.executeChildWorkflow(
                         CancellationWorkflow.self,
                         options: .init(),
                         input: .cancelledError
@@ -64,8 +64,8 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class ThrowingWorkflow {
-            func run(input: Void) async throws {
+        struct ThrowingWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
                 throw CanceledError(message: "Workflow wasn't actually cancelled.")
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowChildWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowChildWorkflowTests.swift
@@ -23,7 +23,7 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowChildWorkflowTests {
         @Workflow
-        final class SimpleChildWorkflow {
+        struct SimpleChildWorkflow {
             enum Scenario: Codable {
                 case `return`
                 case fail
@@ -35,22 +35,22 @@ extension TestServerDependentTests {
             }
             var didPay = false
 
-            func run(input: Input) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Input) async throws -> String {
                 switch input.scenario {
                 case .return:
                     return input.value
                 case .fail:
-                    let detail1 = try Workflow.payloadConverter.convertValue("detail1")
-                    let detail2 = try Workflow.payloadConverter.convertValue("detail2")
+                    let detail1 = try context.payloadConverter.convertValue("detail1")
+                    let detail2 = try context.payloadConverter.convertValue("detail2")
                     throw ApplicationError(message: "Intentional failure", details: [detail1, detail2])
                 case .wait:
-                    try await Workflow.condition { false }
+                    try await context.condition { false }
                     fatalError()
                 }
             }
         }
         @Workflow
-        final class SimpleParentWorkflow {
+        struct SimpleParentWorkflow {
             enum Scenario: Codable {
                 case success
                 case fail
@@ -61,37 +61,37 @@ extension TestServerDependentTests {
                 var value: String
             }
 
-            func run(input: Input) async throws -> [String] {
+            mutating func run(context: WorkflowContext<Self>, input: Input) async throws -> [String] {
                 switch input.scenario {
                 case .success:
-                    let first = try await Workflow.executeChildWorkflow(
+                    let first = try await context.executeChildWorkflow(
                         SimpleChildWorkflow.self,
                         input: .init(scenario: .return, value: input.value)
                     )
-                    let second = try await Workflow.executeChildWorkflow(
+                    let second = try await context.executeChildWorkflow(
                         SimpleChildWorkflow.self,
                         input: .init(scenario: .return, value: input.value)
                     )
-                    let third = try await Workflow.executeChildWorkflow(
+                    let third = try await context.executeChildWorkflow(
                         SimpleChildWorkflow.self,
                         input: .init(scenario: .return, value: input.value)
                     )
                     return [first, second, third]
                 case .fail:
-                    _ = try await Workflow.executeChildWorkflow(
+                    _ = try await context.executeChildWorkflow(
                         SimpleChildWorkflow.self,
                         input: .init(scenario: .fail, value: "")
                     )
                     fatalError()
 
                 case .alreadyExists:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         SimpleChildWorkflow.self,
                         input: .init(scenario: .wait, value: "")
                     )
                     var options = ChildWorkflowOptions()
                     options.id = handle.id
-                    _ = try await Workflow.startChildWorkflow(
+                    _ = try await context.startChildWorkflow(
                         SimpleChildWorkflow.self,
                         options: options,
                         input: .init(scenario: .wait, value: "")
@@ -102,10 +102,10 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class CancelChildWorkflow {
-            func run(input: Void) async throws -> String {
+        struct CancelChildWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
                 do {
-                    try await Workflow.condition { false }
+                    try await context.condition { false }
                     fatalError()
                 } catch is CanceledError {
                     return "Done"
@@ -116,31 +116,31 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class CancelParentWorkflow {
+        struct CancelParentWorkflow {
             enum Scenario: Codable {
                 case cancelWait
                 case cancelTry
             }
 
-            func run(input: Scenario) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 switch input {
                 case .cancelWait:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         CancelChildWorkflow.self,
                         options: .init(),
                         input: ()
                     )
-                    return try await Workflow.timeout(for: .seconds(0.1)) {
+                    return try await context.timeout(for: .seconds(0.1)) {
                         try await handle.result()
                     }
 
                 case .cancelTry:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         CancelChildWorkflow.self,
                         options: .init(cancellationType: .tryCancel),
                         input: ()
                     )
-                    return try await Workflow.timeout(for: .seconds(0.1)) {
+                    return try await context.timeout(for: .seconds(0.1)) {
                         try await handle.result()
                     }
                 }
@@ -250,7 +250,7 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SignalChildWorkflow {
+        struct SignalChildWorkflow {
             enum Scenario: Codable {
                 case wait
                 case finish
@@ -258,10 +258,10 @@ extension TestServerDependentTests {
 
             var signals = [String]()
 
-            func run(input: Scenario) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 switch input {
                 case .wait:
-                    try await Workflow.condition { false }
+                    try await context.condition { false }
                     return "done"
                 case .finish:
                     return "done"
@@ -269,7 +269,7 @@ extension TestServerDependentTests {
             }
 
             @WorkflowSignal
-            func signal(input: String) {
+            mutating func signal(input: String) {
                 self.signals.append(input)
             }
 
@@ -280,17 +280,17 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SignalParentWorkflow {
+        struct SignalParentWorkflow {
             enum Scenario: Codable {
                 case signal
                 case signalButDone
                 case signalThenCancel
             }
 
-            func run(input: Scenario) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 switch input {
                 case .signal:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         SignalChildWorkflow.self,
                         options: .init(),
                         input: .wait
@@ -305,7 +305,7 @@ extension TestServerDependentTests {
                     )
                     return handle.id
                 case .signalButDone:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         SignalChildWorkflow.self,
                         options: .init(),
                         input: .finish
@@ -317,7 +317,7 @@ extension TestServerDependentTests {
                     )
                     return handle.id
                 case .signalThenCancel:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         SignalChildWorkflow.self,
                         options: .init(),
                         input: .finish
@@ -383,45 +383,45 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class ParentClosePolicyChildWorkflow {
+        struct ParentClosePolicyChildWorkflow {
             private var finished = false
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { self.finished }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.finished }
             }
 
             @WorkflowSignal
-            func signal(input: Void) {
+            mutating func signal(input: Void) {
                 self.finished = true
             }
         }
 
         @Workflow
-        final class ParentClosePolicyParentWorkflow {
+        struct ParentClosePolicyParentWorkflow {
             enum Scenario: Codable {
                 case parentCloseTerminate
                 case parentCloseRequestCancel
                 case parentCloseAbandon
             }
 
-            func run(input: Scenario) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 switch input {
                 case .parentCloseTerminate:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         ParentClosePolicyChildWorkflow.self,
                         options: .init(),
                         input: ()
                     )
                     return handle.id
                 case .parentCloseRequestCancel:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         ParentClosePolicyChildWorkflow.self,
                         options: .init(parentClosePolicy: .requestCancel),
                         input: ()
                     )
                     return handle.id
                 case .parentCloseAbandon:
-                    let handle = try await Workflow.startChildWorkflow(
+                    let handle = try await context.startChildWorkflow(
                         ParentClosePolicyChildWorkflow.self,
                         options: .init(parentClosePolicy: .abandon),
                         input: ()
@@ -534,9 +534,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class ChildMemoAndRetryWorkflow {
-            func run(input: Void) async throws {
-                guard let memo = try await Workflow.getMemoValue(for: "hello", as: String.self) else {
+        struct ChildMemoAndRetryWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                guard let memo = try await context.getMemoValue(for: "hello", as: String.self) else {
                     throw ApplicationError(message: "Workflow memo not found!", isNonRetryable: true)
                 }
 
@@ -544,7 +544,7 @@ extension TestServerDependentTests {
                     throw ApplicationError(message: "Workflow memo has invalid value: \(memo)!", isNonRetryable: true)
                 }
 
-                guard let retryPolicy = Workflow.info.retryPolicy,
+                guard let retryPolicy = context.info.retryPolicy,
                     retryPolicy.maximumAttempts == 30
                 else {
                     throw ApplicationError(message: "Retry Policy is not present!", isNonRetryable: true)
@@ -553,9 +553,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class ParentMemoAndRetryWorkflow {
-            func run(input: Void) async throws {
-                try await Workflow.executeChildWorkflow(
+        struct ParentMemoAndRetryWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.executeChildWorkflow(
                     ChildMemoAndRetryWorkflow.self,
                     options: ChildWorkflowOptions(
                         retryPolicy: .init(maximumAttempts: 30),
@@ -574,20 +574,20 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class ChildWorkflow {
+        struct ChildWorkflow {
             struct Input: Codable {
                 let id: Int
             }
 
-            func run(input: Input) async throws {
-                try await Workflow.sleep(for: .seconds(3600))
+            mutating func run(context: WorkflowContext<Self>, input: Input) async throws {
+                try await context.sleep(for: .seconds(3600))
             }
         }
 
         @Workflow
-        final class ParentWorkflow {
-            func run(input: Void) async throws {
-                let logger = Workflow.logger
+        struct ParentWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                let logger = context.logger
                 var ids: [Int] = []
                 ids.reserveCapacity(150)
                 for index in 0..<150 {
@@ -597,11 +597,11 @@ extension TestServerDependentTests {
                 var handles: [ChildWorkflowHandle<ChildWorkflow>] = []
                 handles.reserveCapacity(ids.count)
 
-                _ = Workflow.patch("starting child-workflows ...")
+                _ = context.patch("starting child-workflows ...")
 
                 for id in ids {
                     do {
-                        let handle = try await Workflow.startChildWorkflow(ChildWorkflow.self, input: .init(id: id))
+                        let handle = try await context.startChildWorkflow(ChildWorkflow.self, input: .init(id: id))
                         handles.append(handle)
                     } catch is CanceledError {
                         logger.info("Workflow cancelled skipping start of the other child workflows.")
@@ -612,7 +612,7 @@ extension TestServerDependentTests {
                     }
                 }
 
-                _ = Workflow.patch("started child-workflows")
+                _ = context.patch("started child-workflows")
 
                 var successfulWorkflows = 0
                 var cancelledWorkflows = 0

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowContinueAsNewTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowContinueAsNewTests.swift
@@ -22,13 +22,13 @@ extension TestServerDependentTests {
     struct WorkflowContinueAsNewTests {
 
         @Workflow
-        final class ContinueAsNewWorkflow {
-            func run(input: [String]) async throws -> [String] {
-                let pastRunIDsCount: Int? = try await Workflow.getMemoValue(for: "past_run_id_count")
+        struct ContinueAsNewWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: [String]) async throws -> [String] {
+                let pastRunIDsCount: Int? = try await context.getMemoValue(for: "past_run_id_count")
                 guard input.count == pastRunIDsCount ?? 0 else {
                     throw TestError()
                 }
-                guard Workflow.info.retryPolicy?.maximumAttempts == input.count + 1000 else {
+                guard context.info.retryPolicy?.maximumAttempts == input.count + 1000 else {
                     throw TestError()
                 }
 
@@ -37,8 +37,8 @@ extension TestServerDependentTests {
                 }
 
                 var input = input
-                input.append(Workflow.info.runID)
-                throw try await Workflow.makeContinueAsNewError(
+                input.append(context.info.runID)
+                throw try await context.makeContinueAsNewError(
                     options: .init(
                         retryPolicy: .init(maximumAttempts: input.count + 1000),
                         memo: ["past_run_id_count": input.count]
@@ -94,9 +94,9 @@ extension TestServerDependentTests {
         // MARK: - Continue as different workflow type
 
         @Workflow
-        final class ContinueAsDifferentTypedWorkflow {
-            func run(input: String) async throws -> String {
-                throw try await Workflow.makeContinueAsNewError(
+        struct ContinueAsDifferentTypedWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                throw try await context.makeContinueAsNewError(
                     workflowType: ContinueAsNewTargetWorkflow.self,
                     input: input + "-continued"
                 )
@@ -104,9 +104,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class ContinueAsDifferentUntypedWorkflow {
-            func run(input: String) async throws -> String {
-                throw try await Workflow.makeContinueAsNewError(
+        struct ContinueAsDifferentUntypedWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                throw try await context.makeContinueAsNewError(
                     workflowName: ContinueAsNewTargetWorkflow.name,
                     input: input + "-continued"
                 )
@@ -114,8 +114,8 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class ContinueAsNewTargetWorkflow {
-            func run(input: String) async throws -> String {
+        struct ContinueAsNewTargetWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
                 return input + "-done"
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowExternalWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowExternalWorkflowTests.swift
@@ -22,22 +22,22 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowExternalWorkflowTests {
         @Workflow
-        final class ExternalTargetWorkflow {
+        struct ExternalTargetWorkflow {
             private var signals = [String]()
             private var finished = false
 
-            func run(input: Void) async throws -> String {
-                try await Workflow.condition { self.finished }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
+                try await context.condition { $0.finished }
                 return "done"
             }
 
             @WorkflowSignal
-            func signal(input: String) {
+            mutating func signal(input: String) {
                 self.signals.append(input)
             }
 
             @WorkflowSignal
-            func finish(input: Void) {
+            mutating func finish(input: Void) {
                 self.finished = true
             }
 
@@ -48,9 +48,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SignalExternalWorkflow {
-            func run(input: String) async throws -> String {
-                let handle = Workflow.getExternalWorkflowHandle(
+        struct SignalExternalWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                let handle = context.getExternalWorkflowHandle(
                     ExternalTargetWorkflow.self,
                     id: input
                 )
@@ -67,9 +67,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class CancelExternalWorkflow {
-            func run(input: String) async throws -> String {
-                let handle = Workflow.getExternalWorkflowHandle(
+        struct CancelExternalWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                let handle = context.getExternalWorkflowHandle(
                     ExternalTargetWorkflow.self,
                     id: input
                 )
@@ -79,9 +79,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SignalExternalWithInputWorkflow {
-            func run(input: String) async throws -> String {
-                let handle = Workflow.getExternalWorkflowHandle(id: input)
+        struct SignalExternalWithInputWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                let handle = context.getExternalWorkflowHandle(id: input)
                 try await handle.signal(
                     signalName: "Signal",
                     input: "custom-signal-data"
@@ -91,9 +91,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class CancelExternalUntypedWorkflow {
-            func run(input: String) async throws -> String {
-                let handle = Workflow.getExternalWorkflowHandle(id: input)
+        struct CancelExternalUntypedWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                let handle = context.getExternalWorkflowHandle(id: input)
                 try await handle.cancel()
                 return "cancelled-untyped"
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowHeaderTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowHeaderTests.swift
@@ -132,16 +132,16 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class HeaderWorkflow {
+        struct HeaderWorkflow {
             var proceed = false
 
-            func run(input: Void) async throws -> Bool {
-                try await Workflow.condition { self.proceed }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> Bool {
+                try await context.condition { $0.proceed }
                 return true
             }
 
             @WorkflowSignal
-            func signal(input: Void) throws {
+            mutating func signal(input: Void) throws {
                 proceed = true
             }
 

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowHistoryInfoTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowHistoryInfoTests.swift
@@ -21,7 +21,7 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowHistoryInfoTests {
         @Workflow
-        final class HistoryInfoWorkflow {
+        struct HistoryInfoWorkflow {
             struct Output: Codable {
                 let isReplaying: Bool
                 let continueAsNewSuggested: Bool
@@ -29,20 +29,20 @@ extension TestServerDependentTests {
                 let currentHistorySize: Int
             }
 
-            func run(input: Void) async throws -> Output {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> Output {
                 try await withThrowingDiscardingTaskGroup { group in
                     for _ in 0..<30 {
                         group.addTask {
-                            try await Workflow.sleep(for: .milliseconds(10))
+                            try await context.sleep(for: .milliseconds(10))
                         }
                     }
                 }
 
                 return .init(
-                    isReplaying: Workflow.isReplaying,
-                    continueAsNewSuggested: Workflow.continueAsNewSuggested,
-                    currentHistoryLength: Workflow.currentHistoryLength,
-                    currentHistorySize: Workflow.currentHistorySize
+                    isReplaying: context.isReplaying,
+                    continueAsNewSuggested: context.continueAsNewSuggested,
+                    currentHistoryLength: context.currentHistoryLength,
+                    currentHistorySize: context.currentHistorySize
                 )
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowInfoTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowInfoTests.swift
@@ -22,9 +22,9 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowInfoTests {
         @Workflow
-        final class InfoWorkflow {
-            func run(input: Void) async throws -> WorkflowInfo {
-                Workflow.info
+        struct InfoWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> WorkflowInfo {
+                context.info
             }
         }
 

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowInputOutputTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowInputOutputTests.swift
@@ -21,36 +21,36 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowInputOutputTests {
         @Workflow
-        final class VoidWorkflow {
-            func run(input: Void) async {}
+        struct VoidWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async {}
         }
 
         @Workflow
-        final class StringWorkflow {
-            func run(input: String) async -> String {
+        struct StringWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: String) async -> String {
                 return input
             }
         }
 
         @Workflow
-        final class TestStructWorkflow {
+        struct TestStructWorkflow {
             struct TestStruct {}
 
-            func run(input: Void) async -> TestStruct {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async -> TestStruct {
                 return .init()
             }
         }
 
         static let throwsTestErrorThenSucceedsCounter = Mutex(0)
         @Workflow
-        final class ThrowingWorkflow {
+        struct ThrowingWorkflow {
             enum Scenario: Codable {
                 case throwTestError
                 case throwApplicationError
                 case throwsTestErrorThenSucceeds
             }
 
-            func run(input: Scenario) async throws {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws {
                 switch input {
                 case .throwTestError:
                     throw TestError()

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowMemoTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowMemoTests.swift
@@ -20,7 +20,7 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowMemoTests {
         @Workflow
-        final class MemoWorkflow {
+        struct MemoWorkflow {
             struct Output: Codable, Hashable {
                 var originalKey1: String?
                 var originalKey2: String?
@@ -30,15 +30,15 @@ extension TestServerDependentTests {
                 var updatedKey3: String?
             }
 
-            func run(input: Void) async throws -> Output {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> Output {
                 var output = Output()
-                output.originalKey1 = try await Workflow.getMemoValue(for: "key1")
-                output.originalKey2 = try await Workflow.getMemoValue(for: "key2")
-                output.originalKey3 = try await Workflow.getMemoValue(for: "key3")
-                try await Workflow.upsertMemo(["key1": "new-val1", "key2": nil])
-                output.updatedKey1 = try await Workflow.getMemoValue(for: "key1")
-                output.updatedKey2 = try await Workflow.getMemoValue(for: "key2")
-                output.updatedKey3 = try await Workflow.getMemoValue(for: "key3")
+                output.originalKey1 = try await context.getMemoValue(for: "key1")
+                output.originalKey2 = try await context.getMemoValue(for: "key2")
+                output.originalKey3 = try await context.getMemoValue(for: "key3")
+                try await context.upsertMemo(["key1": "new-val1", "key2": nil])
+                output.updatedKey1 = try await context.getMemoValue(for: "key1")
+                output.updatedKey2 = try await context.getMemoValue(for: "key2")
+                output.updatedKey3 = try await context.getMemoValue(for: "key3")
                 return output
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowMetadataTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowMetadataTests.swift
@@ -21,18 +21,18 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowMetadataTests {
         @Workflow
-        final class TestWorkflow {
-            func run(input: Void) async throws {
-                Workflow.currentDetails = "initial current details"
-                try await Workflow.condition { self.shouldContinue }
-                Workflow.currentDetails = "final current details"
+        struct TestWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                context.currentDetails = "initial current details"
+                try await context.condition { $0.shouldContinue }
+                context.currentDetails = "final current details"
             }
 
             @WorkflowSignal
-            func someSignal(input: Void) async throws {}
+            func someSignal(input: Void) {}
 
             @WorkflowSignal(name: "some signal", description: "some signal description")
-            func someOtherSignal(input: Void) async throws {}
+            func someOtherSignal(input: Void) {}
 
             @WorkflowQuery(description: "continue description")
             func `continue`(input: Void) throws -> Bool {
@@ -41,7 +41,7 @@ extension TestServerDependentTests {
             var shouldContinue = false
 
             @WorkflowUpdate(description: "some update description")
-            func someUpdate(input: Void) async throws {
+            mutating func someUpdate(context: WorkflowContext<Self>, input: Void) async throws {
                 self.shouldContinue = true
             }
 

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowPatchTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowPatchTests.swift
@@ -41,7 +41,7 @@ extension TestServerDependentTests {
         // MARK: - Workflows
 
         @Workflow(name: "PatchWorkflow")
-        final class PrePatchWorkflow {
+        struct PrePatchWorkflow {
             @WorkflowQuery
             func result(input: Void) throws -> String {
                 return _result
@@ -49,37 +49,39 @@ extension TestServerDependentTests {
             @_WorkflowState  // This works around a compiler crash
             var _result = ""
 
-            func run(input: Void) async throws {
-                _result = try await Workflow.executeActivity(
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                let r = try await context.executeActivity(
                     PrePatchActivity.self,
                     options: .init(scheduleToCloseTimeout: .seconds(100))
                 )
+                self._result = r
             }
         }
 
         @Workflow
-        final class PatchWorkflow {
+        struct PatchWorkflow {
             @WorkflowQuery
             func result(input: Void) throws -> String {
                 return _result
             }
             var _result = ""
 
-            func run(input: Void) async throws {
-                _result =
-                    if Workflow.patch("my-patch") {
-                        try await Workflow.executeActivity(
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                let r: String =
+                    if context.patch("my-patch") {
+                        try await context.executeActivity(
                             PostPatchActivity.self,
                             options: .init(scheduleToCloseTimeout: .seconds(100))
                         )
                     } else {
-                        try await Workflow.executeActivity(PrePatchActivity.self, options: .init(scheduleToCloseTimeout: .seconds(100)))
+                        try await context.executeActivity(PrePatchActivity.self, options: .init(scheduleToCloseTimeout: .seconds(100)))
                     }
+                self._result = r
             }
         }
 
         @Workflow(name: "PatchWorkflow")
-        final class DeprecatedPatchWorkflow {
+        struct DeprecatedPatchWorkflow {
             @WorkflowQuery
             func result(input: Void) throws -> String {
                 return _result
@@ -87,17 +89,18 @@ extension TestServerDependentTests {
             @_WorkflowState  // This works around a compiler crash
             var _result = ""
 
-            func run(input: Void) async throws {
-                Workflow.deprecatePatch("my-patch")
-                _result = try await Workflow.executeActivity(
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                context.deprecatePatch("my-patch")
+                let r = try await context.executeActivity(
                     PostPatchActivity.self,
                     options: .init(scheduleToCloseTimeout: .seconds(100))
                 )
+                self._result = r
             }
         }
 
         @Workflow(name: "PatchWorkflow")
-        final class PostPatchWorkflow {
+        struct PostPatchWorkflow {
             @WorkflowQuery
             func result(input: Void) throws -> String {
                 return _result
@@ -105,11 +108,12 @@ extension TestServerDependentTests {
             @_WorkflowState  // This works around a compiler crash
             var _result = ""
 
-            func run(input: Void) async throws {
-                _result = try await Workflow.executeActivity(
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                let r = try await context.executeActivity(
                     PostPatchActivity.self,
                     options: .init(scheduleToCloseTimeout: .seconds(100))
                 )
+                self._result = r
             }
         }
 

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
@@ -257,5 +257,50 @@ extension TestServerDependentTests {
             }
         }
 
+        @Workflow
+        struct QueryWithContextWorkflow {
+            private var state = "initial"
+
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.state == "finished" }
+            }
+
+            @WorkflowQuery
+            func queryWithContext(context: WorkflowContextView, input: Void) throws -> String {
+                "\(state) at \(context.info.workflowType)"
+            }
+
+            @WorkflowSignal
+            mutating func signal(input: String) {
+                self.state = input
+            }
+        }
+
+        @Test
+        func queryWithContextParameter() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [QueryWithContextWorkflow.self]
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: QueryWithContextWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+
+                let result = try await handle.query(
+                    queryType: QueryWithContextWorkflow.QueryWithContext.self
+                )
+                // The query accesses both self.state and context.info.workflowType
+                #expect(result.contains("initial"))
+                #expect(result.contains("QueryWithContextWorkflow"))
+
+                try await handle.signal(
+                    signalType: QueryWithContextWorkflow.Signal.self,
+                    input: "finished"
+                )
+
+                try await handle.result()
+            }
+        }
+
     }
 }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
@@ -36,12 +36,13 @@ extension TestServerDependentTests {
         }
 
         @Workflow(name: "SimpleQueryWorkflow")
-        final class SimpleQueryWorkflow<Activity: ActivityDefinition> where Activity.Input == Void, Activity.Output == String {
+        struct SimpleQueryWorkflow<Activity: ActivityDefinition> where Activity.Input == Void, Activity.Output == String {
             @_WorkflowState  // This works around a compiler crash
             private var state = "initial"
 
-            func run(input: Void) async throws {
-                state = try await Workflow.executeActivity(Activity.self, options: .init(scheduleToCloseTimeout: .seconds(100)))
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                let result = try await context.executeActivity(Activity.self, options: .init(scheduleToCloseTimeout: .seconds(100)))
+                self.state = result
             }
 
             @WorkflowQuery
@@ -51,15 +52,15 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class QueryWorkflow {
+        struct QueryWorkflow {
             enum QueryScenario: Codable {
                 case simpleQuery
             }
 
             private var state = "initial"
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { self.state == "finished" }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.state == "finished" }
             }
 
             @WorkflowQuery
@@ -71,7 +72,7 @@ extension TestServerDependentTests {
             }
 
             @WorkflowSignal
-            func signal(input: String) async throws {
+            mutating func signal(input: String) {
                 self.state = input
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowRawValueTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowRawValueTests.swift
@@ -23,9 +23,9 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowRawValueTests {
         @Workflow
-        final class RawValueWorkflow {
-            func run(input: TemporalRawValue) async throws -> TemporalRawValue {
-                try await Workflow.executeActivity(
+        struct RawValueWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: TemporalRawValue) async throws -> TemporalRawValue {
+                try await context.executeActivity(
                     Container.Activities.DoubleContent.self,
                     options: .init(scheduleToCloseTimeout: .seconds(100)),
                     input: input

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSearchAttributeTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSearchAttributeTests.swift
@@ -31,7 +31,7 @@ extension TestServerDependentTests {
         static let attributeText = SearchAttributeKey.text("SwiftTemporalTestText")
 
         @Workflow
-        final class SearchAttributesWorkflow {
+        struct SearchAttributesWorkflow {
             static let attributesInitial = SearchAttributeCollection {
                 $0[attributeBool] = true
                 $0[attributeDate] = Calendar.current.startOfDay(for: .now)
@@ -73,24 +73,24 @@ extension TestServerDependentTests {
 
             private var proceed = false
             @WorkflowSignal
-            func proceed(input: Void) async throws {
+            mutating func proceed(input: Void) {
                 proceed = true
             }
 
-            func run(input: Void) async throws {
-                #expect(Workflow.searchAttributes == Self.attributesInitial)
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                #expect(context.searchAttributes == Self.attributesInitial)
 
-                try await Workflow.condition { self.proceed }
-                proceed = false
+                try await context.condition { $0.proceed }
+                self.proceed = false
 
-                Workflow.upsertSearchAttributes(Self.attributeFirstUpdates)
-                #expect(Workflow.searchAttributes == Self.attributeFirstUpdated)
+                context.upsertSearchAttributes(Self.attributeFirstUpdates)
+                #expect(context.searchAttributes == Self.attributeFirstUpdated)
 
-                try await Workflow.condition { self.proceed }
-                proceed = false
+                try await context.condition { $0.proceed }
+                self.proceed = false
 
-                Workflow.upsertSearchAttributes(Self.attributeSecondUpdates)
-                #expect(Workflow.searchAttributes == Self.attributeSecondUpdated)
+                context.upsertSearchAttributes(Self.attributeSecondUpdates)
+                #expect(context.searchAttributes == Self.attributeSecondUpdated)
             }
         }
 
@@ -149,9 +149,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SimpleParentWorkflow {
-            func run(input: Void) async throws -> String {
-                try await Workflow.executeChildWorkflow(
+        struct SimpleParentWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
+                try await context.executeChildWorkflow(
                     SimpleWorkflow.self,
                     options: .init(
                         searchAttributes: .init {
@@ -164,9 +164,9 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SimpleWorkflow {
-            func run(input: Void) async throws -> String {
-                "\(Workflow.searchAttributes[attributeInt] ?? 0)-\(Workflow.searchAttributes[attributeKeyword] ?? "")-bar"
+        struct SimpleWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
+                "\(context.searchAttributes[attributeInt] ?? 0)-\(context.searchAttributes[attributeKeyword] ?? "")-bar"
             }
         }
 

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
@@ -22,7 +22,7 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowSignalTests {
         @Workflow
-        final class SignalWorkflow {
+        struct SignalWorkflow {
             enum SignalScenario: Codable {
                 case updateState
                 case throwTestFailureError
@@ -33,14 +33,14 @@ extension TestServerDependentTests {
 
             private var state = ""
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { self.state == "signaled" }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.state == "signaled" }
                 self.state = "runFinished"
-                try await Workflow.condition { Workflow.allHandlersFinished }
+                try await context.condition { context.allHandlersFinished }
             }
 
             @WorkflowSignal
-            func signal(input: SignalScenario) async throws {
+            mutating func signal(context: WorkflowContext<Self>, input: SignalScenario) async throws {
                 switch input {
                 case .updateState:
                     self.state = "signaled"
@@ -52,11 +52,11 @@ extension TestServerDependentTests {
                         type: "Failure"
                     )
                 case .timer:
-                    try await Workflow.sleep(for: .seconds(1))
+                    try await context.sleep(for: .seconds(1))
                     self.state = "signaled"
                 case .updateStateAndWaitCondition:
                     self.state = "signaled"
-                    try await Workflow.condition { self.state == "runFinished" }
+                    try await context.condition { $0.state == "runFinished" }
                 }
             }
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSleepTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSleepTests.swift
@@ -22,7 +22,7 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowSleepTests {
         @Workflow
-        final class SleepWorkflow {
+        struct SleepWorkflow {
             enum Scenario: Codable {
                 case singleSleep
                 case multiSleep
@@ -34,45 +34,45 @@ extension TestServerDependentTests {
                 case cancelWorklow
             }
 
-            func run(input: Scenario) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 switch input {
                 case .singleSleep:
-                    try await Workflow.sleep(for: .seconds(1))
+                    try await context.sleep(for: .seconds(1))
                     return "Done"
                 case .multiSleep:
-                    try await Workflow.sleep(for: .seconds(1))
-                    try await Workflow.sleep(for: .seconds(1))
-                    try await Workflow.sleep(for: .seconds(1))
+                    try await context.sleep(for: .seconds(1))
+                    try await context.sleep(for: .seconds(1))
+                    try await context.sleep(for: .seconds(1))
                     return "Done"
                 case .concurrentSleep:
-                    return try await self.concurrentSleep()
+                    return try await self.concurrentSleep(context: context)
                 case .alreadyCanceledSleep:
-                    return await self.alreadyCanceledSleep()
+                    return await self.alreadyCanceledSleep(context: context)
                 case .cancelSleep:
-                    return await self.cancelSleep()
+                    return await self.cancelSleep(context: context)
                 case .negativeDuration:
-                    return await self.negativeDuration()
+                    return await self.negativeDuration(context: context)
                 case .zeroDuration:
-                    try await Workflow.sleep(for: .zero)
+                    try await context.sleep(for: .zero)
                     return "Done"
                 case .cancelWorklow:
-                    try? await Workflow.sleep(for: .seconds(10000))
+                    try? await context.sleep(for: .seconds(10000))
                     return "Done"
                 }
             }
 
-            private func concurrentSleep() async throws -> String {
+            private func concurrentSleep(context: WorkflowContext<Self>) async throws -> String {
                 return try await withThrowingTaskGroup(of: String.self) { group in
                     group.addTask {
-                        try await Workflow.sleep(for: .seconds(1))
+                        try await context.sleep(for: .seconds(1))
                         return "1"
                     }
                     group.addTask {
-                        try await Workflow.sleep(for: .seconds(1))
+                        try await context.sleep(for: .seconds(1))
                         return "2"
                     }
                     group.addTask {
-                        try await Workflow.sleep(for: .seconds(1))
+                        try await context.sleep(for: .seconds(1))
                         return "3"
                     }
                     var output = ""
@@ -83,11 +83,11 @@ extension TestServerDependentTests {
                 }
             }
 
-            private func alreadyCanceledSleep() async -> String {
+            private func alreadyCanceledSleep(context: WorkflowContext<Self>) async -> String {
                 await withThrowingTaskGroup(of: String.self) { group in
                     group.cancelAll()
                     group.addTask {
-                        try await Workflow.sleep(for: .seconds(100))
+                        try await context.sleep(for: .seconds(100))
                         return "Second"
                     }
                     do {
@@ -98,15 +98,15 @@ extension TestServerDependentTests {
                 }
             }
 
-            private func cancelSleep() async -> String {
+            private func cancelSleep(context: WorkflowContext<Self>) async -> String {
                 await withThrowingTaskGroup(of: String.self) { group in
                     group.addTask {
-                        try await Workflow.sleep(for: .seconds(100))
+                        try await context.sleep(for: .seconds(100))
                         return "Done"
                     }
 
                     do {
-                        try await Workflow.sleep(for: .seconds(1))
+                        try await context.sleep(for: .seconds(1))
                         group.cancelAll()
                         return try await group.next()!
                     } catch {
@@ -115,9 +115,9 @@ extension TestServerDependentTests {
                 }
             }
 
-            private func negativeDuration() async -> String {
+            private func negativeDuration(context: WorkflowContext<Self>) async -> String {
                 do {
-                    try await Workflow.sleep(for: .seconds(-1))
+                    try await context.sleep(for: .seconds(-1))
                 } catch {
                     return "\(type(of: error))"
                 }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowStateTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowStateTests.swift
@@ -22,7 +22,7 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowStateTests {
         @Workflow
-        final class StateWorkflow {
+        struct StateWorkflow {
             struct Output: Codable {
                 var counter1: Int
                 var counter2: Int
@@ -36,21 +36,21 @@ extension TestServerDependentTests {
                 self.counter1 = input
             }
 
-            func run(input: Int) async throws -> Output {
+            mutating func run(context: WorkflowContext<Self>, input: Int) async throws -> Output {
                 self.counter1 += 1
                 self.counter2 += 1
                 self.counter3? += 1
 
                 await withTaskGroup { group in
                     group.addTask {
-                        self.counter1 += 1
-                        self.counter2 += 1
-                        self.counter3? += 1
+                        context.mutateState { $0.counter1 += 1 }
+                        context.mutateState { $0.counter2 += 1 }
+                        context.mutateState { $0.counter3? += 1 }
                     }
                     group.addTask {
-                        self.counter1 += 1
-                        self.counter2 += 1
-                        self.counter3? += 1
+                        context.mutateState { $0.counter1 += 1 }
+                        context.mutateState { $0.counter2 += 1 }
+                        context.mutateState { $0.counter3? += 1 }
                     }
                 }
 

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowTimeoutTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowTimeoutTests.swift
@@ -20,7 +20,7 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests), .serialized)
     struct WorkflowTimeoutTests {
         @Workflow
-        final class TimeoutWorkflow {
+        struct TimeoutWorkflow {
             enum Scenario: Codable {
                 case timeoutSleep
                 case errorIsRethrown
@@ -29,12 +29,12 @@ extension TestServerDependentTests {
                 case alreadyCancelled
             }
 
-            func run(input: Scenario) async throws -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async throws -> String {
                 switch input {
                 case .timeoutSleep:
                     do {
-                        try await Workflow.timeout(for: .seconds(1)) {
-                            try await Workflow.sleep(for: .seconds(100))
+                        try await context.timeout(for: .seconds(1)) {
+                            try await context.sleep(for: .seconds(100))
                         }
                         return "Done"
                     } catch {
@@ -42,7 +42,7 @@ extension TestServerDependentTests {
                     }
                 case .errorIsRethrown:
                     do {
-                        try await Workflow.timeout(for: .milliseconds(1)) {
+                        try await context.timeout(for: .milliseconds(1)) {
                             throw TestError()
                         }
                         return "Done"
@@ -50,22 +50,22 @@ extension TestServerDependentTests {
                         return "\(type(of: error))"
                     }
                 case .bodyReturnsAfterCancel:
-                    return await Workflow.timeout(for: .milliseconds(1)) {
+                    return await context.timeout(for: .milliseconds(1)) {
                         do {
-                            try await Workflow.sleep(for: .seconds(100))
+                            try await context.sleep(for: .seconds(100))
                             fatalError()
                         } catch {
                             return "Done"
                         }
                     }
                 case .bodyReturnsBeforeCancel:
-                    return await Workflow.timeout(for: .milliseconds(1)) {
+                    return await context.timeout(for: .milliseconds(1)) {
                         return "Done"
                     }
                 case .alreadyCancelled:
                     return await withTaskGroup(of: String.self) { group in
                         group.addTask {
-                            await Workflow.timeout(for: .seconds(1)) {
+                            await context.timeout(for: .seconds(1)) {
                                 return "Done"
                             }
                         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowTimestampTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowTimestampTests.swift
@@ -27,20 +27,23 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SlowWorkflow {
-            func run(input: Void) async throws -> Result {
-                let now0 = Workflow.now
-                let now1 = Workflow.now
+        struct SlowWorkflow {
+            var lastTime: Date = .distantPast
 
-                try await Workflow.sleep(for: .seconds(1))
-                let end = Workflow.now
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> Result {
+                let now0 = context.now
+                let now1 = context.now
+                self.lastTime = now0
+
+                try await context.sleep(for: .seconds(1))
+                let end = context.now
 
                 return Result(now0: now0, now1: now1, end: end)
             }
 
             @WorkflowQuery
             func queryTime(input: Void) -> Date {
-                Workflow.now
+                lastTime
             }
         }
 

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
@@ -22,16 +22,16 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowUpdateTests {
         @Workflow
-        final class UpdateWorkflow {
+        struct UpdateWorkflow {
             private var state = ""
 
-            func run(input: Void) async throws {
-                try await Workflow.condition { self.state == "updated" }
-                try await Workflow.condition { Workflow.allHandlersFinished }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.state == "updated" }
+                try await context.condition { context.allHandlersFinished }
             }
 
             @WorkflowUpdate
-            func update(input: String) async throws -> String {
+            mutating func update(context: WorkflowContext<Self>, input: String) async throws -> String {
                 self.state = "updated"
                 return "Hello from update, \(input)"
             }
@@ -139,16 +139,16 @@ extension TestServerDependentTests {
         // MARK: - Update Validator Tests
 
         @Workflow
-        final class ValidatedUpdateWorkflow {
+        struct ValidatedUpdateWorkflow {
             private var value = ""
 
-            func run(input: Void) async throws -> String {
-                try await Workflow.condition { !self.value.isEmpty }
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws -> String {
+                try await context.condition { !$0.value.isEmpty }
                 return self.value
             }
 
             @WorkflowUpdate(validator: "validateSetValue")
-            func setValue(input: String) async throws -> String {
+            mutating func setValue(context: WorkflowContext<Self>, input: String) async throws -> String {
                 self.value = input
                 return "set:\(input)"
             }
@@ -218,16 +218,16 @@ extension TestServerDependentTests {
         // MARK: - Update-with-Start Tests
 
         @Workflow
-        final class UpdateWithStartTargetWorkflow {
+        struct UpdateWithStartTargetWorkflow {
             var value: String = ""
 
-            func run(input: String) async throws -> String {
-                try await Workflow.condition { !self.value.isEmpty }
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                try await context.condition { !$0.value.isEmpty }
                 return self.value
             }
 
             @WorkflowUpdate
-            func setValue(input: String) async -> String {
+            mutating func setValue(input: String) async -> String {
                 self.value = input
                 return "updated:\(input)"
             }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowWaitConditionTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowWaitConditionTests.swift
@@ -21,25 +21,25 @@ extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))
     struct WorkflowWaitConditionTests {
         @Workflow
-        final class WaitConditionWorkflow {
+        struct WaitConditionWorkflow {
             enum Scenario: Codable {
                 case workflowCancel
                 case timeout
             }
 
-            func run(input: Scenario) async -> String {
+            mutating func run(context: WorkflowContext<Self>, input: Scenario) async -> String {
                 switch input {
                 case .workflowCancel:
                     // For testing purposes we are ignoring the error here.
                     // We just want the workflow to complete.
-                    try? await Workflow.condition { false }
+                    try? await context.condition { false }
                     return "Done"
                 case .timeout:
                     // For testing purposes we are ignoring the error here.
                     // We just want the workflow to complete.
-                    try? await Workflow.timeout(for: .seconds(1)) {
+                    try? await context.timeout(for: .seconds(1)) {
                         // Waiting until cancellation here.
-                        try await Workflow.condition { false }
+                        try await context.condition { false }
                     }
                     return "Done"
                 }
@@ -47,11 +47,11 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class ConditionCancelledWorkflow {
-            func run(input: Duration) async -> String {
+        struct ConditionCancelledWorkflow {
+            mutating func run(context: WorkflowContext<Self>, input: Duration) async -> String {
                 do {
                     try? await Task.sleep(for: input)  // if it throws a cancellation error already we are good!
-                    try await Workflow.condition { false }
+                    try await context.condition { false }
                     Issue.record("Condition resolved unexpectedly.")
                     return "Unexpected resolve"
                 } catch let error as CanceledError {

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowWorkerTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowWorkerTests.swift
@@ -46,21 +46,21 @@ private struct FirstWorkflow: WorkflowDefinition {
     static let name: String = "DuplicateWorkflow"
 
     init(input: Void) {}
-    func run(input: Void) async throws {}
+    mutating func run(context: WorkflowContext<Self>, input: Void) async throws {}
 }
 
 private struct SecondWorkflow: WorkflowDefinition {
     static let name: String = "DuplicateWorkflow"  // Same name as FirstWorkflow
 
     init(input: Void) {}
-    func run(input: Void) async throws {}
+    mutating func run(context: WorkflowContext<Self>, input: Void) async throws {}
 }
 
 private struct UniqueWorkflow: WorkflowDefinition {
     static let name: String = "UniqueWorkflow"
 
     init(input: Void) {}
-    func run(input: Void) async throws {}
+    mutating func run(context: WorkflowContext<Self>, input: Void) async throws {}
 }
 
 @Suite()

--- a/Tests/TemporalTests/Worker/WorkflowReplayerTests.swift
+++ b/Tests/TemporalTests/Worker/WorkflowReplayerTests.swift
@@ -39,12 +39,12 @@ extension TestServerDependentTests {
         }
 
         @Workflow
-        final class SayHelloWorkflow {
+        struct SayHelloWorkflow {
             private var waiting = false
             private var finish = false
 
-            func run(input params: ReplayParams) async throws -> String {
-                let result = try await Workflow.executeActivity(
+            mutating func run(context: WorkflowContext<Self>, input params: ReplayParams) async throws -> String {
+                let result = try await context.executeActivity(
                     ReplayActivity.self,
                     options: .init(scheduleToCloseTimeout: .seconds(60)),
                     input: params.name
@@ -52,9 +52,9 @@ extension TestServerDependentTests {
 
                 // Wait if requested
                 if params.shouldWait {
-                    waiting = true
-                    try await Workflow.condition { self.finish }
-                    waiting = false
+                    self.waiting = true
+                    try await context.condition { $0.finish }
+                    self.waiting = false
                 }
 
                 // Throw if requested
@@ -64,15 +64,15 @@ extension TestServerDependentTests {
 
                 // Cause non-determinism if requested and we're replaying
                 // This simulates a code change that adds an extra timer
-                if params.shouldCauseNonDeterminism && Workflow.isReplaying {
-                    try await Workflow.sleep(for: .milliseconds(1))
+                if params.shouldCauseNonDeterminism && context.isReplaying {
+                    try await context.sleep(for: .milliseconds(1))
                 }
 
                 return result
             }
 
             @WorkflowSignal
-            func finish(input: Void) async {
+            mutating func finish(input: Void) async {
                 finish = true
             }
 


### PR DESCRIPTION
# Motivation

Currently, all workflows must be classes. This is was a decision early on to allow state sharing between the run method and the handlers. Having workflows as classes also came with downsides and forced us to dynamically catch invalid usage of the `Workflow` static methods.

# Modification

This PR contains multiple commits. The first one is focused on all the changes necessary to allow workflows to be structs. This required changes in how we store the workflow, the definitions of the workflow and the various handlers. The outcome is that we are now correctly enforcing what is allowed at compile time e.g. update validators are not allowed to mutate the workflow.

# Result

We now have compile time guarantee that state modifications and commands are only issued in run and handlers where allowed