### PR TITLE
Rename xcframework internal library to libTemporalBridge.a

### DIFF
--- a/.github/workflows/build-temporal-core-artifacts.yml
+++ b/.github/workflows/build-temporal-core-artifacts.yml
@@ -318,10 +318,10 @@ jobs:
           mkdir -p temp_catalyst/Headers
 
           # Copy libraries and headers to each platform directory
-          cp "libtemporal_fat.a" "temp_macos/libTemporal.a"
-          cp "libtemporal_ios.a" "temp_ios/libTemporal.a"
-          cp "libtemporal_ios_sim.a" "temp_ios_sim/libTemporal.a"
-          cp "libtemporal_catalyst.a" "temp_catalyst/libTemporal.a"
+          cp "libtemporal_fat.a" "temp_macos/libTemporalBridge.a"
+          cp "libtemporal_ios.a" "temp_ios/libTemporalBridge.a"
+          cp "libtemporal_ios_sim.a" "temp_ios_sim/libTemporalBridge.a"
+          cp "libtemporal_catalyst.a" "temp_catalyst/libTemporalBridge.a"
 
           # Copy headers to all platform directories
           for dir in temp_*/Headers; do
@@ -337,10 +337,10 @@ jobs:
 
           # Create XCFramework using xcodebuild
           xcodebuild -create-xcframework \
-              -library "temp_macos/libTemporal.a" -headers "temp_macos/Headers" \
-              -library "temp_ios/libTemporal.a" -headers "temp_ios/Headers" \
-              -library "temp_ios_sim/libTemporal.a" -headers "temp_ios_sim/Headers" \
-              -library "temp_catalyst/libTemporal.a" -headers "temp_catalyst/Headers" \
+              -library "temp_macos/libTemporalBridge.a" -headers "temp_macos/Headers" \
+              -library "temp_ios/libTemporalBridge.a" -headers "temp_ios/Headers" \
+              -library "temp_ios_sim/libTemporalBridge.a" -headers "temp_ios_sim/Headers" \
+              -library "temp_catalyst/libTemporalBridge.a" -headers "temp_catalyst/Headers" \
               -output "${{ env.XCFRAMEWORK_NAME }}"
 
           # Clean up temporary files


### PR DESCRIPTION
## Motivation

This PR is the first of two changes to unblock `macOS tests / Xcode latest beta`, which has been failing on PRs with:

```
error: Multiple commands produce '/…/Debug/libTemporal.a'
warning: duplicate output file '…libTemporal.a' on task: Libtool …
error: Build failed
```

The two conflicting tasks write to the same output path:

1. `ProcessXCFramework` extracts the xcframework's `libTemporal.a` slice into `Debug/libTemporal.a`.
2. `Libtool` builds the Swift `Temporal` target's own archive, also called `libTemporal.a`, into the same `Debug/` directory.

Xcode 26's build system tolerated the duplicate silently; Xcode 27's swift-build flags it as a build-graph collision.

## Modifications

Renames the xcframework's internal library from `libTemporal.a` to `libTemporalBridge.a`, matching the `Bridge` module name declared in the xcframework's `module.modulemap`.

The Linux artifact bundle names (`libTemporal-<platform>-<arch>.a`) are untouched. Those already carry per-platform suffixes and don't collide.

## Result

After rerunning `build-temporal-core-artifacts.yml` and publishing a new release, the `Multiple commands produce` error should go away. A follow-up PR will bump the xcframework `url:` and `checksum:` in `Package.swift` to point at the new release.

## Test Plan

Reproduced locally with `swift build` on a Swift toolchain that uses swift-build as its default backend (Swift 6.2+ with `--build-system swiftbuild`, or a nightly-main snapshot where swift-build is the default). After the rename, the collision is gone and only expected downstream errors remain. The Linux and macOS 6.2 / 6.3 CI lanes don't reference the xcframework's internal name, so they continue to pass.

> [!NOTE]
> This PR only changes how future xcframework releases are built. To fix CI, once this PR is merged:
> - [x] ~~Trigger `build-temporal-core-artifacts.yml` via `workflow_dispatch` to cut a new release (@FranzBusch)~~
> - [ ] Repackage [db65dd9](https://github.com/apple/swift-temporal-sdk/releases/tag/temporal-sdk-core-db65dd9)'s existing binary as `libTemporalBridge.a` via `create-xcframework`, no rebuild, and cut a release from it (@FranzBusch)
> - [ ] Follow-up PR bumping `Package.swift`'s `url:` and `checksum:` to point at that release (@RalucaP)
