### PR TITLE
Bound test workflows with a default execution timeout

### DIFF
--- a/Tests/TemporalTests/TestHelpers/WorkerTestHelper.swift
+++ b/Tests/TemporalTests/TestHelpers/WorkerTestHelper.swift
@@ -219,7 +219,8 @@ func withTimeSkippingTestWorkerAndClient<Result: Sendable, Worker: TemporalWorke
 func executeWorkflow<Workflow: WorkflowDefinition>(
     _ workflowType: Workflow.Type = Workflow.self,
     input: sending Workflow.Input,
-    workflowExecutionTimeout: Duration? = nil,
+    // Bound execution so a stuck workflow fails fast; the suite time limit can't cancel it.
+    workflowExecutionTimeout: Duration? = .seconds(60),
     workflowRetryPolicy: RetryPolicy? = nil,
     activities: [any ActivityDefinition] = [],
     moreWorkflows: [any WorkflowDefinition.Type] = [],
@@ -269,7 +270,7 @@ func executeWorkflow<Workflow: WorkflowDefinition>(
 func workflowHandle<Workflow: WorkflowDefinition, R>(
     for workflowType: Workflow.Type = Workflow.self,
     input: Workflow.Input,
-    workflowExecutionTimeout: Duration? = nil,
+    workflowExecutionTimeout: Duration? = .seconds(60),
     workflowRetryPolicy: RetryPolicy? = nil,
     activities: [any ActivityDefinition] = [],
     moreWorkflows: [any WorkflowDefinition.Type] = [],

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowInfoTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowInfoTests.swift
@@ -36,6 +36,8 @@ extension TestServerDependentTests {
             let info = try await executeWorkflow(
                 InfoWorkflow.self,
                 input: (),
+                // Assert the unset default; opt out of the helper's safety timeout.
+                workflowExecutionTimeout: nil,
                 taskQueue: taskQueue,
                 id: id
             )


### PR DESCRIPTION
### Motivation

The `.serialized` `TestServerDependentTests` suite occasionally runs to the 6h CI limit on Linux ([example](https://github.com/apple/swift-temporal-sdk/actions/runs/29509675712/job/87659557755)) when a worker workflow never completes: `.timeLimit` can't cancel the non-cancellable `BridgeWorker` poll, and `.serialized` blocks every test behind it.

### Modifications

`executeWorkflow` and `workflowHandle` now default to a 60s `workflowExecutionTimeout`, so the server ends a stuck workflow and the test fails fast. `WorkflowInfoTests` opts out with `nil` to assert the unset default.

### Test Plan

Ran `TestServerDependentTests` locally, all pass.
