### PR TITLE
Fix use-after-free in Array<String>.withByteArrayRefArray

### DIFF
--- a/Sources/Temporal/Bridge/Helpers/ByteArrayRefArray+Helpers.swift
+++ b/Sources/Temporal/Bridge/Helpers/ByteArrayRefArray+Helpers.swift
@@ -17,32 +17,32 @@ import Bridge
 extension Array where Element == String {
     func withByteArrayRefArray<Return, Failure: Error>(
         body: (TemporalCoreByteArrayRefArray) throws(Failure) -> Return
-    ) rethrows -> Return {
-        // Swift-managed [UInt8] buffer
-        let buffers: [[UInt8]] = self.map { [UInt8]($0.utf8) }
+    ) throws(Failure) -> Return {
+        var refs: [TemporalCoreByteArrayRef] = []
+        refs.reserveCapacity(count)
 
-        // Build the ByteArrayRef array
-        let refs: [TemporalCoreByteArrayRef] = .init(unsafeUninitializedCapacity: buffers.count) { refBuffer, initializedCount in
-            for i in 0..<buffers.count {
-                // Capture pointer and length of each [UInt8]
-                buffers[i].withUnsafeBufferPointer { bp in
-                    refBuffer[i] = TemporalCoreByteArrayRef(data: bp.baseAddress!, size: bp.count)
+        // Recurse pinning each string to `refs`, then hand it to `body`
+        func iterate(iterator: inout Iterator) throws(Failure) -> Return {
+            // All strings are pinned, call `body` with the assembled `refs`
+            guard let buffer = iterator.next() else {
+                return try refs.withUnsafeBufferPointer { refsBuffer throws(Failure) in
+                    let refArray = TemporalCoreByteArrayRefArray(
+                        data: refsBuffer.baseAddress,
+                        size: refsBuffer.count
+                    )
+                    return try body(refArray)
                 }
-                initializedCount += 1
+            }
+
+            // Pin the string and recurse into the next one
+            return try buffer.withByteArrayRef { ref throws(Failure) in
+                refs.append(ref)
+                return try iterate(iterator: &iterator)
             }
         }
 
-        // Keep `buffers` alive for the duration of body, `refs` holds raw pointers into it.
-        return try withExtendedLifetime(buffers) {
-            // Memory valid for duration of body
-            try refs.withUnsafeBufferPointer { refBP throws(Failure) in
-                let refArray = TemporalCoreByteArrayRefArray(
-                    data: refBP.baseAddress!,
-                    size: refBP.count
-                )
-                return try body(refArray)
-            }
-        }
+        var iterator = makeIterator()
+        return try iterate(iterator: &iterator)
     }
 }
 

--- a/Sources/Temporal/Bridge/Helpers/ByteArrayRefArray+Helpers.swift
+++ b/Sources/Temporal/Bridge/Helpers/ByteArrayRefArray+Helpers.swift
@@ -32,13 +32,16 @@ extension Array where Element == String {
             }
         }
 
-        // Memory valid for duration of body
-        return try refs.withUnsafeBufferPointer { refBP throws(Failure) in
-            let refArray = TemporalCoreByteArrayRefArray(
-                data: refBP.baseAddress!,
-                size: refBP.count
-            )
-            return try body(refArray)
+        // Keep `buffers` alive for the duration of body, `refs` holds raw pointers into it.
+        return try withExtendedLifetime(buffers) {
+            // Memory valid for duration of body
+            try refs.withUnsafeBufferPointer { refBP throws(Failure) in
+                let refArray = TemporalCoreByteArrayRefArray(
+                    data: refBP.baseAddress!,
+                    size: refBP.count
+                )
+                return try body(refArray)
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation

`Array<String>.withByteArrayRefArray` builds a Swift-managed `[[UInt8]]` (`buffers`), then builds `refs: [TemporalCoreByteArrayRef]` using raw pointers that point directly into the elements of `buffers`. Once `refs` is built, nothing references `buffers` anymore, so ARC is free to deallocate it before `body` gets a chance to read through those pointers on the other side of the Rust interface.

This causes a repeatable production crash on Linux when the Rust SDK validates the gRPC header tokens. It's logged as "Invalid header name '/12': invalid HTTP header name".

The issue can more easily be observed on release configuration on Linux, since `glibc`’s `tcache` writes a "next" pointer directly into the first bytes of a chunk as soon as it's freed, so for small buffers like these it stomps the data right away. macOS's `libmalloc` doesn't scribble freed memory by default, so the same use-after-free can just read back the old bytes.

### Modifications

The function `Array<String>.withByteArrayRefArray` was rewritten to pin each string's bytes via `String.withByteArrayRef` and recurse one string at a time. Every pointer is only read while its owning closure is still on the stack, all the way through to the call to `body`.

### Result

`refs` no longer points into memory that ARC can free out from under it. The fix guarantees the lifetime of the strings by construction.

### Test Plan

The issue can be reproduced on Linux by running the SDK examples on release configuration. The program will crash.

On macOS, the issue can be reproduced by running one of the SDK examples on release configuration and with address sanitiser on.

```
> swift run --sanitize=address --configuration=release --package-path Examples GreetingExample

==32931==ERROR: AddressSanitizer: heap-use-after-free on address 0x606000028480 at pc 0x00010dce7f40 bp 0x00016ceadbf0 sp 0x00016cead390
READ of size 12 at 0x606000028480 thread T-1
    <empty stack>

0x606000028480 is located 32 bytes inside of 61-byte region [0x606000028460,0x60600002849d)
AddressSanitizer: CHECK failed: asan_descriptions.cpp:176 "((id)) != (0)" (0x0, 0x0) (tid=329496)
    <empty stack>

zsh: abort      swift run --sanitize=address --configuration=release --package-path Examples
```

To test the fix, re-run the examples with this branch checked out and verify that the program executes correctly.