### PR TITLE
Build Core SDK artifacts with Rust 1.94

### DIFF
--- a/.github/workflows/build-temporal-core-artifacts.yml
+++ b/.github/workflows/build-temporal-core-artifacts.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  RUST_VERSION: "1.88"
+  RUST_VERSION: "1.94"
   ARTIFACT_BUNDLE_NAME: "temporal.artifactbundle"
   XCFRAMEWORK_NAME: "temporal.xcframework"
   HEADER_SOURCE: "dependencies/sdk-core/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h"


### PR DESCRIPTION
### Motivation

The `build-temporal-core-artifacts.yml` run against #161's core [fails](https://github.com/apple/swift-temporal-sdk/actions/runs/29413263280) on the macOS and both musl Linux jobs:

```
error[E0463]: can't find crate for `core`
```

As of [c57f825](https://github.com/temporalio/sdk-core/blob/c57f825ff4a312d084773498fceeca9eef853607), sdk-core pins its toolchain to 1.94 via [`rust-toolchain.toml`](https://github.com/temporalio/sdk-core/blob/c57f825ff4a312d084773498fceeca9eef853607/rust-toolchain.toml#L2). The workflow installs 1.88 and adds the build targets to it, but builds under the pin (1.94), which has no `std` for those targets.

### Modifications

Set `RUST_VERSION` to `1.94` so the target adds and the build share a toolchain.

### Result

Rerunning the workflow builds the macOS and musl jobs cleanly and publishes a release from c57f825, which #159 can then consume.

### Test plan

- [x] Built the c57f825 core with 1.94 for `x86_64-apple-darwin` (the failing slice) and `aarch64-apple-darwin`, and ran a worker connect + workflow test on the arm64 build end-to-end which passes.
- [ ] musl/iOS slices and the full matrix: the workflow rerun and #159's CI.
