### PR TITLE
Add support for `@WorkflowQuery` on properties

### DIFF
--- a/Sources/Temporal/Macros/WorkflowMacro.swift
+++ b/Sources/Temporal/Macros/WorkflowMacro.swift
@@ -102,17 +102,17 @@ public macro WorkflowSignal(name: String? = nil, description: String? = nil, unf
 ///
 /// ## Usage
 ///
+/// Use on a method to define a query with input:
+///
 /// ```swift
 /// @Workflow
-/// final class GreetingWorkflow {
-///     var name: String
+/// struct GreetingWorkflow {
+///     var name: String = ""
 ///
-///     func run(context: WorkflowContext, input: String) async throws -> String {
-///         self.name = name
-///         return try await executeActivity(
-///             GreetingActivity.self,
-///             input: name
-///         )
+///     mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+///         self.name = input
+///         try await context.condition { $0.name == "done" }
+///         return name
 ///     }
 ///
 ///     @WorkflowQuery
@@ -121,7 +121,17 @@ public macro WorkflowSignal(name: String? = nil, description: String? = nil, unf
 ///     }
 /// }
 /// ```
-/// - Parameter name: The name of the query. If not provided, defaults to the function name.
+/// Use on stored or computed properties to directly expose it as a query:
+///
+/// ```swift
+/// @Workflow
+/// struct OrderWorkflow {
+///     @WorkflowQuery
+///     var status: String = "pending"
+/// }
+/// ```
+///
+/// - Parameter name: The name of the query. If not provided, defaults to the function or property name.
 /// - Parameter description: An optional description of the query's purpose.
 @attached(peer, names: arbitrary)
 public macro WorkflowQuery(name: String? = nil, description: String? = nil) = #externalMacro(module: "TemporalMacros", type: "WorkflowQueryMacro")

--- a/Sources/TemporalMacros/WorkflowMacro.swift
+++ b/Sources/TemporalMacros/WorkflowMacro.swift
@@ -74,106 +74,111 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
         var queryNames = [String]()
         var updateNames = [String]()
         for member in declaration.memberBlock.members {
-            // We need to collect all message handlers
-            guard let functionDecl = member.decl.as(FunctionDeclSyntax.self) else {
-                continue
-            }
+            // Check function declarations for signal/query/update handlers
+            if let functionDecl = member.decl.as(FunctionDeclSyntax.self) {
+                if functionDecl.attributes.contains(where: { element in
+                    element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "WorkflowSignal"
+                }) {
+                    signalNames.append(functionDecl.name.text)
+                }
 
-            if functionDecl.attributes.contains(where: { element in
-                element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "WorkflowSignal"
-            }) {
-                signalNames.append(functionDecl.name.text)
-            }
+                if functionDecl.attributes.contains(where: { element in
+                    element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "WorkflowQuery"
+                }) {
+                    queryNames.append(functionDecl.name.text)
+                }
 
-            if functionDecl.attributes.contains(where: { element in
-                element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "WorkflowQuery"
-            }) {
-                queryNames.append(functionDecl.name.text)
-            }
+                if let updateAttribute = functionDecl.attributes.first(where: { element in
+                    element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "WorkflowUpdate"
+                })?.as(AttributeSyntax.self) {
+                    updateNames.append(functionDecl.name.text)
 
-            if let updateAttribute = functionDecl.attributes.first(where: { element in
-                element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "WorkflowUpdate"
-            })?.as(AttributeSyntax.self) {
-                updateNames.append(functionDecl.name.text)
-
-                // Validate the referenced validator method if specified
-                if let validatorName = updateAttribute.stringValueForArgument(named: "validator") {
-                    let allFunctions = declaration.memberBlock.members.compactMap {
-                        $0.decl.as(FunctionDeclSyntax.self)
-                    }
-                    if let validatorFunc = allFunctions.first(where: { $0.name.text == validatorName }) {
-                        // Validator must not be async
-                        if validatorFunc.signature.effectSpecifiers?.asyncSpecifier?.presence == .present {
-                            context.diagnose(
-                                Diagnostic(
-                                    node: Syntax(validatorFunc),
-                                    message: ValidatorError(message: "Validator method '\(validatorName)' must not be async")
-                                )
-                            )
+                    // Validate the referenced validator method if specified
+                    if let validatorName = updateAttribute.stringValueForArgument(named: "validator") {
+                        let allFunctions = declaration.memberBlock.members.compactMap {
+                            $0.decl.as(FunctionDeclSyntax.self)
                         }
-
-                        // Validator must return Void
-                        if let returnClause = validatorFunc.signature.returnClause,
-                            returnClause.type.as(IdentifierTypeSyntax.self)?.name.text != "Void"
-                        {
-                            context.diagnose(
-                                Diagnostic(
-                                    node: Syntax(returnClause),
-                                    message: ValidatorError(message: "Validator method '\(validatorName)' must return Void")
-                                )
-                            )
-                        }
-
-                        // Validator must have exactly one parameter called 'input'
-                        let validatorParams = validatorFunc.signature.parameterClause.parameters
-                        if validatorParams.count != 1 {
-                            context.diagnose(
-                                Diagnostic(
-                                    node: Syntax(validatorFunc.signature.parameterClause),
-                                    message: ValidatorError(
-                                        message: "Validator method '\(validatorName)' must have exactly one parameter matching the update input"
-                                    )
-                                )
-                            )
-                        } else if let validatorParam = validatorParams.first {
-                            if validatorParam.firstName.text != "input" {
+                        if let validatorFunc = allFunctions.first(where: { $0.name.text == validatorName }) {
+                            // Validator must not be async
+                            if validatorFunc.signature.effectSpecifiers?.asyncSpecifier?.presence == .present {
                                 context.diagnose(
                                     Diagnostic(
-                                        node: Syntax(validatorParam),
-                                        message: ValidatorError(
-                                            message: "Validator method '\(validatorName)' parameter must be called 'input'"
-                                        )
+                                        node: Syntax(validatorFunc),
+                                        message: ValidatorError(message: "Validator method '\(validatorName)' must not be async")
                                     )
                                 )
                             }
 
-                            // Check input type matches
-                            let updateParams = functionDecl.signature.parameterClause.parameters
-                            if let updateParam = updateParams.first(where: { $0.firstName.text == "input" }) {
-                                let updateType = updateParam.type.description.trimmingCharacters(in: .whitespaces)
-                                let validatorType = validatorParam.type.description.trimmingCharacters(in: .whitespaces)
-                                if updateType != validatorType {
+                            // Validator must return Void
+                            if let returnClause = validatorFunc.signature.returnClause,
+                                returnClause.type.as(IdentifierTypeSyntax.self)?.name.text != "Void"
+                            {
+                                context.diagnose(
+                                    Diagnostic(
+                                        node: Syntax(returnClause),
+                                        message: ValidatorError(message: "Validator method '\(validatorName)' must return Void")
+                                    )
+                                )
+                            }
+
+                            // Validator must have exactly one parameter called 'input'
+                            let validatorParams = validatorFunc.signature.parameterClause.parameters
+                            if validatorParams.count != 1 {
+                                context.diagnose(
+                                    Diagnostic(
+                                        node: Syntax(validatorFunc.signature.parameterClause),
+                                        message: ValidatorError(
+                                            message: "Validator method '\(validatorName)' must have exactly one parameter matching the update input"
+                                        )
+                                    )
+                                )
+                            } else if let validatorParam = validatorParams.first {
+                                if validatorParam.firstName.text != "input" {
                                     context.diagnose(
                                         Diagnostic(
-                                            node: Syntax(validatorParam.type),
+                                            node: Syntax(validatorParam),
                                             message: ValidatorError(
-                                                message:
-                                                    "Validator method '\(validatorName)' input type '\(validatorType)' does not match update input type '\(updateType)'"
+                                                message: "Validator method '\(validatorName)' parameter must be called 'input'"
                                             )
                                         )
                                     )
                                 }
+
+                                // Check input type matches
+                                let updateParams = functionDecl.signature.parameterClause.parameters
+                                if let updateParam = updateParams.first(where: { $0.firstName.text == "input" }) {
+                                    let updateType = updateParam.type.description.trimmingCharacters(in: .whitespaces)
+                                    let validatorType = validatorParam.type.description.trimmingCharacters(in: .whitespaces)
+                                    if updateType != validatorType {
+                                        context.diagnose(
+                                            Diagnostic(
+                                                node: Syntax(validatorParam.type),
+                                                message: ValidatorError(
+                                                    message:
+                                                        "Validator method '\(validatorName)' input type '\(validatorType)' does not match update input type '\(updateType)'"
+                                                )
+                                            )
+                                        )
+                                    }
+                                }
                             }
-                        }
-                    } else {
-                        context.diagnose(
-                            Diagnostic(
-                                node: Syntax(updateAttribute),
-                                message: ValidatorError(message: "Validator method '\(validatorName)' not found in workflow")
+                        } else {
+                            context.diagnose(
+                                Diagnostic(
+                                    node: Syntax(updateAttribute),
+                                    message: ValidatorError(message: "Validator method '\(validatorName)' not found in workflow")
+                                )
                             )
-                        )
+                        }
                     }
                 }
+            } else if let variableDecl = member.decl.as(VariableDeclSyntax.self),
+                variableDecl.attributes.contains(where: { element in
+                    element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "WorkflowQuery"
+                }),
+                let identifier = variableDecl.identifier
+            {
+                queryNames.append(identifier.text)
             }
         }
 

--- a/Sources/TemporalMacros/WorkflowQueryMacro.swift
+++ b/Sources/TemporalMacros/WorkflowQueryMacro.swift
@@ -37,11 +37,30 @@ public struct WorkflowQueryMacro: PeerMacro {
         }
         parentName = structDecl.name.text
 
-        // Only methods can be queries
-        guard let functionDecl = declaration.as(FunctionDeclSyntax.self) else {
-            throw MacroError(message: "@WorkflowQuery can only be applied to methods")
+        if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
+            return try expandMethodQuery(
+                node: node,
+                functionDecl: functionDecl,
+                parentName: parentName
+            )
+        } else if let variableDecl = declaration.as(VariableDeclSyntax.self) {
+            return try expandPropertyQuery(
+                node: node,
+                variableDecl: variableDecl,
+                parentName: parentName
+            )
+        } else {
+            throw MacroError(message: "@WorkflowQuery can only be applied to methods or properties")
         }
+    }
 
+    // MARK: - Method Queries
+
+    private static func expandMethodQuery(
+        node: AttributeSyntax,
+        functionDecl: FunctionDeclSyntax,
+        parentName: String
+    ) throws -> [DeclSyntax] {
         // Queries must return something
         guard let returnClause = functionDecl.signature.returnClause,
             returnClause.type.as(IdentifierTypeSyntax.self)?.name.text != "Void"
@@ -55,26 +74,37 @@ public struct WorkflowQueryMacro: PeerMacro {
         let hasContextParam: Bool
         if parameters.count == 2 {
             guard parameters.first?.firstName.text == "context" else {
-                throw MacroError(message: "Workflow query first parameter must be called 'context' with type 'WorkflowContextView'")
+                throw MacroError(
+                    message: "Workflow query first parameter must be called 'context' with type 'WorkflowContextView'"
+                )
             }
             guard parameters.dropFirst().first?.firstName.text == "input" else {
-                throw MacroError(message: "Workflow query second parameter must be called 'input' with a Sendable type")
+                throw MacroError(
+                    message: "Workflow query second parameter must be called 'input' with a Sendable type"
+                )
             }
             hasContextParam = true
         } else if parameters.count == 1 {
             guard parameters.first?.firstName.text == "input" else {
-                throw MacroError(message: "Workflow query parameter must be called 'input' with a Sendable type")
+                throw MacroError(
+                    message: "Workflow query parameter must be called 'input' with a Sendable type"
+                )
             }
             hasContextParam = false
         } else {
-            throw MacroError(message: "Workflow queries must have one parameter 'input' or two parameters 'context' and 'input'")
+            throw MacroError(
+                message: "Workflow queries must have one parameter 'input' or two parameters 'context' and 'input'"
+            )
         }
 
         let input = hasContextParam ? parameters.dropFirst().first! : parameters.first!
 
-        let throwingQuery = functionDecl.signature.effectSpecifiers?.throwsClause?.throwsSpecifier.presence == .present
+        let throwingQuery =
+            functionDecl.signature.effectSpecifiers?.throwsClause?.throwsSpecifier.presence == .present
 
-        let rawAccessModifier = functionDecl.modifiers.accessModifierPrefix(supportedModifiers: .allAccessModifiers)
+        let rawAccessModifier = functionDecl.modifiers.accessModifierPrefix(
+            supportedModifiers: .allAccessModifiers
+        )
 
         var nameDecl: DeclSyntax?
         var descriptionDecl: DeclSyntax?
@@ -82,16 +112,19 @@ public struct WorkflowQueryMacro: PeerMacro {
             nameDecl = "\(raw: rawAccessModifier)static var name: String { \(name) }"
         }
         if let description = node.stringLiteralValueForArgument(named: "description") {
-            descriptionDecl = "\(raw: rawAccessModifier)static var description: String? { \(description) }"
+            descriptionDecl =
+                "\(raw: rawAccessModifier)static var description: String? { \(description) }"
         }
 
         let queryName = functionDecl.name.text.capitalizingFirst()
 
         let closureBody: String
         if hasContextParam {
-            closureBody = "{ workflow, view, input in \(throwingQuery ? "try" : "") workflow.\(functionDecl.name.text)(context: view, input: input) }"
+            closureBody =
+                "{ workflow, view, input in \(throwingQuery ? "try" : "") workflow.\(functionDecl.name.text)(context: view, input: input) }"
         } else {
-            closureBody = "{ workflow, _, input in \(throwingQuery ? "try" : "") workflow.\(functionDecl.name.text)(input: input) }"
+            closureBody =
+                "{ workflow, _, input in \(throwingQuery ? "try" : "") workflow.\(functionDecl.name.text)(input: input) }"
         }
 
         return [
@@ -115,6 +148,68 @@ public struct WorkflowQueryMacro: PeerMacro {
             """
             static var \(raw: functionDecl.name.text): \(raw: queryName) {
                 \(raw: queryName)(run: \(raw: closureBody))
+            }
+            """,
+        ]
+    }
+
+    // MARK: - Property Queries
+
+    private static func expandPropertyQuery(
+        node: AttributeSyntax,
+        variableDecl: VariableDeclSyntax,
+        parentName: String
+    ) throws -> [DeclSyntax] {
+        guard let binding = variableDecl.bindings.first,
+            let identifierPattern = binding.pattern.as(IdentifierPatternSyntax.self)
+        else {
+            throw MacroError(message: "@WorkflowQuery property must have an identifier")
+        }
+
+        let propertyName = identifierPattern.identifier.text
+
+        guard let typeAnnotation = binding.typeAnnotation else {
+            throw MacroError(message: "@WorkflowQuery property must have an explicit type annotation")
+        }
+        let propertyType = typeAnnotation.type
+
+        let accessModifier = variableDecl.modifiers.accessModifierPrefix(
+            supportedModifiers: .allAccessModifiers
+        )
+
+        var nameDecl: DeclSyntax?
+        var descriptionDecl: DeclSyntax?
+        if let name = node.stringLiteralValueForArgument(named: "name") {
+            nameDecl = "\(accessModifier)static var name: String { \(name) }"
+        }
+        if let description = node.stringLiteralValueForArgument(named: "description") {
+            descriptionDecl =
+                "\(accessModifier)static var description: String? { \(description) }"
+        }
+
+        let queryName = propertyName.capitalizingFirst()
+
+        return [
+            """
+            \(accessModifier)struct \(raw: queryName): WorkflowQueryDefinition {
+                \(accessModifier)typealias Input = Void
+                \(accessModifier)typealias Output = \(propertyType)
+                \(accessModifier)typealias Workflow = \(raw: parentName)
+
+                let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
+                    self._run = run
+                }
+                \(accessModifier)func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output {
+                    try self._run(workflow, view, input)
+                }
+                \(nameDecl)
+                \(descriptionDecl)
+            }
+            """,
+            """
+            static var \(raw: propertyName): \(raw: queryName) {
+                \(raw: queryName)(run: { workflow, _, _ in workflow.\(raw: propertyName) })
             }
             """,
         ]

--- a/Sources/TemporalMacros/WorkflowStateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowStateMacro.swift
@@ -116,8 +116,12 @@ extension VariableDeclSyntax {
         let newAttributes = attributes.filter { (attribute: AttributeListSyntax.Element) -> Bool in
             switch attribute {
             case .attribute(let attr):
-                attr.attributeName.identifier != toRemove.attributeName.identifier
-            default: true
+                let name = attr.attributeName.identifier
+                return name != toRemove.attributeName.identifier
+                    && name != "WorkflowQuery"
+                    && name != "WorkflowSignal"
+                    && name != "WorkflowUpdate"
+            default: return true
             }
         }
         return VariableDeclSyntax(

--- a/Tests/TemporalMacrosTests/WorkflowMacrosTests.swift
+++ b/Tests/TemporalMacrosTests/WorkflowMacrosTests.swift
@@ -975,4 +975,252 @@ struct WorkflowMacrosTests {
         // Diagnostic should be on the parameter type
         #expect(diagnostics.first?.node.description.contains("Int") == true)
     }
+
+    // MARK: - Property Query Tests
+
+    @Test(arguments: [nil, "public", "package", "internal", "fileprivate", "private"])
+    func propertyQueryComputed(modifier: String?) throws {
+        let modifierPrefix = modifier.map { "\($0) " } ?? ""
+
+        let (expectedOutput, _) = try parse(
+            """
+            struct FooWorkflow {
+                \(modifierPrefix)var status: String { "pending" }
+
+                \(modifierPrefix)struct Status: WorkflowQueryDefinition {
+                    \(modifierPrefix)typealias Input = Void
+                    \(modifierPrefix)typealias Output = String
+                    \(modifierPrefix)typealias Workflow = FooWorkflow
+
+                    let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
+                        self._run = run
+                    }
+                    \(modifierPrefix)func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output {
+                        try self._run(workflow, view, input)
+                    }
+                    \(modifierPrefix)static var name: String {
+                        "custom_status"
+                    }
+                    \(modifierPrefix)static var description: String? {
+                        "Description"
+                    }
+                }
+
+                static var status: Status {
+                    Status(run: { workflow, _, _ in workflow.status })
+                }
+
+                static var queries: [any WorkflowQueryDefinition<FooWorkflow>] {
+                    [Self.status]
+                }
+
+                init(input: Input) {}
+            }
+
+            extension FooWorkflow: WorkflowDefinition {
+            }
+            """,
+            removeWhitespace: true
+        )
+        let (actualOutput, _) = try parse(
+            """
+            @Workflow
+            struct FooWorkflow {
+                @WorkflowQuery(name: "custom_status", description: "Description") 
+                \(modifierPrefix)var status: String { "pending" }
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(expectedOutput == actualOutput)
+    }
+
+    @Test
+    func propertyQueryStored() throws {
+        let (expectedOutput, _) = try parse(
+            """
+            struct FooWorkflow {
+                var status: String {
+                    @storageRestrictions(initializes: _status)
+                    init(initialValue) {
+                        _status = .init(initialValue: initialValue)
+                    }
+                    get {
+                        return _status.value
+                    }
+                    set {
+                        _status.value = newValue
+                    }
+                }
+
+                struct Status: WorkflowQueryDefinition {
+                    typealias Input = Void
+                    typealias Output = String
+                    typealias Workflow = FooWorkflow
+
+                    let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
+                        self._run = run
+                    }
+                    func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output {
+                        try self._run(workflow, view, input)
+                    }
+                }
+
+                static var status: Status {
+                    Status(run: { workflow, _, _ in workflow.status })
+                }
+
+                private nonisolated(unsafe) var _status: _WorkflowState<String> = _WorkflowState(initialValue: "pending")
+
+                static var queries: [any WorkflowQueryDefinition<FooWorkflow>] {
+                    [Self.status]
+                }
+
+                init(input: Input) {}
+            }
+
+            extension FooWorkflow: WorkflowDefinition {
+            }
+            """,
+            removeWhitespace: true
+        )
+        let (actualOutput, _) = try parse(
+            """
+            @Workflow
+            struct FooWorkflow {
+                @WorkflowQuery
+                var status: String = "pending"
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(expectedOutput == actualOutput)
+    }
+
+    @Test
+    func propertyQueryWithCustomName() throws {
+        let (expectedOutput, _) = try parse(
+            """
+            struct FooWorkflow {
+                var status: String { "pending" }
+
+                struct Status: WorkflowQueryDefinition {
+                    typealias Input = Void
+                    typealias Output = String
+                    typealias Workflow = FooWorkflow
+
+                    let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
+                        self._run = run
+                    }
+                    func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output {
+                        try self._run(workflow, view, input)
+                    }
+                    static var name: String {
+                        "current_status"
+                    }
+                }
+
+                static var status: Status {
+                    Status(run: { workflow, _, _ in workflow.status })
+                }
+
+                static var queries: [any WorkflowQueryDefinition<FooWorkflow>] {
+                    [Self.status]
+                }
+
+                init(input: Input) {}
+            }
+
+            extension FooWorkflow: WorkflowDefinition {
+            }
+            """,
+            removeWhitespace: true
+        )
+        let (actualOutput, _) = try parse(
+            """
+            @Workflow
+            struct FooWorkflow {
+                @WorkflowQuery(name: "current_status")
+                var status: String { "pending" }
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(expectedOutput == actualOutput)
+    }
+
+    @Test
+    func propertyQueryAppearsInQueriesArray() throws {
+        let (expectedOutput, _) = try parse(
+            """
+            struct FooWorkflow {
+                var status: String { "pending" }
+
+                struct Status: WorkflowQueryDefinition {
+                    typealias Input = Void
+                    typealias Output = String
+                    typealias Workflow = FooWorkflow
+
+                    let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
+                        self._run = run
+                    }
+                    func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output {
+                        try self._run(workflow, view, input)
+                    }
+                }
+
+                static var status: Status {
+                    Status(run: { workflow, _, _ in workflow.status })
+                }
+                func getCount(input: Void) -> Int { 0 }
+
+                struct GetCount: WorkflowQueryDefinition {
+                    typealias Input = Void
+                    typealias Output = Int
+                    typealias Workflow = FooWorkflow
+
+                    let _run: @Sendable (Workflow, WorkflowContextView, Input) throws -> Output
+                    init(run: @Sendable @escaping (Workflow, WorkflowContextView, Input) throws -> Output) {
+                        self._run = run
+                    }
+                    func run(workflow: Workflow, view: WorkflowContextView, input: Input) throws -> Output {
+                        try self._run(workflow, view, input)
+                    }
+                }
+
+                static var getCount: GetCount {
+                    GetCount(run: { workflow, _, input in workflow.getCount(input: input) })
+                }
+
+                static var queries: [any WorkflowQueryDefinition<FooWorkflow>] {
+                    [Self.status, Self.getCount]
+                }
+
+                init(input: Input) {}
+            }
+
+            extension FooWorkflow: WorkflowDefinition {
+            }
+            """,
+            removeWhitespace: true
+        )
+        let (actualOutput, _) = try parse(
+            """
+            @Workflow
+            struct FooWorkflow {
+                @WorkflowQuery
+                var status: String { "pending" }
+
+                @WorkflowQuery
+                func getCount(input: Void) -> Int { 0 }
+            }
+            """,
+            removeWhitespace: true
+        )
+        #expect(expectedOutput == actualOutput)
+    }
 }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
@@ -302,5 +302,97 @@ extension TestServerDependentTests {
             }
         }
 
+        // MARK: - Property Query Tests
+
+        @Workflow
+        struct PropertyQueryWorkflow {
+            @WorkflowQuery
+            var status: String = "pending"
+
+            @WorkflowQuery
+            var itemCount: Int { items.count }
+
+            private var items: [String] = []
+
+            mutating func run(context: WorkflowContext<Self>, input: Void) async throws {
+                try await context.condition { $0.status == "done" }
+            }
+
+            @WorkflowSignal
+            mutating func addItem(input: String) {
+                items.append(input)
+            }
+
+            @WorkflowSignal
+            mutating func complete(input: Void) {
+                status = "done"
+            }
+        }
+
+        @Test
+        func propertyQueryStoredProperty() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [PropertyQueryWorkflow.self]
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: PropertyQueryWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+
+                let status = try await handle.query(
+                    queryType: PropertyQueryWorkflow.Status.self
+                )
+                #expect(status == "pending")
+
+                try await handle.signal(
+                    signalType: PropertyQueryWorkflow.Complete.self
+                )
+
+                try await handle.result()
+
+                let finalStatus = try await handle.query(
+                    queryType: PropertyQueryWorkflow.Status.self
+                )
+                #expect(finalStatus == "done")
+            }
+        }
+
+        @Test
+        func propertyQueryComputedProperty() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [PropertyQueryWorkflow.self]
+            ) { taskQueue, client in
+                let handle = try await client.startWorkflow(
+                    type: PropertyQueryWorkflow.self,
+                    options: .init(id: UUID().uuidString, taskQueue: taskQueue)
+                )
+
+                let count = try await handle.query(
+                    queryType: PropertyQueryWorkflow.ItemCount.self
+                )
+                #expect(count == 0)
+
+                try await handle.signal(
+                    signalType: PropertyQueryWorkflow.AddItem.self,
+                    input: "item1"
+                )
+                try await handle.signal(
+                    signalType: PropertyQueryWorkflow.AddItem.self,
+                    input: "item2"
+                )
+
+                let updatedCount = try await handle.query(
+                    queryType: PropertyQueryWorkflow.ItemCount.self
+                )
+                #expect(updatedCount == 2)
+
+                try await handle.signal(
+                    signalType: PropertyQueryWorkflow.Complete.self
+                )
+
+                try await handle.result()
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Often queries just want to return the current value of a property. Instead of requiring developers to write `@WorkflowQuery` methods that just return a property value we can allow to add the `@WorkflowQuery` macro to properties and synthesize the method.