### PR TITLE
Use lower-case names for span attributes

### DIFF
--- a/Sources/Temporal/Instrumentation/SpanAttributes/SpanAttributes+ClientOutboundAttributes.swift
+++ b/Sources/Temporal/Instrumentation/SpanAttributes/SpanAttributes+ClientOutboundAttributes.swift
@@ -50,7 +50,7 @@ extension Span {
         // swift-format-ignore: ReplaceForEachWithForLoop
         input.options.searchAttributes?.forEach { key, value in
             if let value {
-                self.attributes["\(TemporalTracingKeys.workflowSearchAttributesPrefix)\(key.name) (\(key.type.indexedValueTypeString))"] = "\(value)"
+                self.attributes["\(TemporalTracingKeys.workflowSearchAttributesPrefix)\(key.name) (\(String(describing: key.type)))"] = "\(value)"
             }
         }
         // The workflow's memo.
@@ -383,7 +383,7 @@ extension Span {
             // swift-format-ignore: ReplaceForEachWithForLoop
             options.searchAttributes?.forEach { key, value in
                 if let value {
-                    self.attributes["\(TemporalTracingKeys.scheduleSearchAttributesPrefix)\(key.name) (\(key.type.indexedValueTypeString))"] =
+                    self.attributes["\(TemporalTracingKeys.scheduleSearchAttributesPrefix)\(key.name) (\(String(describing: key.type)))"] =
                         "\(value)"
                 }
             }
@@ -413,7 +413,7 @@ extension Span {
             // swift-format-ignore: ReplaceForEachWithForLoop
             workflow.options.searchAttributes?.forEach { key, value in
                 if let value {
-                    self.attributes["\(TemporalTracingKeys.workflowSearchAttributesPrefix)\(key.name) (\(key.type.indexedValueTypeString))"] =
+                    self.attributes["\(TemporalTracingKeys.workflowSearchAttributesPrefix)\(key.name) (\(String(describing: key.type)))"] =
                         "\(value)"
                 }
             }
@@ -489,7 +489,7 @@ extension Span {
             // swift-format-ignore: ReplaceForEachWithForLoop
             workflow.options.searchAttributes?.forEach { key, value in
                 if let value {
-                    self.attributes["\(TemporalTracingKeys.workflowSearchAttributesPrefix)\(key.name) (\(key.type.indexedValueTypeString))"] =
+                    self.attributes["\(TemporalTracingKeys.workflowSearchAttributesPrefix)\(key.name) (\(String(describing: key.type)))"] =
                         "\(value)"
                 }
             }
@@ -499,7 +499,7 @@ extension Span {
         // swift-format-ignore: ReplaceForEachWithForLoop
         response.searchAttributes?.forEach { key, value in
             if let value {
-                self.attributes["\(TemporalTracingKeys.scheduleSearchAttributesPrefix)\(key.name) (\(key.type.indexedValueTypeString))"] = "\(value)"
+                self.attributes["\(TemporalTracingKeys.scheduleSearchAttributesPrefix)\(key.name) (\(String(describing: key.type)))"] = "\(value)"
             }
         }
 


### PR DESCRIPTION
### Motivation

We use a mixture of upper- and lower-cased names from `key.type`. We should align for the sake of sanity.

### Modifications

Unifies usage across the repository to use `String(describing:)` instead of the upper-cased `key.type.indexedValueTypeString`. Keeps `key.type.indexedValueTypeString` around for its usage of setting search attributes for `TemporalTestServer`, and `SearchAttributes` themselves.