### PR TITLE
WorkflowState should not require `Value` to be Sendable

### DIFF
--- a/Sources/Temporal/Worker/Workflow/WorkflowState.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowState.swift
@@ -18,7 +18,8 @@
 /// the workflow's execution context. It enforces that state can only be accessed and
 /// modified on the workflow's dedicated executor, preventing race conditions and ensuring
 /// deterministic execution during workflow replay.
-public struct _WorkflowState<Value: Sendable>: @unchecked Sendable {
+// @unchecked Sendable is safe since we dynamically ensure that the state is only accessed on the workflow executor.
+public struct _WorkflowState<Value>: @unchecked Sendable {
     /// The reference-backed box holding the value.
     private let box: ArcBox<Value>
 
@@ -60,7 +61,7 @@ public struct _WorkflowState<Value: Sendable>: @unchecked Sendable {
     /// Creates a new workflow state wrapper with the specified initial value.
     ///
     /// - Parameter initialValue: The initial value to be wrapped and managed by the workflow state.
-    public init(initialValue: Value) {
+    public init(initialValue: sending Value) {
         self.box = ArcBox(initialValue)
     }
 }


### PR DESCRIPTION
### Motivation

Currently, the `@WorkflowState` is pretty restrictive as it requires its `Value` to be `Sendable`. This is not required, as the Workflow State ensures that all accesses happen from the Workflow executor. Even the docs explain that pretty well
```swift
/// A wrapper that makes workflow state `Sendable` by ensuring it is modified on the workflow's executor.
///
/// `_WorkflowState` ensures that all modifications to workflow state happen safely within
/// the workflow's execution context. [...]
```

### Modifications

* Drop the `Sendable` requirement
* Pass  the `value` as `sending` to the init. The init can run anywhere, therefore, we must require that the value is sent to the workflow executor isolation domain.

### Result

WorkflowState can now be used with non-sendable types as well.

### Test Plan

N/A
