### PR TITLE
Drop iOS deployment targets from the macOS core builds

### DIFF
--- a/.github/workflows/build-temporal-core-artifacts.yml
+++ b/.github/workflows/build-temporal-core-artifacts.yml
@@ -157,9 +157,6 @@ jobs:
           . "$HOME/.cargo/env"
           cd ${{ env.RUST_WORKSPACE_DIR }}
           MACOSX_DEPLOYMENT_TARGET="15" \
-          IPHONEOS_DEPLOYMENT_TARGET="18" \
-          TVOS_DEPLOYMENT_TARGET="18" \
-          WATCHOS_DEPLOYMENT_TARGET="11" \
           cargo rustc \
             --manifest-path crates/sdk-core-c-bridge/Cargo.toml \
             --release \
@@ -173,9 +170,6 @@ jobs:
           . "$HOME/.cargo/env"
           cd ${{ env.RUST_WORKSPACE_DIR }}
           MACOSX_DEPLOYMENT_TARGET="15" \
-          IPHONEOS_DEPLOYMENT_TARGET="18" \
-          TVOS_DEPLOYMENT_TARGET="18" \
-          WATCHOS_DEPLOYMENT_TARGET="11" \
           cargo rustc \
             --manifest-path crates/sdk-core-c-bridge/Cargo.toml \
             --release \


### PR DESCRIPTION
### Motivation

With #162's Rust 1.94 pin in place, the artifacts workflow clears the Linux and musl jobs but [fails](https://github.com/apple/swift-temporal-sdk/actions/runs/29493966592) on the **Build macOS arm64** step:

```
### COMPILER BUG DETECTED ###
ERROR: clang: warning: using sysroot for 'MacOSX' but targeting 'iPhone' [-Wincompatible-sysroot]
```

Every build step sets `IPHONEOS/TVOS/WATCHOS_DEPLOYMENT_TARGET`, including the macOS ones. On the arm64 runner the macOS arm64 build is native, so `aws-lc-sys 0.42.0`'s [compiler self-check](https://github.com/aws/aws-lc-rs/blob/741dbf573a64b6a1e1e6b7c1131a0f8153a28441/builder/cc_builder.rs#L871-L885) runs: it compiles and runs a small probe to detect a memcmp bug. With `IPHONEOS_DEPLOYMENT_TARGET` set, clang builds that probe for iPhone (hence `-Wincompatible-sysroot`: macOS sysroot, iPhone target), so it can't run on the macOS host and the check aborts. macOS x86_64 escapes it (cross-build, the probe never runs), so it only appeared once 1.94 let the build reach the arm64 step.

### Modifications

Drop `IPHONEOS/TVOS/WATCHOS_DEPLOYMENT_TARGET` from the two macOS build steps — a `*-apple-darwin` build only needs `MACOSX_DEPLOYMENT_TARGET`. The iOS and Catalyst steps keep `IPHONEOS_DEPLOYMENT_TARGET`, which they legitimately use.

### Result

The macOS arm64 slice builds and the macOS job runs to completion.

### Test plan

- [x] Built all seven targets locally with Rust 1.94: macOS, iOS (device and both simulators), and Catalyst. On the macOS arm64 build, I also ran a test where a worker connects and runs a workflow, and it passes.
- [ ] Confirmed on the workflow rerun.
