### PR TITLE
Fix fatal crash on worker teardown mid-child-await

### DIFF
--- a/Sources/Temporal/Worker/Workflow/UntypedChildWorkflowHandle.swift
+++ b/Sources/Temporal/Worker/Workflow/UntypedChildWorkflowHandle.swift
@@ -153,14 +153,16 @@ public struct UntypedChildWorkflowHandle: Sendable {
     /// - Parameter resultType: The expected result type for the child workflow output.
     /// - Returns: The child workflow's output value.
     /// - Throws: Errors from child workflow execution, including business logic errors,
-    ///   system failures, timeouts, and cancellation errors.
+    ///   system failures, timeouts, and cancellation errors. Also throws
+    ///   `WorkflowRemovedFromCacheError` if the parent workflow is evicted from the worker's
+    ///   cache while waiting for the child to resolve (e.g. during worker shutdown).
     public func result<Result: Sendable>(
         resultType: Result.Type = Result.self
     ) async throws -> Result {
-        await withTaskCancellationHandler {
+        try await withTaskCancellationHandler {
             // We need to shield for cancellation here to avoid
             // the condition from automatically cancelling itself
-            await self.stateMachine.uncancellableCondition { self.state.resolutionState.isResolved }
+            try await self.stateMachine.uncancellableCondition { self.state.resolutionState.isResolved }
         } onCancel: {
             switch self.state.resolutionState {
             case .resolved:

--- a/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowStateMachineStorage.swift
@@ -162,10 +162,12 @@ package final class WorkflowStateMachineStorage: @unchecked Sendable {
         stateMachine.forceCancelOutstandingContinuations()
     }
 
-    func uncancellableCondition(_ condition: @escaping () -> Bool) async {
+    func uncancellableCondition(_ condition: @escaping () -> Bool) async throws {
         let id = self.stateMachine.condition(condition)
-        // This force unwrap is safe since the continuation for this condition cannot be cancelled.
-        try! await withCheckedThrowingContinuation { continuation in
+        // The continuation cannot be cancelled by Task cancellation, but it can be terminated
+        // by workflow eviction (`forceCancelOutstandingContinuations`), which resumes pending
+        // continuations with `WorkflowRemovedFromCacheError`. Callers must handle that error.
+        try await withCheckedThrowingContinuation { continuation in
             let continuation = self.stateMachine.storeConditionContinuation(id: id, continuation: continuation)
             precondition(continuation == nil, "The continuation is uncancellable so it must not be returned here")
         }

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
@@ -23,9 +23,10 @@ extension TestServerDependentTests {
     /// down while a workflow was parked inside `try await childHandle.result()`.
     ///
     /// Before the fix, `WorkflowStateMachineStorage.uncancellableCondition` did
-    /// `try! await withCheckedThrowingContinuation { … }`. When the worker's cache evicted
-    /// the parked workflow, the continuation was resumed with `WorkflowRemovedFromCacheError`,
-    /// the `try!` re-raised, and the worker thread died — causing tests to hang indefinitely.
+    /// `try! await withCheckedThrowingContinuation { … }`. When the worker's
+    /// cache evicted the parked workflow, the continuation was resumed with
+    /// `WorkflowRemovedFromCacheError`, the `try!` re-raised, and the worker
+    /// thread terminated fatally — causing tests to hang indefinitely.
     ///
     /// After the fix, eviction surfaces as a regular thrown error from the workflow code.
     /// The worker shuts down cleanly and the test completes.
@@ -82,8 +83,10 @@ extension TestServerDependentTests {
         }
 
         /// Returning from the worker body while the parent is parked inside
-        /// `try await childHandle.result()` used to crash the worker thread. With the fix,
-        /// the eviction surfaces as a thrown error and the test completes cleanly.
+        /// `try await childHandle.result()` used to crash the worker thread.
+        ///
+        /// With the fix, the eviction surfaces as a thrown error and the test
+        /// completes cleanly.
         @Test
         func workerTeardownWhileParentAwaitsChildDoesNotFatal() async throws {
             try await withTestWorkerAndClient(

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
@@ -26,7 +26,7 @@ extension TestServerDependentTests {
     /// `try! await withCheckedThrowingContinuation { … }`. When the worker's
     /// cache evicted the parked workflow, the continuation was resumed with
     /// `WorkflowRemovedFromCacheError`, the `try!` re-raised, and the worker
-    /// thread terminated fatally — causing tests to hang indefinitely.
+    /// thread crashed — causing tests to block indefinitely.
     ///
     /// After the fix, eviction surfaces as a regular thrown error from the workflow code.
     /// The worker shuts down cleanly and the test completes.

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
@@ -39,7 +39,7 @@ extension TestServerDependentTests {
             func run(context: WorkflowContext<Self>, input: Input) async throws {
                 // Long enough that the parent is guaranteed to still be awaiting this when
                 // the test body returns and the worker tears down.
-                try await context.sleep(for: .seconds(2))
+                try await context.sleep(for: .seconds(300))
             }
         }
 
@@ -69,7 +69,7 @@ extension TestServerDependentTests {
             }
 
             mutating func run(context: WorkflowContext<Self>, input: Input) async throws {
-                try await context.condition { (wf: Self) in wf.shutdownRequested }
+                try await context.condition { $0.shutdownRequested }
 
                 let childHandle = try await context.startChildWorkflow(
                     ChildWorkflow.self,

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import Temporal
+import TemporalTestKit
+import Testing
+
+extension TestServerDependentTests {
+    /// Regression tests for the fatal crash that previously occurred when a worker was torn
+    /// down while a workflow was parked inside `try await childHandle.result()`.
+    ///
+    /// Before the fix, `WorkflowStateMachineStorage.uncancellableCondition` did
+    /// `try! await withCheckedThrowingContinuation { … }`. When the worker's cache evicted
+    /// the parked workflow, the continuation was resumed with `WorkflowRemovedFromCacheError`,
+    /// the `try!` re-raised, and the worker thread died — causing tests to hang indefinitely.
+    ///
+    /// After the fix, eviction surfaces as a regular thrown error from the workflow code.
+    /// The worker shuts down cleanly and the test completes.
+    @Suite(.tags(.workflowTests))
+    struct WorkflowEvictionTests {
+
+        @Workflow
+        struct ChildWorkflow {
+            struct Input: Codable {}
+
+            func run(context: WorkflowContext<Self>, input: Input) async throws {
+                // Long enough that the parent is guaranteed to still be awaiting this when
+                // the test body returns and the worker tears down.
+                try await context.sleep(for: .seconds(2))
+            }
+        }
+
+        @Workflow
+        struct ParentWorkflow {
+            struct Input: Codable {}
+
+            enum Phase: String, Codable, Sendable {
+                case waiting
+                case awaitingChild
+            }
+
+            struct EmptyInput: Codable {}
+            struct ShutdownInput: Codable {}
+
+            private var phase: Phase = .waiting
+            private var shutdownRequested: Bool = false
+
+            @WorkflowSignal
+            mutating func shutdown(context: WorkflowContext<Self>, input: ShutdownInput) {
+                shutdownRequested = true
+            }
+
+            @WorkflowQuery
+            func currentPhase(input: EmptyInput) -> Phase {
+                return phase
+            }
+
+            mutating func run(context: WorkflowContext<Self>, input: Input) async throws {
+                try await context.condition { (wf: Self) in wf.shutdownRequested }
+
+                let childHandle = try await context.startChildWorkflow(
+                    ChildWorkflow.self,
+                    options: ChildWorkflowOptions(id: "evict-child-\(context.info.workflowID)"),
+                    input: ChildWorkflow.Input()
+                )
+                phase = .awaitingChild
+                _ = try await childHandle.result()
+            }
+        }
+
+        /// Returning from the worker body while the parent is parked inside
+        /// `try await childHandle.result()` used to crash the worker thread. With the fix,
+        /// the eviction surfaces as a thrown error and the test completes cleanly.
+        @Test
+        func workerTeardownWhileParentAwaitsChildDoesNotFatal() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [ParentWorkflow.self, ChildWorkflow.self]
+            ) { taskQueue, client in
+                let parentId = "evict-parent-\(UUID().uuidString)"
+
+                _ = try await client.startWorkflow(
+                    type: ParentWorkflow.self,
+                    options: .init(id: parentId, taskQueue: taskQueue),
+                    input: ParentWorkflow.Input()
+                )
+                let parentHandle = client.untypedWorkflowHandle(id: parentId)
+
+                try await parentHandle.signal(
+                    signalName: "Shutdown",
+                    input: ParentWorkflow.ShutdownInput()
+                )
+
+                // Poll until the parent reports it has entered the uncancellable
+                // `await childHandle.result()`. Without this we may exit the test body
+                // before the parent ever enters the failing code path.
+                let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+                while ContinuousClock.now < deadline {
+                    let phase: ParentWorkflow.Phase = try await parentHandle.query(
+                        queryName: "CurrentPhase",
+                        input: ParentWorkflow.EmptyInput(),
+                        resultTypes: ParentWorkflow.Phase.self
+                    )
+                    if phase == .awaitingChild { break }
+                    try await Task.sleep(for: .milliseconds(20))
+                }
+
+                // Returning here used to fatal in `WorkflowStateMachineStorage`. So the test
+                // passing here is the assertion.
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

`uncancellableCondition` used `try!` which kills the worker when a workflow is evicted from cache while parked inside `childHandle.result()`. Happens in tests when `withConnectedWorker`'s body returns before the awaiting workflow completes.

### Modifications / Results

Changed to `try` so the eviction propagates as a thrown error instead of crashing the process.

### Test Plan

Includes a regression test that starts a parent workflow awaiting a child, then tears down the worker mid-await.