### PR TITLE
Disable Swift 6.1 macOS CI run

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,10 +33,7 @@ jobs:
     with:
       runner_pool: general
       build_scheme: swift-temporal-sdk-Package
-      xcode_16_3_enabled: false
-      xcode_16_4_enabled: false
-      xcode_26_0_enabled: false
-      xcode_26_1_enabled: false
+      swift_6_1_enabled: false
       watchos_xcode_build_enabled: false
       tvos_xcode_build_enabled: false
       visionos_xcode_build_enabled: false


### PR DESCRIPTION
### Motivation

The `xcode_xx_x_enabled` options are deprecated and do no longer have any effect to disable pipelines for macOS.

### Modifications

* Use the `swift_6_1_enabled` option to disable Swift 6.1

### Result

Swift 6.1 pipeline doesn't run (and fail) anymore for macOS tests.

### Test Plan

N/A
