### PR TITLE
Accept zero payloads when decoding a `Void` input

### DIFF
--- a/Sources/Temporal/Converters/PayloadConverter.swift
+++ b/Sources/Temporal/Converters/PayloadConverter.swift
@@ -71,6 +71,12 @@ extension PayloadConverter {
         // swift-format-ignore: NoAssignmentInExpressions
         _ = (repeat (nil as (each Value)?, requestedCount += 1))
 
+        // Older Swift clients / workers incorrectly send `Void` input as a JSON payload in certain
+        // cases; like the other SDKs, ignore extra input payloads for a lone `Void`.
+        if requestedCount == 1, (repeat each Value).self == Void.self {
+            payloads = [.init()]
+        }
+
         guard requestedCount == payloads.count else {
             throw ArgumentError(
                 message: "Mismatched number of values and payloads"

--- a/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInstance.swift
@@ -228,15 +228,10 @@ struct WorkflowInstance: Sendable {
                 message: "Expected first job to be initialize workflow job"
             )
         }
-        let input: Workflow.Input
-        if Workflow.Input.self == Void.self {
-            input = () as! Workflow.Input
-        } else {
-            input = try self.payloadConverter.convertPayloads(
-                initializeWorkflow.arguments,
-                as: (Workflow.Input).self
-            )
-        }
+        let input = try self.payloadConverter.convertPayloads(
+            initializeWorkflow.arguments,
+            as: (Workflow.Input).self
+        )
 
         // Initially setting memo, search attributes and random seed.
         try Self.$isOnWorkflowInstance.withValue(true) {

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
@@ -361,5 +361,66 @@ extension TestServerDependentTests {
                 #expect(workflowResult == "untyped-hello")
             }
         }
+
+        @Workflow
+        struct VoidInputUpdateWorkflow {
+            var ready = false
+
+            mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+                try await context.condition { $0.ready }
+                return "done"
+            }
+
+            @WorkflowUpdate
+            mutating func markReady(input: Void) async -> String {
+                self.ready = true
+                return "marked"
+            }
+        }
+
+        @Test
+        func updateWithStartVoidInput() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [VoidInputUpdateWorkflow.self]
+            ) { taskQueue, client in
+                let workflowID = "wf-\(UUID().uuidString)"
+                let options = WorkflowOptions(id: workflowID, taskQueue: taskQueue)
+
+                let updateResult = try await client.executeUpdateWithStartWorkflow(
+                    type: VoidInputUpdateWorkflow.self,
+                    input: "initial",
+                    options: options,
+                    updateType: VoidInputUpdateWorkflow.MarkReady.self
+                )
+                #expect(updateResult == "marked")
+
+                let workflowHandle = client.workflowHandle(
+                    type: VoidInputUpdateWorkflow.self,
+                    id: workflowID
+                )
+                let workflowResult = try await workflowHandle.result()
+                #expect(workflowResult == "done")
+            }
+        }
+
+        @Test
+        func updateWithStartVoidInputZeroPayloads() async throws {
+            try await withTestWorkerAndClient(
+                workflows: [VoidInputUpdateWorkflow.self]
+            ) { taskQueue, client in
+                let workflowID = "wf-\(UUID().uuidString)"
+                let options = WorkflowOptions(id: workflowID, taskQueue: taskQueue)
+
+                let updateHandle = try await client.startUpdateWithStartWorkflow(
+                    name: VoidInputUpdateWorkflow.name,
+                    input: "initial",
+                    options: options,
+                    updateName: VoidInputUpdateWorkflow.MarkReady.name,
+                    waitForStage: .completed
+                )
+                let updateResult: String = try await updateHandle.result(resultTypes: String.self)
+                #expect(updateResult == "marked")
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
The Swift SDK encodes a `Void` input as a single empty payload, whereas the other SDKs send zero payloads for no input. In one place, `UpdateWithStart`, the Swift SDK does the right thing and sends zero payloads. But on decode the worker rejects zero payloads for `Void.self`: `convertPayloads(as: Void.self)` requires exactly one. So a `Void` update sent via `UpdateWithStart` is rejected before acceptance, and the client sees `notFound` even though the workflow runs fine.

Making the encode consistently send zero payloads would break older workers that still expect the payload, so it is left as a separate change.

### Modifications
In `PayloadConverter.convertPayloads`, treat a single `Void` as carrying no payload and ignore the input payload count, matching the other SDKs, which ignore extra input payloads.

### Result
A `Void` update, signal, or query sent with zero payloads is accepted instead of dropped. The encode is unchanged, so it is safe to roll out in any client / worker order.

### Other Issues (will file separately)
- When the input cannot be decoded, the worker rejects the update and the client surfaces `notFound`, which does not match the other SDKs / APIs that return the conversion failure; the real error is lost.
- The `UpdateWithStart` client does not use the update outcome returned in the first `ExecuteMultiOperation` response; it discards it and makes an extra `PollWorkflowExecutionUpdate` call. The other SDKs reuse the first response.
- Encode `Void` as zero payloads, matching the other SDKs, instead of a single empty payload. This is a breaking wire change because older workers require the payload, so it needs its own change and a version bump.

### Test Plan
`updateWithStartVoidInput` and `updateWithStartVoidInputZeroPayloads` in `WorkflowUpdateTests.swift`; `swift test` passes.
