### PR TITLE
Public inits for Worker interceptor input types

### DIFF
--- a/Sources/Temporal/Worker/Interceptors/Inputs/CancelExternalWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/CancelExternalWorkflowInput.swift
@@ -24,4 +24,16 @@ public struct CancelExternalWorkflowInput: Sendable {
     ///
     /// If `nil`, targets the latest run.
     public var runId: String?
+
+    /// Creates a new cancel external workflow input.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the current workflow execution.
+    ///   - id: The workflow ID of the external workflow to cancel.
+    ///   - runId: The run ID of the external workflow. If `nil`, targets the latest run.
+    public init(info: WorkflowInfo, id: String, runId: String? = nil) {
+        self.info = info
+        self.id = id
+        self.runId = runId
+    }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteActivityInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteActivityInput.swift
@@ -23,13 +23,13 @@ public struct ExecuteActivityInput<Activity: ActivityDefinition>: Sendable {
     /// The input parameters to be passed to the activity for execution.
     public var input: Activity.Input
 
-    /// Creates activity execution input with the specified definition, headers, and parameters.
+    /// Creates a new execute activity input.
     ///
     /// - Parameters:
     ///   - definition: The activity definition containing type and execution information.
     ///   - headers: The headers containing metadata and context for execution.
     ///   - input: The input parameters for activity execution.
-    package init(definition: Activity, headers: [String: Api.Common.V1.Payload], input: Activity.Input) {
+    public init(definition: Activity, headers: [String: Api.Common.V1.Payload], input: Activity.Input) {
         self.definition = definition
         self.headers = headers
         self.input = input

--- a/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteLocalActivityInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteLocalActivityInput.swift
@@ -29,25 +29,25 @@ public struct ScheduleLocalActivityInput<each Input: Sendable>: Sendable {
     /// The input parameters to be passed to the activity for execution.
     public var input: (repeat each Input)
 
-    /// Creates a new activity scheduling input with the specified parameters.
+    /// Creates a new schedule local activity input.
     ///
     /// - Parameters:
     ///   - info: Information about the current workflow execution.
     ///   - name: The activity name identifying the activity type to execute.
     ///   - options: The configuration options controlling activity execution behavior.
     ///   - headers: The metadata and context headers for activity execution.
-    ///   - input: The input parameters to pass to the activity, of varying types and counts.
-    package init(
+    ///   - input: The input parameters to pass to the activity.
+    public init(
         info: WorkflowInfo,
         name: String,
         options: LocalActivityOptions,
         headers: [String: Api.Common.V1.Payload],
-        input: (repeat each Input)
+        input: repeat each Input
     ) {
         self.info = info
         self.name = name
         self.options = options
         self.headers = headers
-        self.input = input
+        self.input = (repeat each input)
     }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/ExecuteWorkflowInput.swift
@@ -23,13 +23,13 @@ public struct ExecuteWorkflowInput<Workflow: WorkflowDefinition>: Sendable {
     /// The input parameters to be passed to the workflow for execution.
     public var input: Workflow.Input
 
-    /// Creates workflow execution input with the specified information, headers, and parameters.
+    /// Creates a new execute workflow input.
     ///
     /// - Parameters:
     ///   - info: Information about the current workflow execution.
     ///   - headers: The headers containing metadata and context for execution.
     ///   - input: The input parameters for workflow execution.
-    package init(info: WorkflowInfo, headers: [String: Api.Common.V1.Payload], input: Workflow.Input) {
+    public init(info: WorkflowInfo, headers: [String: Api.Common.V1.Payload], input: Workflow.Input) {
         self.info = info
         self.headers = headers
         self.input = input

--- a/Sources/Temporal/Worker/Interceptors/Inputs/HandleQueryInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/HandleQueryInput.swift
@@ -35,4 +35,29 @@ public struct HandleQueryInput<Query: WorkflowQueryDefinition>: Sendable {
 
     /// The input parameters to be passed to the query handler for execution.
     public var input: Query.Input
+
+    /// Creates a new handle query input.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the current workflow execution.
+    ///   - id: The unique identifier for this specific query request.
+    ///   - name: The name identifying the type of query being executed.
+    ///   - definition: The query definition containing type information and execution metadata.
+    ///   - headers: Headers containing metadata and context information for query execution.
+    ///   - input: The input parameters to be passed to the query handler for execution.
+    public init(
+        info: WorkflowInfo,
+        id: String,
+        name: String,
+        definition: Query,
+        headers: [String: Api.Common.V1.Payload],
+        input: Query.Input
+    ) {
+        self.info = info
+        self.id = id
+        self.name = name
+        self.definition = definition
+        self.headers = headers
+        self.input = input
+    }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/HandleSignalInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/HandleSignalInput.swift
@@ -28,4 +28,26 @@ public struct HandleSignalInput<Signal: WorkflowSignalDefinition>: Sendable {
 
     /// The input parameters to be passed to the signal handler for execution.
     public var input: Signal.Input
+
+    /// Creates a new handle signal input.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the current workflow execution.
+    ///   - name: The name identifying the type of signal being processed.
+    ///   - definition: The signal definition containing type information and execution metadata.
+    ///   - headers: Headers containing metadata and context information for signal execution.
+    ///   - input: The input parameters to be passed to the signal handler for execution.
+    public init(
+        info: WorkflowInfo,
+        name: String,
+        definition: Signal,
+        headers: [String: Api.Common.V1.Payload],
+        input: Signal.Input
+    ) {
+        self.info = info
+        self.name = name
+        self.definition = definition
+        self.headers = headers
+        self.input = input
+    }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/HandleSleepInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/HandleSleepInput.swift
@@ -26,4 +26,16 @@ public struct HandleSleepInput: Sendable {
     ///
     /// - Important: This is currently experimental.
     public var summary: String?
+
+    /// Creates a new handle sleep input.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the current workflow execution.
+    ///   - duration: The duration of the sleep operation.
+    ///   - summary: Optional identifier for the sleep operation.
+    public init(info: WorkflowInfo, duration: Duration, summary: String? = nil) {
+        self.info = info
+        self.duration = duration
+        self.summary = summary
+    }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/HandleUpdateInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/HandleUpdateInput.swift
@@ -31,4 +31,29 @@ public struct HandleUpdateInput<Update: WorkflowUpdateDefinition>: Sendable {
 
     /// The input parameters to be passed to the update handler for execution.
     public var input: Update.Input
+
+    /// Creates a new handle update input.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the current workflow execution.
+    ///   - id: The unique identifier for this specific update request.
+    ///   - name: The name identifying the type of update being executed.
+    ///   - definition: The update definition containing type information and execution metadata.
+    ///   - headers: Headers containing metadata and context information for update execution.
+    ///   - input: The input parameters to be passed to the update handler for execution.
+    public init(
+        info: WorkflowInfo,
+        id: String,
+        name: String,
+        definition: Update,
+        headers: [String: Api.Common.V1.Payload],
+        input: Update.Input
+    ) {
+        self.info = info
+        self.id = id
+        self.name = name
+        self.definition = definition
+        self.headers = headers
+        self.input = input
+    }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/MakeContinueAsNewErrorInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/MakeContinueAsNewErrorInput.swift
@@ -28,4 +28,26 @@ public struct MakeContinueAsNewErrorInput<each Input: Sendable>: Sendable {
 
     /// The input parameters to be passed to the restarted workflow for execution.
     public var input: (repeat each Input)
+
+    /// Creates a new make continue-as-new error input.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the current workflow execution.
+    ///   - workflowName: The workflow name to continue as.
+    ///   - options: The configuration options for the continue-as-new workflow execution.
+    ///   - headers: Headers containing metadata and context information for continue-as-new execution.
+    ///   - input: The input parameters to be passed to the restarted workflow for execution.
+    public init(
+        info: WorkflowInfo,
+        workflowName: String,
+        options: ContinueAsNewOptions,
+        headers: [String: Api.Common.V1.Payload],
+        input: repeat each Input
+    ) {
+        self.info = info
+        self.workflowName = workflowName
+        self.options = options
+        self.headers = headers
+        self.input = (repeat each input)
+    }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/ScheduleActivityInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/ScheduleActivityInput.swift
@@ -29,25 +29,25 @@ public struct ScheduleActivityInput<each Input: Sendable>: Sendable {
     /// The input parameters to be passed to the activity for execution.
     public var input: (repeat each Input)
 
-    /// Creates a new activity scheduling input with the specified parameters.
+    /// Creates a new schedule activity input.
     ///
     /// - Parameters:
     ///   - info: Information about the current workflow execution.
     ///   - name: The activity name identifying the activity type to execute.
     ///   - options: The configuration options controlling activity execution behavior.
     ///   - headers: The metadata and context headers for activity execution.
-    ///   - input: The input parameters to pass to the activity, of varying types and counts.
-    package init(
+    ///   - input: The input parameters to pass to the activity.
+    public init(
         info: WorkflowInfo,
         name: String,
         options: ActivityOptions,
         headers: [String: Api.Common.V1.Payload],
-        input: (repeat each Input)
+        input: repeat each Input
     ) {
         self.info = info
         self.name = name
         self.options = options
         self.headers = headers
-        self.input = input
+        self.input = (repeat each input)
     }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/SignalChildWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/SignalChildWorkflowInput.swift
@@ -25,4 +25,23 @@ public struct SignalChildWorkflowInput<each Input: Sendable>: Sendable {
 
     /// The input parameters to be passed to the child workflow signal handler for processing.
     public var input: (repeat each Input)
+
+    /// Creates a new signal child workflow input.
+    ///
+    /// - Parameters:
+    ///   - id: The unique identifier of the child workflow to signal.
+    ///   - name: The name identifying the type of signal being sent to the child workflow.
+    ///   - headers: Headers containing metadata and context information for child workflow signal execution.
+    ///   - input: The input parameters to be passed to the child workflow signal handler for processing.
+    public init(
+        id: String,
+        name: String,
+        headers: [String: Api.Common.V1.Payload],
+        input: repeat each Input
+    ) {
+        self.id = id
+        self.name = name
+        self.headers = headers
+        self.input = (repeat each input)
+    }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/SignalExternalWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/SignalExternalWorkflowInput.swift
@@ -33,4 +33,29 @@ public struct SignalExternalWorkflowInput<each Input: Sendable>: Sendable {
 
     /// The input parameters to be passed to the external workflow signal handler for processing.
     public var input: (repeat each Input)
+
+    /// Creates a new signal external workflow input.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the current workflow execution.
+    ///   - id: The workflow ID of the external workflow to signal.
+    ///   - runId: The run ID of the external workflow. If `nil`, targets the latest run.
+    ///   - name: The name identifying the type of signal being sent to the external workflow.
+    ///   - headers: Headers containing metadata and context information for external workflow signal execution.
+    ///   - input: The input parameters to be passed to the external workflow signal handler for processing.
+    public init(
+        info: WorkflowInfo,
+        id: String,
+        runId: String? = nil,
+        name: String,
+        headers: [String: Api.Common.V1.Payload],
+        input: repeat each Input
+    ) {
+        self.info = info
+        self.id = id
+        self.runId = runId
+        self.name = name
+        self.headers = headers
+        self.input = (repeat each input)
+    }
 }

--- a/Sources/Temporal/Worker/Interceptors/Inputs/StartChildWorkflowInput.swift
+++ b/Sources/Temporal/Worker/Interceptors/Inputs/StartChildWorkflowInput.swift
@@ -28,4 +28,26 @@ public struct StartChildWorkflowInput<each Input: Sendable>: Sendable {
 
     /// The input parameters to be passed to the child workflow for execution.
     public var input: (repeat each Input)
+
+    /// Creates a new start child workflow input.
+    ///
+    /// - Parameters:
+    ///   - info: Information about the current workflow execution.
+    ///   - name: The name identifying the type of child workflow to be started.
+    ///   - options: The configuration options controlling how the child workflow should be executed.
+    ///   - headers: Headers containing metadata and context information for child workflow startup and execution.
+    ///   - input: The input parameters to be passed to the child workflow for execution.
+    public init(
+        info: WorkflowInfo,
+        name: String,
+        options: ChildWorkflowOptions,
+        headers: [String: Api.Common.V1.Payload],
+        input: repeat each Input
+    ) {
+        self.info = info
+        self.name = name
+        self.options = options
+        self.headers = headers
+        self.input = (repeat each input)
+    }
 }

--- a/Sources/Temporal/Worker/Workflow/InternalWorkflowContext.swift
+++ b/Sources/Temporal/Worker/Workflow/InternalWorkflowContext.swift
@@ -234,7 +234,7 @@ struct InternalWorkflowContext: Sendable {
                 name: name,
                 options: options,
                 headers: [:],
-                input: (repeat each input)
+                input: repeat each input
             )
         )
     }
@@ -253,7 +253,7 @@ struct InternalWorkflowContext: Sendable {
                 name: name,
                 options: options,
                 headers: [:],
-                input: (repeat each input)
+                input: repeat each input
             )
         )
     }
@@ -284,7 +284,7 @@ struct InternalWorkflowContext: Sendable {
                 name: name,
                 options: options,
                 headers: [:],
-                input: (repeat each inputs)
+                input: repeat each inputs
             )
         )
     }
@@ -361,7 +361,7 @@ struct InternalWorkflowContext: Sendable {
                 workflowName: workflowName,
                 options: options,
                 headers: [:],
-                input: (repeat each input)
+                input: repeat each input
             )
         )
     }

--- a/Sources/Temporal/Worker/Workflow/UntypedChildWorkflowHandle.swift
+++ b/Sources/Temporal/Worker/Workflow/UntypedChildWorkflowHandle.swift
@@ -237,7 +237,7 @@ public struct UntypedChildWorkflowHandle: Sendable {
                 id: self.id,
                 name: signalName,
                 headers: [:],
-                input: (repeat each input)
+                input: repeat each input
             )
         )
     }

--- a/Sources/Temporal/Worker/Workflow/UntypedExternalWorkflowHandle.swift
+++ b/Sources/Temporal/Worker/Workflow/UntypedExternalWorkflowHandle.swift
@@ -103,7 +103,7 @@ public struct UntypedExternalWorkflowHandle: Sendable {
                 runId: self.runId,
                 name: signalName,
                 headers: [:],
-                input: (repeat each input)
+                input: repeat each input
             )
         )
     }


### PR DESCRIPTION
### Motivation

Some worker interceptor input types are missing a `public` initializer, they currently use `package` or default `internal` access. All Client interceptor input types already have proper `public` initializers.

### Modifications

Added `public` initializers (with documentation) for all worker interceptor input types.

### Result

All worker interceptor input types now have `public` initializers, consistent with their client counterparts.

### Test Plan

None, mirrors the existing client interceptor input types, which have no dedicated tests for the `init`s.