### PR TITLE
Bump minimum require grpc-swift-2 version to 2.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.1"),
-        .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
+        .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.3.0"),
         .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift-extras.git", from: "2.0.0"),


### PR DESCRIPTION
### Motivation

Temporal generates code like below which uses the new `type` parameter from https://github.com/grpc/grpc-swift-2/pull/41 which only shipped with the [2.3.0](https://github.com/grpc/grpc-swift-2/releases/tag/2.3.0) release.
```swift
package static let descriptor = GRPCCore.MethodDescriptor(
  service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "temporal.api.cloud.cloudservice.v1.CloudService"),
  method: "GetUsers",
  type: .unary
)
```

### Modifications

We bump the minimum required grpc-swift-2 version.
