### PR TITLE
Attach inbound trace context as a span link

### DIFF
--- a/Sources/Temporal/Instrumentation/Utils/TemporalTraceRecording.swift
+++ b/Sources/Temporal/Instrumentation/Utils/TemporalTraceRecording.swift
@@ -145,8 +145,7 @@ struct TemporalTraceRecording {
     }
 
     /// Extracts the trace context carried on a Temporal request header into a
-    /// `ServiceContext` suitable for attaching as a ``SpanLink``. Returns
-    /// `nil` when no tracing header is present.
+    /// `ServiceContext` suitable for attaching as a ``SpanLink``.
     private func extractLinkContext(
         headers: [String: Api.Common.V1.Payload]
     ) throws -> ServiceContext? {

--- a/Sources/Temporal/Instrumentation/Utils/TemporalTraceRecording.swift
+++ b/Sources/Temporal/Instrumentation/Utils/TemporalTraceRecording.swift
@@ -93,13 +93,16 @@ struct TemporalTraceRecording {
         setSpanAttributes: (any Span) -> Void,
         next: () async throws -> R
     ) async throws -> R {
-        let serviceContext = try makeInboundServiceContext(headers: headers)
+        let linkContext = try extractLinkContext(headers: headers)
 
         return try await self.tracer.withSpan(
             spanName,
-            context: serviceContext,
+            context: .topLevel,
             ofKind: .server  // matches C#
         ) { span in
+            if let linkContext {
+                span.addLink(SpanLink(context: linkContext, attributes: [:]))
+            }
             setSpanAttributes(span)
 
             do {
@@ -119,13 +122,16 @@ struct TemporalTraceRecording {
         setSpanAttributes: (any Span) -> Void,
         next: () throws -> R
     ) throws -> R {
-        let serviceContext = try makeInboundServiceContext(headers: headers)
+        let linkContext = try extractLinkContext(headers: headers)
 
         return try self.tracer.withSpan(
             spanName,
-            context: serviceContext,
+            context: .topLevel,
             ofKind: .server  // matches C#
         ) { span in
+            if let linkContext {
+                span.addLink(SpanLink(context: linkContext, attributes: [:]))
+            }
             setSpanAttributes(span)
 
             do {
@@ -138,15 +144,15 @@ struct TemporalTraceRecording {
         }
     }
 
-    /// Extracts raw Temporal tracing header into a new `ServiceContext`.
-    private func makeInboundServiceContext(
+    /// Extracts the trace context carried on a Temporal request header into a
+    /// `ServiceContext` suitable for attaching as a ``SpanLink``. Returns
+    /// `nil` when no tracing header is present.
+    private func extractLinkContext(
         headers: [String: Api.Common.V1.Payload]
-    ) throws -> ServiceContext {
-        var serviceContext = ServiceContext.topLevel
-
+    ) throws -> ServiceContext? {
         // Check if header with tracer key exists
         guard let tracerPayload = headers[self.tracingHeaderKey] else {
-            return serviceContext
+            return nil
         }
 
         // Like C#, use default sync payload converters and bubble up conversion errors
@@ -156,13 +162,12 @@ struct TemporalTraceRecording {
             .payloadConverter
             .convertPayloadHandlingVoid(tracerPayload)
 
-        // Set extracted tracer header as context.
+        var linkContext = ServiceContext.topLevel
         self.tracer.extract(
             convertedTracerPayload,
-            into: &serviceContext,
+            into: &linkContext,
             using: self.extractor
         )
-
-        return serviceContext
+        return linkContext
     }
 }

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
@@ -76,8 +76,9 @@ struct TemporalWorkerInboundTracingInterceptorTests {
                 input: ()
             )
         ) { input in
-            // Make sure we get the metadata injected into our service context
-            #expect(ServiceContext.current?.traceID == traceID.uuidString)
+            // With span links, the inbound trace becomes a link on the span
+            // rather than the parent context, so it's not on `current`.
+            #expect(ServiceContext.current?.traceID == nil)
         }
 
         assertTestSpanComponents(
@@ -100,6 +101,11 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         } assertErrors: { errors in
             #expect(errors == [])
         }
+
+        // Inbound trace context is attached as a span link.
+        let links = tracer.getSpan(ofOperation: "RunWorkflow:\(Self.workflowName)")?.context.spanLinks ?? []
+        #expect(links.count == 1)
+        #expect(links.first?.context.traceID == traceID.uuidString)
     }
 
     @Test
@@ -128,8 +134,9 @@ struct TemporalWorkerInboundTracingInterceptorTests {
                     input: ()
                 )
             ) { input in
-                // Make sure we get the metadata injected into our service context
-                #expect(ServiceContext.current?.traceID == traceID.uuidString)
+                // With span links, the inbound trace becomes a link on the span
+                // rather than the parent context, so it's not on `current`.
+                #expect(ServiceContext.current?.traceID == nil)
 
                 // Simulates an error within the RPC
                 throw TracingInterceptorTestError.testError
@@ -150,6 +157,11 @@ struct TemporalWorkerInboundTracingInterceptorTests {
             } assertErrors: { errors in
                 #expect(errors == [.testError])
             }
+
+            // Inbound trace context is attached as a span link.
+            let links = tracer.getSpan(ofOperation: "RunWorkflow:\(Self.workflowName)")?.context.spanLinks ?? []
+            #expect(links.count == 1)
+            #expect(links.first?.context.traceID == traceID.uuidString)
         }
     }
 
@@ -182,8 +194,9 @@ struct TemporalWorkerInboundTracingInterceptorTests {
                 input: ()
             )
         ) { input in
-            // Make sure we get the metadata injected into our service context
-            #expect(ServiceContext.current?.traceID == traceID.uuidString)
+            // With span links, the inbound trace becomes a link on the span
+            // rather than the parent context, so it's not on `current`.
+            #expect(ServiceContext.current?.traceID == nil)
 
             return ()
         }
@@ -201,6 +214,11 @@ struct TemporalWorkerInboundTracingInterceptorTests {
         } assertErrors: { errors in
             #expect(errors == [])
         }
+
+        // Inbound trace context is attached as a span link.
+        let links = tracer.getSpan(ofOperation: "RunActivity:\(TestActivityName.name)")?.context.spanLinks ?? []
+        #expect(links.count == 1)
+        #expect(links.first?.context.traceID == traceID.uuidString)
     }
 
     @Test
@@ -229,8 +247,9 @@ struct TemporalWorkerInboundTracingInterceptorTests {
                     input: ()
                 )
             ) { input in
-                // Make sure we get the metadata injected into our service context
-                #expect(ServiceContext.current?.traceID == traceID.uuidString)
+                // With span links, the inbound trace becomes a link on the span
+                // rather than the parent context, so it's not on `current`.
+                #expect(ServiceContext.current?.traceID == nil)
 
                 // Simulates an error within the RPC
                 throw TracingInterceptorTestError.testError
@@ -251,6 +270,11 @@ struct TemporalWorkerInboundTracingInterceptorTests {
             } assertErrors: { errors in
                 #expect(errors == [.testError])
             }
+
+            // Inbound trace context is attached as a span link.
+            let links = tracer.getSpan(ofOperation: "RunActivity:\(TestActivityName.name)")?.context.spanLinks ?? []
+            #expect(links.count == 1)
+            #expect(links.first?.context.traceID == traceID.uuidString)
         }
     }
 }

--- a/Tests/TemporalTests/Instrumentation/Tracing/Utils/TracingTestsUtils.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/Utils/TracingTestsUtils.swift
@@ -144,7 +144,9 @@ final class TestSpan: Span, Sendable {
 
     func addLink(_ link: Tracing.SpanLink) {
         self.state.withLock {
-            $0.context.spanLinks?.append(link)
+            var links = $0.context.spanLinks ?? []
+            links.append(link)
+            $0.context.spanLinks = links
         }
     }
 


### PR DESCRIPTION
### Motivation

The SDK does not emit any span links, leading to all executions landing on the caller's trace.

### Modifications

Each workflow or activity execution now starts its own trace root with a link back to whoever called it, instead of being parented into the caller's trace. Keeps long-lived workflows from ballooning a single trace to unusable size and makes signal/query traces stand on their own. Also fixes a latent bug in `TestSpan.addLink` where the links array was never initialised — no test was exercising it until now.