### PR TITLE
Update Core SDK binaries to c57f825

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,13 +58,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Bridge",
-            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-db65dd9/temporal.artifactbundle.zip",
-            checksum: "f306b8196694d73eb16c0f9bd22d7f84fe26ed590bef2a266002d0ba51bfee9d"
+            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-c57f825-2/temporal.artifactbundle.zip",
+            checksum: "4387fefa11a4178448b5d4673bf00325b7a3f8c1adfdc88081b81cc96f66e161"
         ),
         .binaryTarget(
             name: "BridgeDarwin",
-            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-db65dd9/temporal.xcframework.zip",
-            checksum: "45a2e8fa61ee97bb6f4c5b0a2cb6a14f8a5cd0a3e0e0e8bf0d7b5554c01b158e"
+            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-c57f825-2/temporal.xcframework.zip",
+            checksum: "f252cc7510ff25cef03609bed55116d3976ffa3250c0df5460c36f442cb5a98c"
         ),
         .target(
             name: "Temporal",


### PR DESCRIPTION
### Motivation

Bumps `Package.swift` to [`temporal-sdk-core-c57f825-2`](https://github.com/apple/swift-temporal-sdk/releases/tag/temporal-sdk-core-c57f825-2), which clears the two macOS failures on this PR:

- `Xcode latest beta` hit `Multiple commands produce libTemporal.a`. #155 renamed the xcframework's internal library to `libTemporalBridge.a`; this release is built with that rename, so the collision is gone. (This is the unblock the PR was opened for.)
- The worker's first `get_system_info` call then failed with "missing grpc-status trailer": rebuilding `db65dd9` drifts onto tonic 0.14.6, which rejects a trailerless HTTP-200. c57f825 ([temporalio/sdk-core#1257](https://github.com/temporalio/sdk-core/pull/1257)) emits the trailer.

### Modifications

Point both binary targets at the release: `Bridge` (artifactbundle) and `BridgeDarwin` (xcframework), updating `url` and `checksum` on each. Bumped together so Linux and Darwin build against the same core.

### Test Plan

- [x] CI green (the Xcode-beta collision + the macOS worker lanes).
