### PR TITLE
docs editorial updates

### DIFF
--- a/Sources/Temporal/Converters/DefaultFailureConverter.swift
+++ b/Sources/Temporal/Converters/DefaultFailureConverter.swift
@@ -65,6 +65,11 @@ public struct DefaultFailureConverter: FailureConverter {
         return temporalFailure
     }
 
+    /// Converts the given Temporal failure to a Swift error.
+    ///
+    /// - Parameter temporalFailure: The Temporal failure to convert.
+    /// - Parameter payloadConverter: The payload converter to use when decoding encoded attributes.
+    /// - Returns: The converted error.
     public func convertFailure(
         _ temporalFailure: Api.Failure.V1.Failure,
         payloadConverter: some PayloadConverter

--- a/Sources/Temporal/Documentation.docc/Connecting-to-Temporal.md
+++ b/Sources/Temporal/Documentation.docc/Connecting-to-Temporal.md
@@ -10,9 +10,8 @@ Temporal services. Use it to start workflows, query workflow state,
 send signals, and manage workflow lifecycles across different environments.
 
 This article shows you how to establish connections to local development
-and production instances. You'll learn to configure authentication,
-handle connection lifecycle, and implement retry policies for robust client
-operations.
+and production instances. You'll learn to configure authentication and
+handle connection lifecycle.
 
 ## Connect to a local development server
 

--- a/Sources/Temporal/Documentation.docc/Connecting-to-Temporal.md
+++ b/Sources/Temporal/Documentation.docc/Connecting-to-Temporal.md
@@ -5,8 +5,8 @@ environments.
 
 ## Overview
 
-The Temporal client serves as your application's gateway to interact with
-Temporal services. Use it to start workflows, query workflow state,
+The Temporal client serves as your application's gateway to Temporal services.
+Use it to start workflows, query workflow state,
 send signals, and manage workflow lifecycles across different environments.
 
 This article shows you how to establish connections to local development
@@ -39,14 +39,13 @@ try await client.run()
 ```
 
 A development server typically runs on `localhost:7233` with a plaintext
-transport. This configuration provides no encryption and should **never** be
-used in production environments.
+transport. This configuration provides no encryption — never use it
+in production environments.
 
 ## Connect to Temporal with mTLS
 
 Most production Temporal servers require mutual TLS (mTLS) authentication, which uses
-client certificates. The following example illustrates how to configure your client with
-the required certificates:
+client certificates. Configure your client with the required certificates:
 
 ```swift
 import X509
@@ -120,5 +119,5 @@ struct TemporalApplication {
 }
 ```
 
-By using the Swift Service Lifecycle to manage the service, your application shuts
+Use Swift Service Lifecycle to manage the service so your application shuts
 down cleanly when it receives termination signals.

--- a/Sources/Temporal/Documentation.docc/Connecting-to-Temporal.md
+++ b/Sources/Temporal/Documentation.docc/Connecting-to-Temporal.md
@@ -45,8 +45,8 @@ used in production environments.
 
 ## Connect to Temporal with mTLS
 
-Most production Temporal servers require mutual TLS (mTLS) authentication which uses
-client certificates. The example below illustrates how to configure your client with
+Most production Temporal servers require mutual TLS (mTLS) authentication, which uses
+client certificates. The following example illustrates how to configure your client with
 the required certificates:
 
 ```swift
@@ -83,14 +83,15 @@ try await client.run()
 
 For more advanced transport configuration, use the
 ``TemporalClient/connect(transport:configuration:logger:_:)`` method
-and check out the [grpc-swift project](https://github.com/grpc/grpc-swift-2).
+and see the [grpc-swift project](https://github.com/grpc/grpc-swift-2).
 
 ## Manage client lifecycle
 
 Handle client startup and shutdown gracefully in your application using
 [Swift ServiceLifecycle](https://github.com/swift-server/swift-service-lifecycle).
 An instance of ``TemporalClient`` conforms to the `Service` protocol,
-which you can include within the `ServiceGroup` your app runs, as show below:
+which you can include within the `ServiceGroup` your app runs, as shown in the
+following example:
 
 ```swift
 import Logging

--- a/Sources/Temporal/Documentation.docc/GettingStarted.md
+++ b/Sources/Temporal/Documentation.docc/GettingStarted.md
@@ -4,14 +4,14 @@ Build your first Temporal workflow and activity.
 
 ## Overview
 
-This guide walks you through creating a simple Temporal workflow consisting
-of a single activity, from installation to running your first workflow locally.
-This article shows you how to create an activity, define a workflow that calls it,
-set up a worker, and execute the workflow.
+Create a simple Temporal workflow consisting of a single activity,
+from installation to running your first workflow locally.
+Define an activity, create a workflow that calls it,
+set up a worker, and run the workflow.
 
 ## Add the dependency
 
-Add the Swift Temporal SDK to your package dependencies. Use the command
+Add the Swift Temporal SDK to your package dependencies:
 
 ```sh
 swift package add-dependency \
@@ -19,7 +19,7 @@ swift package add-dependency \
     --from 0.1.0
 ```
 
-Or manually update your project's Package.swift to include the SDK as a dependency:
+Alternatively, update your project's Package.swift to include the SDK as a dependency:
 
 ```swift
 dependencies: [
@@ -34,8 +34,8 @@ dependencies: [
 
 Install the Temporal CLI by visiting the
 [Temporal CLI installation page](https://temporal.io/setup/install-temporal-cli)
-and following the installation instructions for your platform. After the CLI is installed,
-start a development server:
+and following the installation instructions for your platform. After you install
+the CLI, start a development server:
 
 ```sh
 # Start development server

--- a/Sources/Temporal/Documentation.docc/GettingStarted.md
+++ b/Sources/Temporal/Documentation.docc/GettingStarted.md
@@ -4,9 +4,9 @@ Build your first Temporal workflow and activity.
 
 ## Overview
 
-Create a simple Temporal workflow consisting of a single activity,
-from installation to running your first workflow locally.
-Define an activity, create a workflow that calls it,
+This guide walks you through creating a simple Temporal workflow consisting
+of a single activity, from installation to running your first workflow locally.
+This article shows you how to create an activity, define a workflow that calls it,
 set up a worker, and run the workflow.
 
 ## Add the dependency

--- a/Sources/Temporal/Documentation.docc/GettingStarted.md
+++ b/Sources/Temporal/Documentation.docc/GettingStarted.md
@@ -32,7 +32,8 @@ dependencies: [
 
 ## Set up a local Temporal server
 
-Install the Temporal CLI by visiting https://temporal.io/setup/install-temporal-cli
+Install the Temporal CLI by visiting the
+[Temporal CLI installation page](https://temporal.io/setup/install-temporal-cli)
 and following the installation instructions for your platform. After the CLI is installed,
 start a development server:
 
@@ -41,14 +42,14 @@ start a development server:
 temporal server start-dev
 ```
 
-The development server runs at `localhost:7233`, and hosts a Web UI at
+The development server runs at `localhost:7233`, and hosts a web UI at
 `http://localhost:8233`.
 
 ## Create your first workflow
 
 ### Define the activity
 
-Activities are the units of work within a workflow, and define the logic that performs the work in your application.
+Each activity defines a unit of work — an individual operation that a workflow coordinates.
 Create a simple greeting activity:
 
 ```swift
@@ -65,7 +66,7 @@ struct GreetingActivities {
 
 ### Define the workflow
 
-Workflows orchestrate activities and contain your business logic for coordinating them.
+Workflows contain your business logic and orchestrate the activities that carry it out.
 Create a workflow that calls the activity and returns the generated greeting:
 
 ```swift
@@ -88,7 +89,7 @@ struct GreetingWorkflow {
 ### Start a worker and client
 
 Create an application that starts a worker with the workflow and activity, then
-execute the workflow:
+executes the workflow:
 
 ```swift
 import Foundation
@@ -163,7 +164,7 @@ struct GreetingApplication {
 
 ## Run your application
 
-When you run your application, you should see output similar to:
+When you run your application, the output looks similar to:
 
 ```
 Executing workflow

--- a/Sources/Temporal/Documentation.docc/Implementing-Activities.md
+++ b/Sources/Temporal/Documentation.docc/Implementing-Activities.md
@@ -6,8 +6,8 @@ with proper error handling and lifecycle management.
 ## Overview
 
 Activities represent the individual units of work in your Temporal application.
-They execute the actual business logic such as calling external APIs, processing
-data, interacting with databases, or performing any side-effect operations that
+They run the actual business logic such as calling external APIs, processing
+data, interacting with databases, or performing side effect operations that
 workflows coordinate.
 
 This article shows you how to define activities using macros, organize them in
@@ -43,13 +43,14 @@ struct UserActivities {
 
 The `@Activity` macro automatically generates activity definitions when nested
 inside a type annotated with the `@ActivityContainer` macro. The container
-allows you to group related activities together and provide dependencies,
+lets you group related activities together and provide dependencies,
 such as database clients, to your activities.
 
 ## Give activities custom names
 
-Temporal identifies activities by name, sometimes called the *activity type*. This defaults to the unqualified method name of the activity,
-but can be customized by providing a `name` parameter to the `@Activity` macro:
+Temporal identifies activities by name, sometimes called the *activity type*.
+This defaults to the unqualified method name of the activity,
+but you can customize it by providing a `name` parameter to the `@Activity` macro:
 
 ```swift
 @Activity(name: "CustomFindUser")
@@ -76,7 +77,7 @@ let worker = try TemporalWorker(
 )
 ```
 
-You can also register all activities inside a container at once:
+You can also register all activities in a container at once:
 
 ```swift
 import Temporal
@@ -97,8 +98,8 @@ an activity with the matching name.
 
 ## Access the activity's execution context
 
-When running in an activity, the ``ActivityExecutionContext`` is available
-via ``ActivityExecutionContext/current`` which is backed by a task local.
+Access the ``ActivityExecutionContext`` through
+``ActivityExecutionContext/current``, a task local, while running in an activity.
 Among other capabilities, this context provides:
 
 - ``ActivityExecutionContext/Info`` - Information about the currently running activity.
@@ -111,13 +112,13 @@ For a non-local activity to receive cancellation requests, it must call
 ``ActivityExecutionContext/heartbeat(details:)``. Call this function regularly
 in all but the fastest activities.
 
-Cancellation is propagated through Swift's built-in task cancellation and can 
-be checked by calling `Task.isCancelled` or setting up a task cancellation handler.
+Cancellation propagates through Swift's built-in task cancellation. Check
+for cancellation by calling `Task.isCancelled` or setting up a task cancellation handler.
 
-An activity can be canceled for multiple reasons, some server-side and some
-worker-side. Server-side cancellation reasons include workflow canceling the
-activity, workflow completing, or activity timing out. On the worker side, the
-activity can be canceled on worker shutdown.
+Multiple reasons can cancel an activity, some server-side and some
+worker-side. Server-side cancellation reasons include the workflow canceling the
+activity, the workflow completing, or the activity timing out. On the worker side,
+worker shutdown cancels the activity.
 
 ```swift
 @Activity
@@ -140,11 +141,11 @@ func longRunningCalculation(input: Int) async throws -> Int {
 }
 ```
 
-In addition to obtaining cancellation information, heartbeats also support
+Beyond cancellation information, heartbeats also support
 detail data that the server persists for retrieval during activity retry.
 Provide the details when calling the ``ActivityExecutionContext/heartbeat(details:)``
 method and retrieve them with the ``ActivityExecutionContext/Info/heartbeatDetails(as:)``
-method. The above example can use this to resume from the latest computation result
+method. The following example uses this to resume from the latest computation result
 when retrying the activity.
 
 ```swift

--- a/Sources/Temporal/Documentation.docc/Implementing-Activities.md
+++ b/Sources/Temporal/Documentation.docc/Implementing-Activities.md
@@ -48,8 +48,7 @@ such as database clients, to your activities.
 
 ### Give activities custom names
 
-Temporal activities are identified by their name (or sometimes referred to as
-"activity type"). This defaults to the unqualified method name of the activity,
+Temporal identifies activities by name, sometimes called the *activity type*. This defaults to the unqualified method name of the activity,
 but can be customized by providing a `name` parameter to the `@Activity` macro:
 
 ```swift
@@ -60,7 +59,7 @@ func findUser(input: FindUserInput) async throws -> FindUserOutput {
 }
 ```
 
-### Registering activities with a worker
+### Register activities with a worker
 
 Register your activities with a ``TemporalWorker`` to make them available for
 execution:
@@ -100,7 +99,7 @@ an activity with the matching name.
 
 When running in an activity, the ``ActivityExecutionContext`` is available
 via ``ActivityExecutionContext/current`` which is backed by a task local.
-In addition to other more advanced things, this context provides:
+Among other capabilities, this context provides:
 
 - ``ActivityExecutionContext/Info`` - Information about the currently running activity.
 - ``ActivityExecutionContext/heartbeat(details:)`` - Method to call to record an activity heartbeat.
@@ -108,9 +107,9 @@ In addition to other more advanced things, this context provides:
 
 ### Handle activity heartbeating and cancellation
 
-In order for a non-local activity to be notified of cancellation requests, it must call
-``ActivityExecutionContext/heartbeat(details:)``. It is strongly recommended that
-all but the fastest executing activities call this function regularly.
+For a non-local activity to receive cancellation requests, it must call
+``ActivityExecutionContext/heartbeat(details:)``. Call this function regularly
+in all but the fastest activities.
 
 Cancellation is propagated through Swift's built-in task cancellation and can 
 be checked by calling `Task.isCancelled` or setting up a task cancellation handler.
@@ -142,7 +141,7 @@ func longRunningCalculation(input: Int) async throws -> Int {
 ```
 
 In addition to obtaining cancellation information, heartbeats also support
-detail data that is persisted on the server for retrieval during activity retry.
+detail data that the server persists for retrieval during activity retry.
 Provide the details when calling the ``ActivityExecutionContext/heartbeat(details:)``
 method and retrieve them with the ``ActivityExecutionContext/Info/heartbeatDetails(as:)``
 method. The above example can use this to resume from the latest computation result

--- a/Sources/Temporal/Documentation.docc/Implementing-Activities.md
+++ b/Sources/Temporal/Documentation.docc/Implementing-Activities.md
@@ -15,7 +15,7 @@ containers, handle cancellation and timeouts, and implement proper error
 handling patterns. You'll learn to build robust activities that integrate
 seamlessly with your workflow orchestration.
 
-### Define activities with the Activity macro
+## Define activities with the Activity macro
 
 Use the `@Activity` macro to define activities:
 
@@ -46,7 +46,7 @@ inside a type annotated with the `@ActivityContainer` macro. The container
 allows you to group related activities together and provide dependencies,
 such as database clients, to your activities.
 
-### Give activities custom names
+## Give activities custom names
 
 Temporal identifies activities by name, sometimes called the *activity type*. This defaults to the unqualified method name of the activity,
 but can be customized by providing a `name` parameter to the `@Activity` macro:
@@ -59,7 +59,7 @@ func findUser(input: FindUserInput) async throws -> FindUserOutput {
 }
 ```
 
-### Register activities with a worker
+## Register activities with a worker
 
 Register your activities with a ``TemporalWorker`` to make them available for
 execution:
@@ -95,7 +95,7 @@ the appropriate activity methods based on their names. When a workflow schedules
 an activity execution, Temporal routes the task to a worker that has registered
 an activity with the matching name.
 
-### Access the activity's execution context
+## Access the activity's execution context
 
 When running in an activity, the ``ActivityExecutionContext`` is available
 via ``ActivityExecutionContext/current`` which is backed by a task local.
@@ -105,7 +105,7 @@ Among other capabilities, this context provides:
 - ``ActivityExecutionContext/heartbeat(details:)`` - Method to call to record an activity heartbeat.
 - ``ActivityExecutionContext/cancellationReason`` - The reason for why an activity is canceled.
 
-### Handle activity heartbeating and cancellation
+## Handle activity heartbeating and cancellation
 
 For a non-local activity to receive cancellation requests, it must call
 ``ActivityExecutionContext/heartbeat(details:)``. Call this function regularly

--- a/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
@@ -14,7 +14,7 @@ This article shows you how to define workflows, coordinate activities, handle
 signals and queries, and implement complex orchestration patterns. You'll learn
 to build workflows that survive failures and scale across distributed systems.
 
-### Define a workflow with the Workflow macro
+## Define a workflow with the Workflow macro
 
 Use the `@Workflow` macro on a `struct` to create a ``WorkflowDefinition``.
 The main entry point for a workflow is the `run(context:input:)` method, which
@@ -78,13 +78,13 @@ struct RegisterUserWorkflow {
 }
 ```
 
-#### Best practices for workflow definitions
+### Best practices for workflow definitions
 
 Workflows should define custom input and output types rather than using basic
 types. This allows adding optional fields to input or output structures without
 breaking existing workflows.
 
-#### Customizing workflow names
+### Customizing workflow names
 
 By default, workflows use their struct name as the workflow type. You can
 customize this by providing a `name` parameter in the `@Workflow` macro:
@@ -96,7 +96,7 @@ struct RegisterUserWorkflow {
 }
 ```
 
-#### Initializing state
+### Initializing state
 
 Define an optional `init(input:)` initializer to set up the workflow state from
 input parameters, eliminating the need for optional properties or
@@ -124,13 +124,13 @@ struct RegisterUserWorkflow {
 }
 ```
 
-### Defining signal, query, and update handlers
+## Define signal, query, and update handlers
 
 Use the `@WorkflowSignal`, `@WorkflowQuery`, and `@WorkflowUpdate` macros
 inside a type annotated with the `@Workflow` macro to define those respective
 handlers.
 
-#### Signal handlers
+### Signal handlers
 
 Signal handlers allow external systems to send information to running workflows.
 They're ideal for handling approvals, cancellations, or status updates.
@@ -207,7 +207,7 @@ You can customize the signal name using the `name` parameter, for example:
 @WorkflowSignal(name: "CustomApproveRegistration")
 ```
 
-#### Query handlers
+### Query handlers
 
 Queries allow external systems to retrieve information synchronously from running workflows.
 They're useful for getting the current state of a workflow without modifying it.
@@ -280,7 +280,7 @@ You can customize the query name using the `name` parameter, for example:
 @WorkflowQuery(name: "CustomGetRegistrationState")
 ```
 
-#### Update handlers
+### Update handlers
 
 Updates combine aspects of both signals and queries - they can modify a workflow's
 state and return values asynchronously.

--- a/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
@@ -195,7 +195,7 @@ struct RegisterUserWorkflow {
 ```
 
 Signal handlers that modify workflow state are declared as `mutating func`.
-Because workflows are now value types, signal handlers that only mutate state
+Because workflows are value types, signal handlers that only mutate state
 do not need to be `async throws`. Follow the same best practice of using custom
 input types for signal handlers as you do for workflows to support backward
 compatibility.
@@ -273,7 +273,7 @@ query handlers provide compile-time safety: they are non-mutating by default,
 guaranteeing they cannot modify workflow state. Use custom input and output types
 for queries to maintain backward compatibility.
 
-By default, the signal name is the unqualified capitalized method name.
+By default, the query name is the unqualified capitalized method name.
 You can customize the query name using the `name` parameter, for example:
 
 ```swift
@@ -316,14 +316,14 @@ struct RegisterUserWorkflow {
     mutating func updateUserName(input: UpdateUserNameInput) async throws -> UpdateUserNameOutput {
         // Can only update details while waiting for approval
         guard currentState == .waitingForApproval else {
-            return UpdateUserDetailsOutput(
+            return UpdateUserNameOutput(
                 success: false
             )
         }
 
         self.userName = input.userName
 
-        return UpdateUserDetailsOutput(
+        return UpdateUserNameOutput(
             success: true
         )
     }
@@ -341,6 +341,6 @@ By default the update name is the unqualified
 capitalized method name. You can customize the update name using the
 `name` parameter, for example:
 
-```swidt
+```swift
 @WorkflowUpdate(name: "CustomUpdateUserName")
 ```

--- a/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
@@ -15,7 +15,7 @@ Workflows can safely use Swift's concurrency primitives, such as `async let`,
 execution guarantees required by Temporal. This enables you to write concurrent
 workflow logic that remains predictable and testable.
 
-### Deterministic execution guarantees
+## Deterministic execution guarantees
 
 Workflows run on a specialized task executor that ensures consistent execution
 order across different runs. This executor processes tasks sequentially by task
@@ -29,7 +29,7 @@ reaches a real suspension point before the executor picks up the next job. This
 approach also ensures that Structured Concurrency patterns like task groups produce
 identical results across workflow replays.
 
-### Use Structured Concurrency patterns
+## Use Structured Concurrency patterns
 
 Workflows support Swift's Structured Concurrency patterns, including task groups
 and async let bindings. These patterns maintain deterministic execution while
@@ -70,7 +70,7 @@ The workflow executor ensures that even though tasks run concurrently, they
 execute in a consistent order during replay. The first task added to the group
 is run first, followed by the second task, maintaining deterministic behavior.
 
-### Use safe APIs for deterministic execution
+## Use safe APIs for deterministic execution
 
 Workflows must maintain deterministic behavior across replays. Use only these
 APIs inside your workflows:
@@ -89,7 +89,7 @@ APIs inside your workflows:
 - Non-deterministic APIs like `RandomNumberGenerator` - Instead, use
 ``WorkflowContext/randomNumberGenerator``.
 
-### Handle cancellation properly
+## Handle cancellation properly
 
 Workflows support Swift's standard cancellation primitives, enabling graceful
 shutdown and cleanup. Use `Task.isCancelled`, `withTaskCancellationHandler`, and

--- a/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
@@ -1,4 +1,4 @@
-# How workflows leverage Swift Concurrency
+# Using Swift Concurrency in workflows
 
 Build deterministic workflows using Swift's async/await and Structured
 Concurrency primitives.
@@ -82,7 +82,7 @@ APIs inside your workflows:
 - Swift's standard Task cancellation primitives.
 
 **Avoid these APIs:**
-- `Task.detached` - Instead use Structured Concurrency alternatives.
+- `Task.detached` - Instead, use Structured Concurrency alternatives.
 - Actor isolation - Introduces potential executor hops.
 - `Task.sleep` or `Clock.sleep` - Instead, use ``WorkflowContext/sleep(for:summary:)``.
 - Direct I/O operations - Instead, use activities for any non-deterministic code.

--- a/Sources/Temporal/Documentation.docc/Working-with-Data.md
+++ b/Sources/Temporal/Documentation.docc/Working-with-Data.md
@@ -1,4 +1,4 @@
-# Data conversion
+# Configuring data conversion
 
 Configure data conversion, serialization, and type-safe payload handling for
 workflows and activities.
@@ -17,7 +17,7 @@ applications.
 
 ### Use the default data converter
 
-Data converters (``DataConverter``) are a combination of ``PayloadConverter``, ``PayloadCodec`` and
+Data converters (``DataConverter``) are a combination of ``PayloadConverter``, ``PayloadCodec``, and
 ``FailureConverter``. Payload converters convert Swift types to and from
 serialized bytes. Payload codecs convert bytes to bytes, for example compressing
 or encrypting them. Failure converters convert `Error`s to and from serialized
@@ -32,7 +32,7 @@ The SDK provides the ``DataConverter/default`` which uses the
 - `Codable`
 
 The default payload converter is a collection of types that conform to ``EncodingPayloadConverter``.
-Each converter is tried in order until one can successfully encode a value.
+The system tries each converter in order until one successfully encodes a value.
 The encoding converters also set an `encoding` metadata value, which is used
 to identify the correct converter to use when deserializing bytes into Swift values.
 

--- a/Sources/Temporal/Documentation.docc/Working-with-Data.md
+++ b/Sources/Temporal/Documentation.docc/Working-with-Data.md
@@ -15,7 +15,7 @@ custom serialization logic, configure payload codecs for encryption or
 compression, and handle complex data types safely in your Temporal
 applications.
 
-### Use the default data converter
+## Use the default data converter
 
 Data converters (``DataConverter``) are a combination of ``PayloadConverter``, ``PayloadCodec``, and
 ``FailureConverter``. Payload converters convert Swift types to and from
@@ -36,7 +36,7 @@ The system tries each converter in order until one successfully encodes a value.
 The encoding converters also set an `encoding` metadata value, which is used
 to identify the correct converter to use when deserializing bytes into Swift values.
 
-### Implement custom data converters
+## Implement custom data converters
 
 Create a custom data converter by providing a payload converter, payload codec,
 or failure converter to the ``DataConverter/init(payloadConverter:failureConverter:payloadCodec:)``.


### PR DESCRIPTION
- **add missing doc comment**
- **using gerunds for article titles, imperative verbs for section headings, fixing mispellings and mismatches with code examples, and reworking some passive voice to active**
- **raises headings level to promote the content to in-page navigation (with a wide enough view) and minimize nesting**
- **The article doesn't touch on implementing retry policies, so removing it from the introduction here for consistency**
- **guideline based changes:**
- **restoring the you'll learn phrasing**
- **guidelines fixes - mostly passive voice:**
