### PR TITLE
Add withWorkerAndClient convenience to TemporalTestServer

### DIFF
--- a/Sources/Temporal/Bridge/BridgeTestServer.swift
+++ b/Sources/Temporal/Bridge/BridgeTestServer.swift
@@ -193,7 +193,7 @@ package struct BridgeTestServer: ~Copyable, Sendable {
     package static let bridgeRuntime = try! BridgeRuntime()
     private nonisolated(unsafe) let serverPointer: OpaquePointer
 
-    package static func withBridgeTestServer<Result: Sendable>(
+    package static func withBridgeTestServer<Result>(
         testServerOptions: BridgeTestServer.TestServerOptions = .default,
         _ body: (borrowing BridgeTestServer, String) async throws -> Result
     ) async throws -> Result {
@@ -241,10 +241,10 @@ package struct BridgeTestServer: ~Copyable, Sendable {
         return result
     }
 
-    package static func withBridgeDevServer<Result: Sendable>(
+    package static func withBridgeDevServer<Result>(
         devServerOptions: BridgeTestServer.DevServerOptions = .default,
-        _ body: (borrowing BridgeTestServer, String) async throws -> sending Result
-    ) async throws -> sending Result {
+        _ body: (borrowing BridgeTestServer, String) async throws -> Result
+    ) async throws -> Result {
         let (serverPointer, connectTarget): (UnsafeTransfer<OpaquePointer>, String) = try await withCheckedThrowingContinuation { continuation in
             devServerOptions.withBridgeDevServerOptions { devServerOptions in
                 withUnsafePointer(to: devServerOptions) { devServerOptionsPointer in

--- a/Sources/Temporal/Documentation.docc/Testing/Testing-Activities.md
+++ b/Sources/Temporal/Documentation.docc/Testing/Testing-Activities.md
@@ -123,5 +123,4 @@ through ``ActivityExecutionContext/cancellationReason``. See
 
 For end-to-end testing of activities as part of a workflow execution, see
 <doc:Testing-Workflows>. The integration test pattern is the same: apply a test
-trait, register your activities with `TemporalTestServer.withConnectedWorker`,
-and start the workflow through a connected client.
+trait and pass your activities to `TemporalTestServer.withWorkerAndClient`.

--- a/Sources/Temporal/Documentation.docc/Testing/Testing-Workflows.md
+++ b/Sources/Temporal/Documentation.docc/Testing/Testing-Workflows.md
@@ -22,12 +22,11 @@ changes stay deterministic with replay testing. There are two main approaches:
 ### Integration testing a workflow
 
 Apply the `.temporalTestServer` test trait to start a local Temporal server.
-Use `TemporalTestServer.withConnectedWorker` and
-`TemporalTestServer.withConnectedClient` to set up a worker and client
-connected to the test server:
+Use `TemporalTestServer.withWorkerAndClient` to set up a worker and client
+connected to the test server in a single call:
 
 ```swift
-import Logging
+import Foundation
 import Temporal
 import TemporalTestKit
 import Testing
@@ -37,34 +36,18 @@ struct GreetingWorkflowTests {
     @Test
     func greetingReturnsHello() async throws {
         let testServer = TemporalTestServer.testServer!
-        let taskQueue = "test-\(UUID())"
-        let logger = Logger(label: "test")
 
-        let config = TemporalWorker.Configuration(
-            namespace: "default",
-            taskQueue: taskQueue,
-            instrumentation: .init(serverHostname: "localhost")
-        )
-
-        try await testServer.withConnectedWorker(
-            configuration: config,
+        try await testServer.withWorkerAndClient(
             activities: GreetingActivities().allActivities,
             workflows: [GreetingWorkflow.self]
-        ) { _ in
-            try await testServer.withConnectedClient(
-                logger: logger
-            ) { client in
-                let handle = try await client.startWorkflow(
-                    type: GreetingWorkflow.self,
-                    options: .init(
-                        id: "wf-\(UUID())",
-                        taskQueue: taskQueue
-                    ),
-                    input: "World"
-                )
-                let result = try await handle.result()
-                #expect(result == "Hello, World!")
-            }
+        ) { taskQueue, client in
+            let handle = try await client.startWorkflow(
+                type: GreetingWorkflow.self,
+                options: .init(id: "wf-\(UUID())", taskQueue: taskQueue),
+                input: "World"
+            )
+            let result = try await handle.result()
+            #expect(result == "Hello, World!")
         }
     }
 }
@@ -167,44 +150,28 @@ struct TimeSkippingTests {
     @Test
     func delayedGreetingCompletesQuickly() async throws {
         let testServer = TemporalTestServer.timeSkippingTestServer!
-        let taskQueue = "test-\(UUID())"
-        let logger = Logger(label: "test")
 
-        let config = TemporalWorker.Configuration(
-            namespace: "default",
-            taskQueue: taskQueue,
-            instrumentation: .init(serverHostname: "localhost")
-        )
-
-        try await testServer.withConnectedWorker(
-            configuration: config,
+        try await testServer.withWorkerAndClient(
             workflows: [DelayedGreetingWorkflow.self]
-        ) { _ in
-            try await testServer.withConnectedClient(
-                logger: logger
-            ) { client in
-                let start = ContinuousClock.now
-                let handle = try await client.startWorkflow(
-                    type: DelayedGreetingWorkflow.self,
-                    options: .init(
-                        id: "wf-\(UUID())",
-                        taskQueue: taskQueue
-                    ),
-                    input: "World"
-                )
-                let result = try await handle.result()
-                #expect(result == "Hello, World!")
+        ) { taskQueue, client in
+            let start = ContinuousClock.now
+            let handle = try await client.startWorkflow(
+                type: DelayedGreetingWorkflow.self,
+                options: .init(id: "wf-\(UUID())", taskQueue: taskQueue),
+                input: "World"
+            )
+            let result = try await handle.result()
+            #expect(result == "Hello, World!")
 
-                let elapsed = ContinuousClock.now - start
-                #expect(elapsed < .seconds(30))
-            }
+            let elapsed = ContinuousClock.now - start
+            #expect(elapsed < .seconds(30))
         }
     }
 }
 ```
 
-> Tip: `TemporalTestServer.withConnectedClient` installs the
-> time-skipping interceptor for you.
+> Tip: `TemporalTestServer.withWorkerAndClient` installs the time-skipping
+> interceptor for you when used with the time-skipping test server.
 
 ### Replay testing with WorkflowReplayer
 

--- a/Sources/TemporalTestKit/TemporalTestServer.swift
+++ b/Sources/TemporalTestKit/TemporalTestServer.swift
@@ -170,7 +170,7 @@ public struct TemporalTestServer: Sendable {
     ///   - body: An async closure that receives the test server instance and performs test operations.
     /// - Returns: The result value returned by the closure.
     /// - Throws: Any errors thrown by the closure or during server lifecycle management.
-    public static func withTestServer<Result: Sendable>(
+    public static func withTestServer<Result>(
         searchAttributes: [AnySearchAttributeKey] = [],
         extraArguments: [String] = [],
         _ body: (borrowing TemporalTestServer) async throws -> Result
@@ -464,6 +464,80 @@ public struct TemporalTestServer: Sendable {
         }
     }
 
+    // MARK: - Worker and Client Convenience
+
+    /// Starts a connected worker and client for integration testing, then executes your closure.
+    ///
+    /// This convenience combines `withConnectedWorker` and `withConnectedClient` into a single
+    /// call. It creates a worker configuration with a unique task queue, starts the worker,
+    /// connects a client, and passes both the task queue name and client to your closure.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// let testServer = TemporalTestServer.testServer!
+    /// try await testServer.withWorkerAndClient(
+    ///     activities: GreetingActivities().allActivities,
+    ///     workflows: [GreetingWorkflow.self]
+    /// ) { taskQueue, client in
+    ///     let handle = try await client.startWorkflow(
+    ///         type: GreetingWorkflow.self,
+    ///         options: .init(id: "wf-\(UUID())", taskQueue: taskQueue),
+    ///         input: "World"
+    ///     )
+    ///     let result = try await handle.result()
+    ///     #expect(result == "Hello, World!")
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - activities: Activity implementations to register on the worker.
+    ///   - workflows: Workflow types to register on the worker.
+    ///   - namespace: The Temporal namespace to use. Defaults to `"default"`.
+    ///   - workerInterceptors: Worker interceptors to apply.
+    ///   - clientInterceptors: Client interceptors to apply.
+    ///   - logger: Logger used by both the worker and client. Defaults to a stdout `Logger` at `.info`.
+    ///   - body: An async closure that receives the task queue name and a connected client.
+    /// - Returns: The value returned by `body`.
+    /// - Throws: Any error thrown while creating the worker, connecting the client, or by the `body` closure.
+    public func withWorkerAndClient<Result: Sendable>(
+        activities: [any ActivityDefinition] = [],
+        workflows: [any WorkflowDefinition.Type] = [],
+        namespace: String = "default",
+        workerInterceptors: [any WorkerInterceptor] = [],
+        clientInterceptors: [any Temporal.ClientInterceptor] = [],
+        logger: Logger = {
+            var logger = Logger(label: "TestWorker", factory: { StreamLogHandler.standardOutput(label: $0) })
+            logger.logLevel = .info
+            return logger
+        }(),
+        body: sending @escaping (String, TemporalClient) async throws -> Result
+    ) async throws -> sending Result {
+        let (host, _) = self.hostAndPort()
+        let taskQueue = UUID().uuidString
+
+        var config = TemporalWorker.Configuration(
+            namespace: namespace,
+            taskQueue: taskQueue,
+            instrumentation: .init(serverHostname: host)
+        )
+        config.interceptors = workerInterceptors
+
+        return try await self.withConnectedWorker(
+            configuration: config,
+            activities: activities,
+            workflows: workflows,
+            logger: logger
+        ) { _ in
+            try await self.withConnectedClient(
+                logger: logger,
+                interceptors: clientInterceptors
+            ) { client, _, _ in
+                try await body(taskQueue, client)
+            }
+        }
+    }
+
     // MARK: - Time Control
 
     /// Advances the test server time by the specified duration.
@@ -526,7 +600,7 @@ public struct TemporalTestServer: Sendable {
     ///
     /// This is used internally by ``TimeSkippingClientInterceptor`` to allow time to
     /// advance while waiting for workflow results.
-    func withTimeSkippingUnlocked<Result: Sendable>(
+    func withTimeSkippingUnlocked<Result>(
         _ body: () async throws -> Result
     ) async throws -> Result {
         guard let testServiceClient else {

--- a/Tests/TemporalTests/Worker/WithWorkerAndClientTests.swift
+++ b/Tests/TemporalTests/Worker/WithWorkerAndClientTests.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Temporal
+import TemporalTestKit
+import Testing
+
+extension TestServerDependentTests {
+    @Suite
+    struct WithWorkerAndClientTests {
+        @ActivityContainer
+        struct TestActivities {
+            @Activity
+            func greet(input: String) -> String {
+                "Hello, \(input)!"
+            }
+        }
+
+        @Workflow
+        struct TestWorkflow {
+            mutating func run(
+                context: WorkflowContext<Self>,
+                input: String
+            ) async throws -> String {
+                try await context.executeActivity(
+                    TestActivities.Activities.Greet.self,
+                    options: ActivityOptions(startToCloseTimeout: .seconds(30)),
+                    input: input
+                )
+            }
+        }
+
+        @Test
+        func workflowExecutesThroughHelper() async throws {
+            let testServer = TemporalTestServer.testServer!
+
+            let result = try await testServer.withWorkerAndClient(
+                activities: TestActivities().allActivities,
+                workflows: [TestWorkflow.self]
+            ) { taskQueue, client in
+                try await client.executeWorkflow(
+                    type: TestWorkflow.self,
+                    options: .init(id: "wf-\(UUID())", taskQueue: taskQueue),
+                    input: "World"
+                )
+            }
+            #expect(result == "Hello, World!")
+        }
+    }
+}


### PR DESCRIPTION
Closes #143.

### Motivation

Integration tests require nesting `withConnectedWorker` and `withConnectedClient` plus creating a `TemporalWorker.Configuration` by hand every time.

### Modifications

- Add `withWorkerAndClient` on `TemporalTestServer` that creates a worker config with a unique task queue, starts the worker, connects a client, and passes `(taskQueue, client)` to the closure.
- Update the testing documentation to use the new helper, simplifying the integration and time-skipping examples.

### Result

The common integration test setup is a single call. Testing docs are 34 lines shorter as a result.

### Test Plan

Added a test covering workflow execution through the helper. Updated the testing docs and verified the new examples are correct.
