### PR TITLE
Doc comment style fixes

### DIFF
--- a/Sources/Temporal/Client/NamespaceService/TemporalClient+NamespaceService.swift
+++ b/Sources/Temporal/Client/NamespaceService/TemporalClient+NamespaceService.swift
@@ -26,7 +26,7 @@ extension TemporalClient {
         /// Metadata applied to all namespace service requests.
         let metadata: GRPCCore.Metadata
 
-        /// Initializes a new Temporal namespace service client.
+        /// Creates a new Temporal namespace service client.
         ///
         /// - Parameters:
         ///   - client: A configured gRPC client for performing namespace operations.

--- a/Sources/Temporal/Client/OperatorService/TemporalClient+OperatorService.swift
+++ b/Sources/Temporal/Client/OperatorService/TemporalClient+OperatorService.swift
@@ -28,7 +28,7 @@ extension TemporalClient {
         let client: TemporalClient.ConfiguredClient
         let metadata: GRPCCore.Metadata
 
-        /// Initializes a new Temporal operator client for accessing operator services.
+        /// Creates a new Temporal operator client for accessing operator services.
         ///
         /// - Parameters:
         ///   - client: A type-erased, configured `GRPCClient` used for performing RPCs.

--- a/Sources/Temporal/Client/TemporalClient+AsyncActivityHandle.swift
+++ b/Sources/Temporal/Client/TemporalClient+AsyncActivityHandle.swift
@@ -24,7 +24,7 @@ extension TemporalClient {
     /// Creates a handle for performing asynchronous completion operations on an existing activity.
     ///
     /// Use this method when you have a reference to an activity that will be completed asynchronously
-    /// (i.e., outside of its original execution context) and you need to send heartbeats, complete it
+    /// (that is, outside of its original execution context) and you need to send heartbeats, complete it
     /// with a result, fail it with an error, or report it as cancelled.
     ///
     /// The returned ``AsyncActivityHandle`` provides methods that map directly to Temporal's server-side

--- a/Sources/Temporal/Client/TemporalClient+ConfiguredClient.swift
+++ b/Sources/Temporal/Client/TemporalClient+ConfiguredClient.swift
@@ -22,7 +22,7 @@ extension TemporalClient {
         let client: AnyUInt8GRPCClient
         private let metadata: GRPCCore.Metadata
 
-        /// Initialize a new type-erased configured gRPC client for performing RPCs.
+        /// Creates a new type-erased configured gRPC client for performing RPCs.
         ///
         /// - Parameters:
         ///   - client: The `GRPCClient` to use.

--- a/Sources/Temporal/Client/WorkflowService/Model/Schedules/Listing/ScheduleListState.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Schedules/Listing/ScheduleListState.swift
@@ -17,14 +17,14 @@ public struct ScheduleListState: Hashable, Sendable {
     /// A human-readable note describing the current state of the schedule.
     public var note: String?
 
-    /// A boolean value that indicates whether the schedule is currently paused.
+    /// A Boolean value that indicates whether the schedule is currently paused.
     public var isPaused: Bool
 
     /// Creates a new schedule list state with the specified configuration.
     ///
     /// - Parameters:
     ///   - note: An optional descriptive message about the schedule state.
-    ///   - isPaused: A Boolean value indicating whether the schedule is paused.
+    ///   - isPaused: A Boolean value that indicates whether the schedule is paused.
     package init(note: String? = nil, isPaused: Bool = false) {
         self.note = note
         self.isPaused = isPaused

--- a/Sources/Temporal/Client/WorkflowService/Model/Schedules/ScheduleUpdate.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Schedules/ScheduleUpdate.swift
@@ -25,7 +25,7 @@ public struct ScheduleUpdate<Input: Sendable>: Sendable {
     /// - If `nil`, the search attributes will not be updated.
     /// - If present but empty, the search attributes will be cleared.
     /// - If present and non-empty, all search attributes will be updated to the provided
-    ///   collection. This means existing attributes which do not exist in the provided collection
+    ///   collection. This means existing attributes that do not exist in the provided collection
     ///   will be removed. You can copy attributes from the existing ``ScheduleDescription``
     ///   to avoid this.
     public var searchAttributes: SearchAttributeCollection?

--- a/Sources/Temporal/Client/WorkflowService/Model/Workflows/RetryPolicy.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Workflows/RetryPolicy.swift
@@ -25,7 +25,7 @@ public struct RetryPolicy: Hashable, Sendable {
     ///
     /// Each retry interval is calculated by multiplying the previous interval by this coefficient.
     /// For example, with an initial interval of 1 second and a coefficient of 2.0, subsequent
-    /// retries will occur after 1s, 2s, 4s, 8s, etc. Must be 1.0 or greater. A value of 1.0
+    /// retries will occur after 1s, 2s, 4s, 8s, and so on. Must be 1.0 or greater. A value of 1.0
     /// results in fixed intervals with no exponential growth.
     public var backoffCoefficient: Double
 

--- a/Sources/Temporal/Client/WorkflowService/Model/Workflows/WorkflowOptions.swift
+++ b/Sources/Temporal/Client/WorkflowService/Model/Workflows/WorkflowOptions.swift
@@ -78,7 +78,7 @@ public struct WorkflowOptions: Sendable {
     /// The cron schedule expression for the workflow.
     ///
     /// When set, the workflow will be executed on the specified cron schedule. Uses standard cron
-    /// expression syntax (e.g. `"0 * * * *"` for every hour).
+    /// expression syntax (for example, `"0 * * * *"` for every hour).
     ///
     /// - Note: Deprecated in favor of Temporal Schedules, but still supported for backward compatibility.
     /// - Note: Cannot be used with ``startDelay``.

--- a/Sources/Temporal/Client/WorkflowService/TemporalClient+WorkflowService.swift
+++ b/Sources/Temporal/Client/WorkflowService/TemporalClient+WorkflowService.swift
@@ -28,7 +28,7 @@ extension TemporalClient {
         let client: TemporalClient.ConfiguredClient
         let metadata: GRPCCore.Metadata
 
-        /// Initializes a new Temporal workflow client for accessing workflow services.
+        /// Creates a new Temporal workflow client for accessing workflow services.
         ///
         /// - Parameters:
         ///   - client: A type-erased, configured `GRPCClient` used for performing RPCs to the Temporal server.

--- a/Sources/Temporal/Client/WorkflowService/WorkflowService+Update.swift
+++ b/Sources/Temporal/Client/WorkflowService/WorkflowService+Update.swift
@@ -172,7 +172,7 @@ extension TemporalClient.WorkflowService {
     /// Initiates a workflow update by name and returns the update ID along with any known outcome.
     ///
     /// This is an internal variant that also captures the outcome payloads from the response
-    /// when the update completes during the start call (e.g., when ``waitForStage`` is
+    /// when the update completes during the start call (for example, when ``waitForStage`` is
     /// ``WorkflowUpdateStage/completed``). The captured outcome can be used to avoid
     /// redundant RPCs when retrieving the update result.
     package func startWorkflowUpdateWithOutcome<each Input: Sendable>(

--- a/Sources/Temporal/Converters/DataConverter.swift
+++ b/Sources/Temporal/Converters/DataConverter.swift
@@ -17,7 +17,7 @@ import SwiftProtobuf
 /// A data converter encodes data from your application to an ``Api/Common/V1/Payload`` before sending it
 /// to the Temporal server.
 ///
-/// When the server sends data back to a worker the data converter decodes it before
+/// When the server sends data back to a worker, the data converter decodes it before
 /// passing it to your activity/workflow.
 public struct DataConverter: Sendable {
     /// The default data converter.

--- a/Sources/Temporal/Converters/DataConverter.swift
+++ b/Sources/Temporal/Converters/DataConverter.swift
@@ -37,7 +37,7 @@ public struct DataConverter: Sendable {
     /// The payload codec.
     public let payloadCodec: (any PayloadCodec)?
 
-    /// Initializes a new data converter.
+    /// Creates a new data converter.
     ///
     /// - Parameters:
     ///   - payloadConverter: The payload converter.

--- a/Sources/Temporal/Converters/DefaultFailureConverter.swift
+++ b/Sources/Temporal/Converters/DefaultFailureConverter.swift
@@ -27,7 +27,7 @@ public struct DefaultFailureConverter: FailureConverter {
     /// When set to `true`, the `message` and `stackTrace` fields are converted and encoded using the payload converter.
     public var encodeCommonAttributes: Bool = false
 
-    /// Initializes a new default failure converter.
+    /// Creates a new default failure converter.
     public init() {}
 
     public func convertError(

--- a/Sources/Temporal/Documentation.docc/Connecting-to-Temporal.md
+++ b/Sources/Temporal/Documentation.docc/Connecting-to-Temporal.md
@@ -10,8 +10,8 @@ Use it to start workflows, query workflow state,
 send signals, and manage workflow lifecycles across different environments.
 
 This article shows you how to establish connections to local development
-and production instances. You'll learn to configure authentication and
-handle connection lifecycle.
+and production instances, configure authentication,
+and handle connection lifecycle.
 
 ## Connect to a local development server
 
@@ -39,7 +39,7 @@ try await client.run()
 ```
 
 A development server typically runs on `localhost:7233` with a plaintext
-transport. This configuration provides no encryption — never use it
+transport. This configuration provides no encryption. Don't use it
 in production environments.
 
 ## Connect to Temporal with mTLS

--- a/Sources/Temporal/Documentation.docc/Implementing-Activities.md
+++ b/Sources/Temporal/Documentation.docc/Implementing-Activities.md
@@ -12,8 +12,8 @@ workflows coordinate.
 
 This article shows you how to define activities using macros, organize them in
 containers, handle cancellation and timeouts, and implement proper error
-handling patterns. You'll learn to build robust activities that integrate
-seamlessly with your workflow orchestration.
+handling patterns. Use these patterns to build robust activities that integrate
+with your workflow orchestration.
 
 ## Define activities with the Activity macro
 

--- a/Sources/Temporal/Documentation.docc/Temporal.md
+++ b/Sources/Temporal/Documentation.docc/Temporal.md
@@ -31,7 +31,7 @@ Learn the fundamentals of building Temporal applications.
 - <doc:GettingStarted>
 - <doc:Connecting-to-Temporal>
 
-### Core development
+### Building activities and workflows
 
 Build activities and workflows.
 
@@ -40,7 +40,7 @@ Build activities and workflows.
 - <doc:Workflow-Concurrency>
 - <doc:Working-with-Data>
 
-### Workflow development
+### Developing workflows
 
 Create workflows that orchestrate business logic and coordinate activities.
 
@@ -49,7 +49,7 @@ Create workflows that orchestrate business logic and coordinate activities.
 - ``WorkflowOptions``
 - ``WorkflowHandle``
 
-### Activity development
+### Implementing activities
 
 Implement activities that perform the actual work in your workflows.
 
@@ -57,7 +57,7 @@ Implement activities that perform the actual work in your workflows.
 - ``ActivityOptions``
 - ``ActivityContainer``
 
-### Configuration and deployment
+### Configuring and deploying
 
 Configure workers and clients for different environments.
 

--- a/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
@@ -19,8 +19,8 @@ systems.
 
 Use the `@Workflow` macro on a `struct` to create a ``WorkflowDefinition``.
 The main entry point for a workflow is the `run(context:input:)` method, which
-receives a ``WorkflowContext`` and returns the workflow result. Errors thrown from
-the `run` method are treated as workflow failures.
+receives a ``WorkflowContext`` and returns the workflow result. The `run` method
+treats thrown errors as workflow failures.
 
 The struct-based design provides compile-time safety guarantees: query handlers
 cannot mutate workflow state, and update validators cannot mutate state either.
@@ -195,13 +195,13 @@ struct RegisterUserWorkflow {
 }
 ```
 
-Signal handlers that modify workflow state are declared as `mutating func`.
+Declare signal handlers that modify workflow state as `mutating func`.
 Because workflows are value types, signal handlers that only mutate state
 do not need to be `async throws`. Follow the same best practice of using custom
 input types for signal handlers as you do for workflows to support backward
 compatibility.
 
-By default the signal name is the unqualified capitalized method name.
+By default, the signal name matches the unqualified capitalized method name.
 You can customize the signal name using the `name` parameter, for example:
 
 ```swift
@@ -274,7 +274,7 @@ query handlers provide compile-time safety: they are non-mutating by default,
 guaranteeing they cannot modify workflow state. Use custom input and output types
 for queries to maintain backward compatibility.
 
-By default, the query name is the unqualified capitalized method name.
+By default, the query name matches the unqualified capitalized method name.
 You can customize the query name using the `name` parameter, for example:
 
 ```swift
@@ -338,7 +338,7 @@ values. Unlike queries, updates can modify workflow state and execute
 activities. Use custom input and output types for updates to maintain backward
 compatibility.
 
-By default the update name is the unqualified
+By default, the update name matches the unqualified
 capitalized method name. You can customize the update name using the
 `name` parameter, for example:
 

--- a/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
@@ -79,13 +79,13 @@ struct RegisterUserWorkflow {
 }
 ```
 
-### Best practices for workflow definitions
+### Follow best practices for workflow definitions
 
 Workflows should define custom input and output types rather than using basic
 types. This allows adding optional fields to input or output structures without
 breaking existing workflows.
 
-### Customizing workflow names
+### Customize workflow names
 
 By default, workflows use their struct name as the workflow type. You can
 customize this by providing a `name` parameter in the `@Workflow` macro:
@@ -97,7 +97,7 @@ struct RegisterUserWorkflow {
 }
 ```
 
-### Initializing state
+### Initialize state
 
 Define an optional `init(input:)` initializer to set up the workflow state from
 input parameters, eliminating the need for optional properties or
@@ -131,7 +131,7 @@ Use the `@WorkflowSignal`, `@WorkflowQuery`, and `@WorkflowUpdate` macros
 inside a type annotated with the `@Workflow` macro to define those respective
 handlers.
 
-### Signal handlers
+### Define signal handlers
 
 Signal handlers allow external systems to send information to running workflows.
 They're ideal for handling approvals, cancellations, or status updates.
@@ -208,7 +208,7 @@ You can customize the signal name using the `name` parameter, for example:
 @WorkflowSignal(name: "CustomApproveRegistration")
 ```
 
-### Query handlers
+### Define query handlers
 
 Queries allow external systems to retrieve information synchronously from running workflows.
 They're useful for getting the current state of a workflow without modifying it.
@@ -281,7 +281,7 @@ You can customize the query name using the `name` parameter, for example:
 @WorkflowQuery(name: "CustomGetRegistrationState")
 ```
 
-### Update handlers
+### Define update handlers
 
 Updates combine aspects of both signals and queries - they can modify a workflow's
 state and return values asynchronously.

--- a/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Developing-Workflows.md
@@ -11,8 +11,9 @@ long-running processes. Workflows must be deterministic to ensure reliable
 replay and recovery.
 
 This article shows you how to define workflows, coordinate activities, handle
-signals and queries, and implement complex orchestration patterns. You'll learn
-to build workflows that survive failures and scale across distributed systems.
+signals and queries, and implement complex orchestration patterns. Use these
+patterns to build workflows that survive failures and scale across distributed
+systems.
 
 ## Define a workflow with the Workflow macro
 

--- a/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
@@ -15,7 +15,7 @@ Workflows can safely use Swift's concurrency primitives, such as `async let`,
 execution guarantees required by Temporal. This enables you to write concurrent
 workflow logic that remains predictable and testable.
 
-## Deterministic execution guarantees
+## Understand deterministic execution guarantees
 
 Workflows run on a specialized task executor that ensures consistent execution
 order across different runs. This executor processes tasks sequentially by task

--- a/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
+++ b/Sources/Temporal/Documentation.docc/Workflows/Workflow-Concurrency.md
@@ -35,7 +35,7 @@ Workflows support Swift's Structured Concurrency patterns, including task groups
 and async let bindings. These patterns maintain deterministic execution while
 enabling concurrent operations.
 
-Here's an example using a task group to run two child tasks concurrently:
+The following example uses a task group to run two child tasks concurrently:
 
 ```swift
 @Workflow
@@ -95,9 +95,9 @@ Workflows support Swift's standard cancellation primitives, enabling graceful
 shutdown and cleanup. Use `Task.isCancelled`, `withTaskCancellationHandler`, and
 other cancellation APIs as you would in regular Swift code.
 
-When a workflow is cancelled, many ``WorkflowContext`` operations throw
+When Temporal cancels a workflow, many ``WorkflowContext`` operations throw
 `CancellationError`, allowing your workflow to detect cancellation and perform
 cleanup. Cancellation propagates through structured concurrency patterns, such as
-task groups, ensuring that all child tasks are properly cancelled when the workflow
-is cancelled.
+task groups, ensuring that all child tasks cancel when the workflow
+cancels.
 

--- a/Sources/Temporal/Errors/ArgumentError.swift
+++ b/Sources/Temporal/Errors/ArgumentError.swift
@@ -26,7 +26,7 @@ public struct ArgumentError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new argument error.
+    /// Creates a new argument error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/CompleteAsyncError.swift
+++ b/Sources/Temporal/Errors/CompleteAsyncError.swift
@@ -48,6 +48,6 @@ public struct CompleteAsyncError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String = ""
 
-    /// Create a new error that signals that the activity will be completed asynchronously.
+    /// Creates a new error that signals that the activity completes asynchronously.
     public init() {}
 }

--- a/Sources/Temporal/Errors/Failures/ActivityError.swift
+++ b/Sources/Temporal/Errors/Failures/ActivityError.swift
@@ -41,7 +41,7 @@ public struct ActivityError: TemporalFailureError {
     /// The retry state of the failed activity.
     public var retryState: Api.Enums.V1.RetryState
 
-    /// Initializes a new activity error.
+    /// Creates a new activity error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/Failures/ApplicationError.swift
+++ b/Sources/Temporal/Errors/Failures/ApplicationError.swift
@@ -32,10 +32,10 @@ public struct ApplicationError: TemporalFailureError {
     /// The details of the error.
     public var details: [Api.Common.V1.Payload]
 
-    /// The string type of the error if any.
+    /// The string type of the error, if any.
     public var type: String?
 
-    /// Boolean indicating whether the error was set as non-retry.
+    /// A Boolean value that indicates whether the error is nonretryable.
     public var isNonRetryable: Bool
 
     /// Delay duration before the next retry attempt.
@@ -44,14 +44,14 @@ public struct ApplicationError: TemporalFailureError {
     /// The error category.
     public var category: Api.Enums.V1.ApplicationErrorCategory
 
-    /// Initializes a new application error.
+    /// Creates a new application error.
     ///
     /// - Parameters:
     ///   - message: The error's message.
     ///   - cause: The cause of the current error. Defaults to `nil`.
     ///   - stackTrace: The stack trace of the current error.
     ///   - details: The details of the error. Defaults to empty details.
-    ///   - type: The string type of the error if any. Defaults to `nil`.
+    ///   - type: The string type of the error, if any. Defaults to `nil`.
     ///   - isNonRetryable: A Boolean value that indicates whether the error is nonretryable. Defaults to `false`.
     ///   - nextRetryDelay: Delay duration before the next retry attempt. Defaults to `nil`.
     ///   - category: The error category. Defaults to `.unspecified`.

--- a/Sources/Temporal/Errors/Failures/BasicTemporalFailureError.swift
+++ b/Sources/Temporal/Errors/Failures/BasicTemporalFailureError.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A basic temporal failure.
+/// A basic Temporal failure error.
 public struct BasicTemporalFailureError: TemporalFailureError {
     /// The error's message.
     public var message: String
@@ -23,6 +23,12 @@ public struct BasicTemporalFailureError: TemporalFailureError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
+    /// Creates a new basic Temporal failure error.
+    ///
+    /// - Parameters:
+    ///   - message: The error's message.
+    ///   - cause: The cause of the current error. Defaults to `nil`.
+    ///   - stackTrace: The stack trace of the current error.
     public init(
         message: String,
         cause: (any Error)? = nil,

--- a/Sources/Temporal/Errors/Failures/CanceledError.swift
+++ b/Sources/Temporal/Errors/Failures/CanceledError.swift
@@ -26,7 +26,7 @@ public struct CanceledError: TemporalFailureError {
     /// The details of the error.
     public var details: [Api.Common.V1.Payload]
 
-    /// Initializes a new canceled error.
+    /// Creates a new canceled error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/Failures/ChildWorkflowFailure.swift
+++ b/Sources/Temporal/Errors/Failures/ChildWorkflowFailure.swift
@@ -38,7 +38,7 @@ public struct ChildWorkflowError: TemporalFailureError {
     /// The child workflow's retry state.
     public var retryState: Api.Enums.V1.RetryState
 
-    /// Initializes a new child workflow error.
+    /// Creates a new child workflow error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/Failures/ServerError.swift
+++ b/Sources/Temporal/Errors/Failures/ServerError.swift
@@ -26,13 +26,13 @@ public struct ServerError: TemporalFailureError {
     /// A Boolean value that indicates whether the error is nonretryable.
     public var isNonRetryable: Bool
 
-    /// Initializes a new server error.
+    /// Creates a new server error.
     ///
     /// - Parameters:
     ///   - message: The error's message.
     ///   - cause: The cause of the current error. Defaults to `nil`.
     ///   - stackTrace: The stack trace of the current error.
-    ///   - isNonRetryable: Boolean indicating whether the error was set as non-retry.
+    ///   - isNonRetryable: A Boolean value that indicates whether the error is nonretryable.
     public init(
         message: String,
         cause: (any Error)? = nil,

--- a/Sources/Temporal/Errors/Failures/TerminatedError.swift
+++ b/Sources/Temporal/Errors/Failures/TerminatedError.swift
@@ -26,7 +26,7 @@ public struct TerminatedError: TemporalFailureError {
     /// The details of the error.
     public var details: [Api.Common.V1.Payload]
 
-    /// Initializes a new terminated error.
+    /// Creates a new terminated error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/Failures/TimeoutError.swift
+++ b/Sources/Temporal/Errors/Failures/TimeoutError.swift
@@ -29,7 +29,7 @@ public struct TimeoutError: TemporalFailureError {
     /// The details of the last heartbeat.
     public var lastHeartbeatDetails: [Api.Common.V1.Payload]
 
-    /// Initializes a new timed out error.
+    /// Creates a new timeout error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/Failures/WorkflowAlreadyStartedError.swift
+++ b/Sources/Temporal/Errors/Failures/WorkflowAlreadyStartedError.swift
@@ -32,7 +32,7 @@ public struct WorkflowAlreadyStartedError: TemporalFailureError {
     /// Name of the already-started workflow.
     public var workflowName: String
 
-    /// Initializes a new workflow already started error.
+    /// Creates a new workflow-already-started error.
     ///
     /// - Parameters:
     ///   - cause: The error's cause.

--- a/Sources/Temporal/Errors/InternalErrors.swift
+++ b/Sources/Temporal/Errors/InternalErrors.swift
@@ -19,7 +19,7 @@ struct TemporalSDKError: TemporalError {
     var cause: (any Error)?
     /// The stack trace of the current error.
     var stackTrace: String
-    /// Indicates if the error is retryable.
+    /// A Boolean value that indicates whether the error is retryable.
     let nonRetryable: Bool
 
     init(

--- a/Sources/Temporal/Errors/InvalidOperationError.swift
+++ b/Sources/Temporal/Errors/InvalidOperationError.swift
@@ -23,7 +23,7 @@ public struct InvalidOperationError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes an invalid operation error.
+    /// Creates an invalid operation error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/ScheduleAlreadyRunningError.swift
+++ b/Sources/Temporal/Errors/ScheduleAlreadyRunningError.swift
@@ -23,7 +23,7 @@ public struct ScheduleAlreadyRunningError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new schedule already running error.
+    /// Creates a new schedule-already-running error.
     ///
     /// - Parameters:
     ///   - cause: The error's cause.

--- a/Sources/Temporal/Errors/UnknownError.swift
+++ b/Sources/Temporal/Errors/UnknownError.swift
@@ -23,7 +23,7 @@ public struct UnknownError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new unknown error.
+    /// Creates a new unknown error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/UnknownWorkflowEventError.swift
+++ b/Sources/Temporal/Errors/UnknownWorkflowEventError.swift
@@ -23,7 +23,7 @@ public struct UnknownWorkflowEventError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new unknown workflow event error.
+    /// Creates a new unknown workflow event error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/WorkflowContinuedAsNewError.swift
+++ b/Sources/Temporal/Errors/WorkflowContinuedAsNewError.swift
@@ -26,7 +26,7 @@ public struct WorkflowContinuedAsNewError: TemporalError {
     /// New execution run ID the workflow continued to.
     public var newRunID: String
 
-    /// Initializes a new workflow continued-as-new error.
+    /// Creates a new workflow continued-as-new error.
     ///
     /// - Parameters:
     ///   - stackTrace: The stack trace of the current error.

--- a/Sources/Temporal/Errors/WorkflowFailedError.swift
+++ b/Sources/Temporal/Errors/WorkflowFailedError.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Error that is returned when a workflow execution is unsuccessful.
+/// An error that represents an unsuccessful workflow execution.
 public struct WorkflowFailedError: TemporalError {
     /// The error's message.
     public var message: String = "Workflow execution failed"
@@ -23,7 +23,7 @@ public struct WorkflowFailedError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new workflow failed error.
+    /// Creates a new workflow failed error.
     ///
     /// - Parameters:
     ///   - cause: The cause of the current error. Defaults to `nil`.

--- a/Sources/Temporal/Errors/WorkflowHistoryEmptyError.swift
+++ b/Sources/Temporal/Errors/WorkflowHistoryEmptyError.swift
@@ -23,7 +23,7 @@ public struct WorkflowHistoryEmptyError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new workflow history empty error.
+    /// Creates a new workflow history empty error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/WorkflowQueryFailedError.swift
+++ b/Sources/Temporal/Errors/WorkflowQueryFailedError.swift
@@ -23,7 +23,7 @@ public struct WorkflowQueryFailedError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new workflow query failed error.
+    /// Creates a new workflow query failed error.
     ///
     /// - Parameters:
     ///   - message: The error's message.

--- a/Sources/Temporal/Errors/WorkflowQueryRejectedError.swift
+++ b/Sources/Temporal/Errors/WorkflowQueryRejectedError.swift
@@ -26,7 +26,7 @@ public struct WorkflowQueryRejectedError: TemporalError {
     /// The workflow's execution status.
     public var workflowExecutionStatus: Api.Enums.V1.WorkflowExecutionStatus
 
-    /// Initializes a new workflow query rejected error.
+    /// Creates a new workflow query rejected error.
     ///
     /// - Parameters:
     ///   - stackTrace: The stack trace of the current error.

--- a/Sources/Temporal/Errors/WorkflowRemovedFromCacheError.swift
+++ b/Sources/Temporal/Errors/WorkflowRemovedFromCacheError.swift
@@ -23,7 +23,7 @@ public struct WorkflowRemovedFromCacheError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new workflow removed from cache error.
+    /// Creates a new workflow-removed-from-cache error.
     ///
     /// - Parameters:
     ///   - cause: The cause of the current error. Defaults to `nil`.

--- a/Sources/Temporal/Errors/WorkflowUpdateFailedError.swift
+++ b/Sources/Temporal/Errors/WorkflowUpdateFailedError.swift
@@ -23,7 +23,7 @@ public struct WorkflowUpdateFailedError: TemporalError {
     /// The stack trace of the current error.
     public var stackTrace: String
 
-    /// Initializes a new workflow update failed error.
+    /// Creates a new workflow update failed error.
     ///
     /// - Parameters:
     ///   - cause: The cause of the current error. Defaults to `nil`.

--- a/Sources/Temporal/Instrumentation/TemporalClientTracingInterceptor+Outbound.swift
+++ b/Sources/Temporal/Instrumentation/TemporalClientTracingInterceptor+Outbound.swift
@@ -20,7 +20,7 @@ extension TemporalClientTracingInterceptor {
     public struct Outbound: ClientOutboundInterceptor {
         private let traceRecording: TemporalTraceRecording
 
-        /// Create the client outbound interceptor.
+        /// Creates the client outbound interceptor.
         ///
         /// - Parameters:
         ///    - tracer: The `Tracer` instance to use for creating spans.

--- a/Sources/Temporal/Instrumentation/TemporalClientTracingInterceptor.swift
+++ b/Sources/Temporal/Instrumentation/TemporalClientTracingInterceptor.swift
@@ -56,7 +56,7 @@ public struct TemporalClientTracingInterceptor: ClientInterceptor {
         )
     }
 
-    /// Create the interceptor with a custom `Tracer`, useful for testing.
+    /// Creates the interceptor with a custom `Tracer`, useful for testing.
     ///
     /// - Parameters:
     ///    - tracer: Custom `Tracer` passed in.

--- a/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+ActivityInbound.swift
+++ b/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+ActivityInbound.swift
@@ -19,7 +19,7 @@ extension TemporalWorkerTracingInterceptor {
     public struct ActivityInbound: ActivityInboundInterceptor {
         private let traceRecording: TemporalTraceRecording
 
-        /// Create the worker activity inbound interceptor.
+        /// Creates the worker activity inbound interceptor.
         ///
         /// - Parameters:
         ///    - tracer: The `Tracer` instance to use for creating spans.

--- a/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+WorkflowInbound.swift
+++ b/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+WorkflowInbound.swift
@@ -19,7 +19,7 @@ extension TemporalWorkerTracingInterceptor {
     public struct WorkflowInbound: WorkflowInboundInterceptor {
         private let traceRecording: TemporalTraceRecording
 
-        /// Create the worker workflow inbound interceptor.
+        /// Creates the worker workflow inbound interceptor.
         ///
         /// - Parameters:
         ///    - tracer: The `Tracer` instance to use for creating spans.

--- a/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+WorkflowOutbound.swift
+++ b/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor+WorkflowOutbound.swift
@@ -19,7 +19,7 @@ extension TemporalWorkerTracingInterceptor {
     public struct WorkflowOutbound: WorkflowOutboundInterceptor {
         private let traceRecording: TemporalTraceRecording
 
-        /// Create the worker workflow outbound interceptor.
+        /// Creates the worker workflow outbound interceptor.
         /// - Parameters:
         ///    - tracer: The `Tracer` instance to use for creating spans.
         ///    - tracingHeaderKey: The name of the Temporal tracing header key.

--- a/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor.swift
+++ b/Sources/Temporal/Instrumentation/TemporalWorkerTracingInterceptor.swift
@@ -58,7 +58,7 @@ public struct TemporalWorkerTracingInterceptor: WorkerInterceptor {
         )
     }
 
-    /// Create the interceptor with a custom `Tracer`, useful for testing.
+    /// Creates the interceptor with a custom `Tracer`, useful for testing.
     ///
     /// - Parameters:
     ///    - tracer: Custom `Tracer` passed in.

--- a/Sources/Temporal/Worker/Activities/ActivityCancellationDetails.swift
+++ b/Sources/Temporal/Worker/Activities/ActivityCancellationDetails.swift
@@ -14,21 +14,21 @@
 
 /// Details about why an activity was cancelled, paused, or reset.
 public struct ActivityCancellationDetails: Sendable, Hashable {
-    /// Whether the activity was explicitly cancelled.
+    /// A Boolean value that indicates whether the activity was explicitly canceled.
     public var cancelRequested: Bool
 
-    /// Whether the activity was explicitly paused.
+    /// A Boolean value that indicates whether the activity was explicitly paused.
     public var paused: Bool
 
-    /// Whether the activity was explicitly reset.
+    /// A Boolean value that indicates whether the activity was explicitly reset.
     public var reset: Bool
 
     /// Creates cancellation details.
     ///
     /// - Parameters:
-    ///   - cancelRequested: Whether the activity was explicitly cancelled.
-    ///   - paused: Whether the activity was explicitly paused.
-    ///   - reset: Whether the activity was explicitly reset.
+    ///   - cancelRequested: A Boolean value that indicates whether the activity was explicitly canceled.
+    ///   - paused: A Boolean value that indicates whether the activity was explicitly paused.
+    ///   - reset: A Boolean value that indicates whether the activity was explicitly reset.
     public init(cancelRequested: Bool, paused: Bool, reset: Bool) {
         self.cancelRequested = cancelRequested
         self.paused = paused

--- a/Sources/Temporal/Worker/Activities/ActivityDefinition.swift
+++ b/Sources/Temporal/Worker/Activities/ActivityDefinition.swift
@@ -57,7 +57,7 @@ public protocol ActivityDefinition: Sendable {
     /// Defaults to the string representation of the conforming type.
     static var name: String { get }
 
-    /// Whether this activity is a dynamic activity that handles unregistered activity types.
+    /// A Boolean value that indicates whether this activity is a dynamic activity that handles unregistered activity types.
     ///
     /// Dynamic activities act as catch-all handlers for activity types that are not explicitly registered
     /// with the worker. When the worker receives a task for an unregistered activity type and a dynamic

--- a/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
+++ b/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
@@ -22,9 +22,9 @@ extension TemporalWorker {
     /// The configuration defines how the worker connects to the Temporal server, manages task execution,
     /// and handles various operational aspects like concurrency limits, timeouts, and versioning.
     ///
-    /// ## Creating a Configuration
+    /// ## Creating a configuration
     ///
-    /// Initialize with required parameters:
+    /// Create a configuration with the required parameters:
     ///
     /// ```swift
     /// let config = TemporalWorker.Configuration(
@@ -42,7 +42,7 @@ extension TemporalWorker {
     /// )
     /// ```
     ///
-    /// ## Customizing Behavior
+    /// ## Customizing behavior
     ///
     /// Adjust operational settings after initialization:
     ///

--- a/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
+++ b/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
@@ -247,12 +247,12 @@ extension TemporalWorker {
 
         /// The name of the SDK being implemented on top of the Core SDK.
         ///
-        /// Is set as `client-name` header in all RPC calls.
+        /// Sent as the `client-name` header in all RPC calls.
         static let workerClientName: String = "swift-temporal"
 
         /// The version of the SDK being implemented on top of the Core SDK.
         ///
-        /// Is set as `client-version` header in all RPC calls. The server decides if the client is supported based on this.
+        /// Sent as the `client-version` header in all RPC calls. The server uses this to decide whether the client is supported.
         static let workerClientVersion: String = Constants.sdkVersion  // derived from current git tag / commit
 
         /// The namespace where this worker polls for tasks.
@@ -360,7 +360,7 @@ extension TemporalWorker {
         public var gracefulShutdownPeriod: Duration = .seconds(0)
         /// Polling behavior for nexus tasks (default max `5`).
         public var nexusTaskPollerBehavior: PollerBehavior = .simpleMaximum(maximum: 5)
-        /// Skip fetching server system info on startup (default `false`).
+        /// A Boolean value that indicates whether to skip fetching server system info on startup (default `false`).
         public var skipGetSystemInfo: Bool = false
 
         /// Creates a Temporal worker configuration with the specified parameters.

--- a/Sources/Temporal/Worker/TemporalWorker.swift
+++ b/Sources/Temporal/Worker/TemporalWorker.swift
@@ -29,9 +29,9 @@ import TemporalInstrumentation
 /// You can manage the worker's lifetime as a `swift-service-lifecycle` `Service` within a
 /// `ServiceGroup` for structured concurrency and graceful shutdown handling.
 ///
-/// ## Creating a Worker
+/// ## Creating a worker
 ///
-/// Initialize a worker with configuration, transport, activities, workflows, and a logger:
+/// Create a worker with configuration, transport, activities, workflows, and a logger:
 ///
 /// ```swift
 /// let temporalWorker = TemporalWorker(
@@ -50,7 +50,7 @@ import TemporalInstrumentation
 /// )
 /// ```
 ///
-/// ## Running the Worker
+/// ## Running the worker
 ///
 /// Start processing tasks by calling the `run()` method:
 ///
@@ -60,7 +60,7 @@ import TemporalInstrumentation
 ///
 /// The worker runs indefinitely until cancelled or gracefully shut down.
 ///
-/// ## Lifecycle Management
+/// ## Lifecycle management
 ///
 /// The worker supports graceful shutdown through the `Service` protocol. When shutdown is initiated,
 /// the worker stops polling for new tasks, completes running tasks, and releases resources.

--- a/Sources/Temporal/Worker/Workflow/ActivityOptions.swift
+++ b/Sources/Temporal/Worker/Workflow/ActivityOptions.swift
@@ -66,7 +66,7 @@ public struct ActivityOptions: Hashable, Sendable {
     ///   setting this value, as incorrect usage can lead to unexpected behavior.
     public var activityID: String?
 
-    /// A boolean value that indicates whether eager activity execution is disabled for this activity.
+    /// A Boolean value that indicates whether eager activity execution is disabled for this activity.
     ///
     /// Eager activity execution is a server optimization that sends activities back to the same worker
     /// as the calling workflow if the worker has available capacity. When `false` (the default),

--- a/Sources/Temporal/Worker/Workflow/InternalWorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/InternalWorkflowContext.swift
@@ -92,7 +92,7 @@ struct InternalWorkflowContext: Sendable {
         self.stateMachine.setCurrentDetails(newValue)
     }
 
-    /// A boolean value that indicates whether continue as new was suggested.
+    /// A Boolean value that indicates whether continue as new was suggested.
     var continueAsNewSuggested: Bool {
         self.stateMachine.continueAsNewSuggested()
     }

--- a/Sources/Temporal/Worker/Workflow/InternalWorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/InternalWorkflowContext.swift
@@ -54,12 +54,12 @@ struct InternalWorkflowContext: Sendable {
         WorkflowRandomNumberGenerator(stateMachine: self.stateMachine)
     }
 
-    /// Indicates whether all update and signal handlers have finished executing.
+    /// A Boolean value that indicates whether all update and signal handlers have finished executing.
     var allHandlersFinished: Bool {
         self.stateMachine.allHandlersFinished()
     }
 
-    /// Indicates whether the workflow is currently in replay mode.
+    /// A Boolean value that indicates whether the workflow is currently in replay mode.
     package var isReplaying: Bool {
         self.stateMachine.isReplaying()
     }

--- a/Sources/Temporal/Worker/Workflow/UntypedChildWorkflowHandle.swift
+++ b/Sources/Temporal/Worker/Workflow/UntypedChildWorkflowHandle.swift
@@ -42,7 +42,7 @@ public struct UntypedChildWorkflowHandle: Sendable {
             ///   successful completion, failure, or cancellation.
             case resolved(result: Coresdk.ChildWorkflow.ChildWorkflowResult)
 
-            /// A boolean value that indicates whether the child workflow has completed execution.
+            /// A Boolean value that indicates whether the child workflow has completed execution.
             var isResolved: Bool {
                 switch self {
                 case .unresolved:

--- a/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
@@ -105,7 +105,7 @@ public struct WorkflowContext<Workflow: WorkflowDefinition>: @unchecked Sendable
     ///
     /// Returns the update ID and name when called from within an update handler
     /// or update validator. Returns `nil` when called outside of an update context
-    /// (e.g., from the main workflow run method, signal handlers, or query handlers).
+    /// (for example, from the main workflow run method, signal handlers, or query handlers).
     public var currentUpdateInfo: WorkflowUpdateInfo? {
         InternalWorkflowContext.currentUpdateInfo
     }
@@ -182,7 +182,7 @@ public struct WorkflowContext<Workflow: WorkflowDefinition>: @unchecked Sendable
         self.internalContext.now
     }
 
-    /// Indicates whether the workflow is currently in replay mode.
+    /// A Boolean value that indicates whether the workflow is currently in replay mode.
     package var isReplaying: Bool {
         self.internalContext.isReplaying
     }

--- a/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowContext.swift
@@ -415,7 +415,7 @@ public struct WorkflowContext<Workflow: WorkflowDefinition>: @unchecked Sendable
     /// ```
     ///
     /// - Parameter id: A unique identifier for this patch.
-    /// - Returns: A boolean value that indicates whether this should take the newer patch path.
+    /// - Returns: A Boolean value that indicates whether this should take the newer patch path.
     public func patch(_ id: String) -> Bool {
         self.internalContext.patch(id)
     }

--- a/Sources/Temporal/Worker/Workflow/WorkflowContextView.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowContextView.swift
@@ -71,7 +71,7 @@ public struct WorkflowContextView: @unchecked Sendable {
         storage.currentDeploymentVersion()
     }
 
-    /// A boolean value that indicates whether continue as new was suggested.
+    /// A Boolean value that indicates whether continue as new was suggested.
     public var continueAsNewSuggested: Bool {
         storage.continueAsNewSuggested()
     }

--- a/Sources/Temporal/Worker/Workflow/WorkflowContextView.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowContextView.swift
@@ -56,7 +56,7 @@ public struct WorkflowContextView: @unchecked Sendable {
         storage.now()
     }
 
-    /// Indicates whether the workflow is currently in replay mode.
+    /// A Boolean value that indicates whether the workflow is currently in replay mode.
     public var isReplaying: Bool {
         storage.isReplaying()
     }
@@ -97,7 +97,7 @@ public struct WorkflowContextView: @unchecked Sendable {
         storage.currentHistorySize()
     }
 
-    /// Indicates whether all update and signal handlers have finished executing.
+    /// A Boolean value that indicates whether all update and signal handlers have finished executing.
     public var allHandlersFinished: Bool {
         storage.allHandlersFinished()
     }

--- a/Sources/Temporal/Worker/Workflow/WorkflowDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowDefinition.swift
@@ -78,7 +78,7 @@ public protocol WorkflowDefinition: Sendable {
 
     /// Creates a new workflow instance.
     ///
-    /// This initializer is called by the Temporal SDK when a new workflow execution is started.
+    /// The Temporal SDK calls this initializer when starting a new workflow execution.
     /// Use this method to set up initial workflow state based on the provided input.
     ///
     /// - Parameter input: The input data for the workflow execution.

--- a/Sources/Temporal/Worker/Workflow/WorkflowDefinition.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowDefinition.swift
@@ -76,7 +76,7 @@ public protocol WorkflowDefinition: Sendable {
     /// Defaults to an empty array.
     static var updates: [any WorkflowUpdateDefinition<Self>] { get }
 
-    /// Initializes a new workflow instance.
+    /// Creates a new workflow instance.
     ///
     /// This initializer is called by the Temporal SDK when a new workflow execution is started.
     /// Use this method to set up initial workflow state based on the provided input.

--- a/Sources/TemporalInstrumentation/Logs/ClientOTelLoggingInterceptor.swift
+++ b/Sources/TemporalInstrumentation/Logs/ClientOTelLoggingInterceptor.swift
@@ -28,11 +28,11 @@ package struct ClientOTelLoggingInterceptor: ClientInterceptor {
     /// Creates an OTel logging interceptor for the gRPC client.
     ///
     /// - Parameters:
-    ///   - logger: The `Logger` instance to-be-used in the interceptor. The `Logger.Metadata` should include trace and span IDs for log correlation.
+    ///   - logger: The `Logger` instance used by the interceptor. The `Logger.Metadata` should include trace and span IDs for log correlation.
     ///   - serverHostname: The hostname of the RPC server. This will be the value for the `server.address` attribute in spans.
-    ///   - networkTransportMethod: The transport in use (e.g. "tcp", "unix"). This will be the value for the `network.transport` attribute in spans.
-    ///   - includeRequestMetadata: if `true`, **all** metadata keys with string values included in the request will be added to the logger metadata.
-    ///   - includeResponseMetadata: if `true`, **all** metadata keys with string values included in the response will be added to the logger metadata.
+    ///   - networkTransportMethod: The transport in use (for example, "tcp" or "unix"). This will be the value for the `network.transport` attribute in spans.
+    ///   - includeRequestMetadata: If `true`, all metadata keys with string values included in the request are added to the logger metadata.
+    ///   - includeResponseMetadata: If `true`, all metadata keys with string values included in the response are added to the logger metadata.
     package init(
         logger: Logger,
         serverHostname: String,
@@ -94,7 +94,7 @@ package struct ClientOTelLoggingInterceptor: ClientInterceptor {
 
         switch response.accepted {
         case .success:
-            // An "accepted" request is one where the the server responds with initial metadata and attempts to process the request.
+            // An "accepted" request is one where the server responds with initial metadata and attempts to process the request.
             // Does NOT guarantee that the request will be processed successfully, server could fail to complete processing the request.
             self.logger.trace("Accepted RPC", metadata: metadata)
         case .failure(let rpcError):

--- a/Sources/TemporalInstrumentation/Logs/ClientOTelLoggingInterceptor.swift
+++ b/Sources/TemporalInstrumentation/Logs/ClientOTelLoggingInterceptor.swift
@@ -25,11 +25,11 @@ package struct ClientOTelLoggingInterceptor: ClientInterceptor {
     private var includeRequestMetadata: Bool
     private var includeResponseMetadata: Bool
 
-    /// Initialize an OTel logging interceptor for the gRPC client.
+    /// Creates an OTel logging interceptor for the gRPC client.
     ///
     /// - Parameters:
     ///   - logger: The `Logger` instance to-be-used in the interceptor. The `Logger.Metadata` should include trace and span IDs for log correlation.
-    ///   - severHostname: The hostname of the RPC server. This will be the value for the `server.address` attribute in spans.
+    ///   - serverHostname: The hostname of the RPC server. This will be the value for the `server.address` attribute in spans.
     ///   - networkTransportMethod: The transport in use (e.g. "tcp", "unix"). This will be the value for the `network.transport` attribute in spans.
     ///   - includeRequestMetadata: if `true`, **all** metadata keys with string values included in the request will be added to the logger metadata.
     ///   - includeResponseMetadata: if `true`, **all** metadata keys with string values included in the response will be added to the logger metadata.

--- a/Sources/TemporalInstrumentation/Metrics/Utils/SpanAttributes+RPC.swift
+++ b/Sources/TemporalInstrumentation/Metrics/Utils/SpanAttributes+RPC.swift
@@ -89,7 +89,7 @@ extension RPCAttributes {
         package struct NestedSpanAttributes: NestedSpanAttributesProtocol {
             /// The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request.
             ///
-            /// E.g. ``RPCAttributes/GRPCAttributes/StatusCode/ok``.
+            /// For example, ``RPCAttributes/GRPCAttributes/StatusCode/ok``.
             package var statusCode: Key<String> {
                 "rpc.grpc.status_code"
             }


### PR DESCRIPTION
### Motivation

A final pass cleanup, applying internal style guides for consistency and minor tweaks - English spelling, consistency in API phrasing, removing latin abbreviations, re-working some of the section headings with gerunds and verb phrases to match Apple's style, and so on.

### Modifications

Wording tweaks to documentation comments and markdown.

