### PR TITLE
Use FoundationEssentials where available across the project

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,6 +51,31 @@ jobs:
       linux_6_0_enabled: false
       linux_6_1_enabled: false
 
+  construct-linkage-test-matrix:
+    name: Construct linkage test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      linkage-test-matrix: '${{ steps.generate-matrix.outputs.linkage-test-matrix }}'
+    steps:
+      - id: generate-matrix
+        run: echo "linkage-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-temporal-sdk
+          MATRIX_LINUX_COMMAND: ./scripts/run-linkage-test.sh
+          MATRIX_LINUX_5_10_ENABLED: false
+          MATRIX_LINUX_6_0_ENABLED: false
+          MATRIX_LINUX_6_1_ENABLED: false
+          MATRIX_LINUX_NIGHTLY_NEXT_ENABLED: false
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+
+  linkage-test:
+    name: Linkage test
+    needs: construct-linkage-test-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "Linkage test"
+      matrix_string: '${{ needs.construct-linkage-test-matrix.outputs.linkage-test-matrix }}'
+
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/Examples/AsyncActivities/AsyncActivitiesExample.swift
+++ b/Examples/AsyncActivities/AsyncActivitiesExample.swift
@@ -13,10 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 #if GRPCNIOTransport
-import Foundation
 import GRPCNIOTransportHTTP2Posix
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Examples/AsyncActivities/FilmPermitActivities.swift
+++ b/Examples/AsyncActivities/FilmPermitActivities.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Examples/AsyncActivities/FilmPermitWorkflow.swift
+++ b/Examples/AsyncActivities/FilmPermitWorkflow.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Workflow for processing NYC film permits with parallel and sequential modes.
 @Workflow

--- a/Examples/ChildWorkflows/ChildWorkflowExample.swift
+++ b/Examples/ChildWorkflows/ChildWorkflowExample.swift
@@ -13,10 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 #if GRPCNIOTransport
-import Foundation
 import GRPCNIOTransportHTTP2Posix
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Child Workflows Example - Pizza Restaurant.
 ///

--- a/Examples/ChildWorkflows/PizzaActivities.swift
+++ b/Examples/ChildWorkflows/PizzaActivities.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Activities for pizza restaurant operations.
 @ActivityContainer

--- a/Examples/ChildWorkflows/PizzaOrderWorkflow.swift
+++ b/Examples/ChildWorkflows/PizzaOrderWorkflow.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Parent workflow that orchestrates pizza order fulfillment.
 ///

--- a/Examples/ErrorHandling/ErrorHandlingActivities.swift
+++ b/Examples/ErrorHandling/ErrorHandlingActivities.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Activities for the travel booking workflow demonstrating error handling patterns.
 ///

--- a/Examples/ErrorHandling/ErrorHandlingExample.swift
+++ b/Examples/ErrorHandling/ErrorHandlingExample.swift
@@ -13,10 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 #if GRPCNIOTransport
-import Foundation
 import GRPCNIOTransportHTTP2Posix
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Travel Booking Error Handling Example.
 ///

--- a/Examples/ErrorHandling/ErrorHandlingWorkflow.swift
+++ b/Examples/ErrorHandling/ErrorHandlingWorkflow.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Demonstrates error handling and compensation patterns in Temporal workflows.
 ///

--- a/Examples/Greeting/GreetingExample.swift
+++ b/Examples/Greeting/GreetingExample.swift
@@ -13,10 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 #if GRPCNIOTransport
-import Foundation
 import GRPCNIOTransportHTTP2Posix
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @main
 struct GreetingExample {

--- a/Examples/MultipleActivities/FakeDatabaseClient.swift
+++ b/Examples/MultipleActivities/FakeDatabaseClient.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // MARK: - Service Protocols
 

--- a/Examples/MultipleActivities/MultipleActivitiesActivities.swift
+++ b/Examples/MultipleActivities/MultipleActivitiesActivities.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Activities representing external service calls in an order fulfillment workflow.
 ///

--- a/Examples/MultipleActivities/MultipleActivitiesExample.swift
+++ b/Examples/MultipleActivities/MultipleActivitiesExample.swift
@@ -13,10 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 #if GRPCNIOTransport
-import Foundation
 import GRPCNIOTransportHTTP2Posix
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Order Fulfillment Example.
 ///

--- a/Examples/Schedule/Activities.swift
+++ b/Examples/Schedule/Activities.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Examples/Schedule/Models.swift
+++ b/Examples/Schedule/Models.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // MARK: - Operation Types
 

--- a/Examples/Schedule/ScheduleExample.swift
+++ b/Examples/Schedule/ScheduleExample.swift
@@ -13,10 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 #if GRPCNIOTransport
-import Foundation
 import GRPCNIOTransportHTTP2Posix
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Space Mission Schedule Example.
 ///

--- a/Examples/Schedule/Workflow.swift
+++ b/Examples/Schedule/Workflow.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Workflow
 struct SpaceMissionWorkflow {

--- a/Examples/Signals/SignalActivities.swift
+++ b/Examples/Signals/SignalActivities.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Activities for order processing workflow demonstrating external system interactions.
 @ActivityContainer

--- a/Examples/Signals/SignalExample.swift
+++ b/Examples/Signals/SignalExample.swift
@@ -13,10 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 #if GRPCNIOTransport
-import Foundation
 import GRPCNIOTransportHTTP2Posix
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Signal, Query, and Update Example.
 ///

--- a/Sources/Temporal/API/ProtoConversions/Namespace/NamespaceConfig+Proto.swift
+++ b/Sources/Temporal/API/ProtoConversions/Namespace/NamespaceConfig+Proto.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension NamespaceConfig {
     init(proto: Api.Namespace.V1.NamespaceConfig) {

--- a/Sources/Temporal/API/SearchAttributeKey.swift
+++ b/Sources/Temporal/API/SearchAttributeKey.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 
 /// A key (unique name and type) used to specify a search attribute.
 ///

--- a/Sources/Temporal/Bridge/BridgeError.swift
+++ b/Sources/Temporal/Bridge/BridgeError.swift
@@ -13,7 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 import Bridge
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 struct BridgeError: Error, Hashable {
     let message: String

--- a/Sources/Temporal/Bridge/BridgeReplayer.swift
+++ b/Sources/Temporal/Bridge/BridgeReplayer.swift
@@ -13,8 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 import Bridge
-import Foundation
 internal import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 package final class BridgeReplayer: Sendable {
     /// The underlying worker pointer from the Core SDK.

--- a/Sources/Temporal/Bridge/BridgeWorker.swift
+++ b/Sources/Temporal/Bridge/BridgeWorker.swift
@@ -13,9 +13,14 @@
 //===----------------------------------------------------------------------===//
 
 import Bridge
-import Foundation
 import GRPCCore
 internal import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 package protocol BridgeWorkerProtocol: Sendable {
     init(

--- a/Sources/Temporal/Bridge/Helpers/Data+Bridge.swift
+++ b/Sources/Temporal/Bridge/Helpers/Data+Bridge.swift
@@ -13,7 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 import Bridge
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 extension Data {
     /// Takes ownership of the buffer in `bytesPtr` and frees the `ByteArray`.

--- a/Sources/Temporal/Converters/BinaryProtobufPayloadConverter.swift
+++ b/Sources/Temporal/Converters/BinaryProtobufPayloadConverter.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Converts any type conforming to `SwiftProtobuf.Message` into binary protobuf encoding.
 public struct BinaryProtobufPayloadConverter: EncodingPayloadConverter {

--- a/Sources/Temporal/Converters/JSONProtobufPayloadConverter.swift
+++ b/Sources/Temporal/Converters/JSONProtobufPayloadConverter.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// A payload converter for types conforming to `SwiftProtobuf.Message` using JSON protobuf encoding.
 public struct JSONProtobufPayloadConverter: EncodingPayloadConverter {

--- a/Sources/Temporal/Extensions/ScheduleActivity+Proto.swift
+++ b/Sources/Temporal/Extensions/ScheduleActivity+Proto.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 extension Coresdk.WorkflowCommands.ScheduleActivity {
     init(

--- a/Sources/Temporal/Extensions/ScheduleLocalActivity.swift
+++ b/Sources/Temporal/Extensions/ScheduleLocalActivity.swift
@@ -12,9 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
 import struct SwiftProtobuf.Google_Protobuf_Timestamp
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension Coresdk.WorkflowCommands.ScheduleLocalActivity {
     init(

--- a/Sources/Temporal/Replayer/WorkflowHistory.swift
+++ b/Sources/Temporal/Replayer/WorkflowHistory.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-public import Foundation
 internal import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
+public import Foundation
+#endif
 
 /// Represents a workflow's execution history for replay purposes.
 public struct WorkflowHistory: Sendable {

--- a/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
+++ b/Sources/Temporal/Worker/TemporalWorker+Configuration.swift
@@ -13,7 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 public import Configuration
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 extension TemporalWorker {
     /// Configuration settings for the Temporal worker controlling operational behavior and connection

--- a/Sources/Temporal/Worker/Workflow/WorkflowInfo.swift
+++ b/Sources/Temporal/Worker/Workflow/WorkflowInfo.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 
 /// Information about a workflow execution.
 ///

--- a/Sources/TemporalMacros/String+Capitalized.swift
+++ b/Sources/TemporalMacros/String+Capitalized.swift
@@ -14,17 +14,13 @@
 
 extension String {
     func capitalizingFirst() -> String {
-        let capitalized = capitalized
-        guard count > 1 else { return capitalized }
-
-        // The string may already be capitalized.
-        let prefix = capitalized.commonPrefix(with: self)
-        guard prefix.rangeOfCharacter(from: .letters) == nil else {
-            return self
-        }
-
-        // There may be backticks at the start / end of string.
-        // `capitalized` handles that automatically
-        return String(capitalized.prefix(prefix.count + 1) + dropFirst(prefix.count + 1))
+        guard let firstLetterIndex = firstIndex(where: \.isLetter) else { return self }
+        guard self[firstLetterIndex].isLowercase else { return self }
+        var result = self
+        result.replaceSubrange(
+            firstLetterIndex...firstLetterIndex,
+            with: self[firstLetterIndex].uppercased()
+        )
+        return result
     }
 }

--- a/Sources/TemporalMacros/String+Capitalized.swift
+++ b/Sources/TemporalMacros/String+Capitalized.swift
@@ -12,8 +12,26 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Darwin)
+import Foundation
+#endif
+
 extension String {
     func capitalizingFirst() -> String {
+        #if canImport(Darwin)
+        let capitalized = capitalized
+        guard count > 1 else { return capitalized }
+
+        // The string may already be capitalized.
+        let prefix = capitalized.commonPrefix(with: self)
+        guard prefix.rangeOfCharacter(from: .letters) == nil else {
+            return self
+        }
+
+        // There may be backticks at the start / end of string.
+        // `capitalized` handles that automatically
+        return String(capitalized.prefix(prefix.count + 1) + dropFirst(prefix.count + 1))
+        #else
         guard let firstLetterIndex = firstIndex(where: \.isLetter) else { return self }
         guard self[firstLetterIndex].isLowercase else { return self }
         var result = self
@@ -22,5 +40,6 @@ extension String {
             with: self[firstLetterIndex].uppercased()
         )
         return result
+        #endif
     }
 }

--- a/Sources/TemporalMacros/WorkflowMacro.swift
+++ b/Sources/TemporalMacros/WorkflowMacro.swift
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Darwin)
+import Foundation
+#endif
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
@@ -147,8 +150,13 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
                                 // Check input type matches
                                 let updateParams = functionDecl.signature.parameterClause.parameters
                                 if let updateParam = updateParams.first(where: { $0.firstName.text == "input" }) {
+                                    #if canImport(Darwin)
+                                    let updateType = updateParam.type.description.trimmingCharacters(in: .whitespaces)
+                                    let validatorType = validatorParam.type.description.trimmingCharacters(in: .whitespaces)
+                                    #else
                                     let updateType = updateParam.type.trimmedDescription
                                     let validatorType = validatorParam.type.trimmedDescription
+                                    #endif
                                     if updateType != validatorType {
                                         context.diagnose(
                                             Diagnostic(

--- a/Sources/TemporalMacros/WorkflowMacro.swift
+++ b/Sources/TemporalMacros/WorkflowMacro.swift
@@ -16,12 +16,6 @@ import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
 /// Macro implementation for the `@Workflow` attribute.
 public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
     struct UnexpectedInitWarning: DiagnosticMessage {
@@ -153,8 +147,8 @@ public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {
                                 // Check input type matches
                                 let updateParams = functionDecl.signature.parameterClause.parameters
                                 if let updateParam = updateParams.first(where: { $0.firstName.text == "input" }) {
-                                    let updateType = updateParam.type.description.trimmingCharacters(in: .whitespaces)
-                                    let validatorType = validatorParam.type.description.trimmingCharacters(in: .whitespaces)
+                                    let updateType = updateParam.type.trimmedDescription
+                                    let validatorType = validatorParam.type.trimmedDescription
                                     if updateType != validatorType {
                                         context.diagnose(
                                             Diagnostic(

--- a/Sources/TemporalMacros/WorkflowMacro.swift
+++ b/Sources/TemporalMacros/WorkflowMacro.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Macro implementation for the `@Workflow` attribute.
 public struct WorkflowMacro: ExtensionMacro, MemberMacro, MemberAttributeMacro {

--- a/Sources/TemporalMacros/WorkflowQueryMacro.swift
+++ b/Sources/TemporalMacros/WorkflowQueryMacro.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftSyntax
 import SwiftSyntaxMacros
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Macro implementation for the `@WorkflowQuery` attribute.
 public struct WorkflowQueryMacro: PeerMacro {

--- a/Sources/TemporalMacros/WorkflowQueryMacro.swift
+++ b/Sources/TemporalMacros/WorkflowQueryMacro.swift
@@ -15,12 +15,6 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
 /// Macro implementation for the `@WorkflowQuery` attribute.
 public struct WorkflowQueryMacro: PeerMacro {
     public static func expansion(

--- a/Sources/TemporalMacros/WorkflowSignalMacro.swift
+++ b/Sources/TemporalMacros/WorkflowSignalMacro.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftSyntax
 import SwiftSyntaxMacros
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Macro implementation for the `@WorkflowSignal` attribute.
 public struct WorkflowSignalMacro: PeerMacro {

--- a/Sources/TemporalMacros/WorkflowSignalMacro.swift
+++ b/Sources/TemporalMacros/WorkflowSignalMacro.swift
@@ -15,12 +15,6 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
 /// Macro implementation for the `@WorkflowSignal` attribute.
 public struct WorkflowSignalMacro: PeerMacro {
     public static func expansion(

--- a/Sources/TemporalMacros/WorkflowStateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowStateMacro.swift
@@ -17,12 +17,6 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
 /// Macro implementation for the `@WorkflowState` attribute.
 public struct WorkflowStateMacro: AccessorMacro, PeerMacro {
     static let stateMacroName = "_WorkflowState"

--- a/Sources/TemporalMacros/WorkflowStateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowStateMacro.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Macro implementation for the `@WorkflowState` attribute.
 public struct WorkflowStateMacro: AccessorMacro, PeerMacro {

--- a/Sources/TemporalMacros/WorkflowUpdateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowUpdateMacro.swift
@@ -15,12 +15,6 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
 /// Macro implementation for the `@WorkflowUpdate` attribute.
 public struct WorkflowUpdateMacro: PeerMacro {
     public static func expansion(

--- a/Sources/TemporalMacros/WorkflowUpdateMacro.swift
+++ b/Sources/TemporalMacros/WorkflowUpdateMacro.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftSyntax
 import SwiftSyntaxMacros
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Macro implementation for the `@WorkflowUpdate` attribute.
 public struct WorkflowUpdateMacro: PeerMacro {

--- a/Tests/LinkageTest/.gitignore
+++ b/Tests/LinkageTest/.gitignore
@@ -1,0 +1,2 @@
+.build
+Package.resolved

--- a/Tests/LinkageTest/Package.swift
+++ b/Tests/LinkageTest/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "linkage-test",
+    platforms: [
+        .macOS(.v15), .iOS(.v18),
+    ],
+    dependencies: [
+        .package(name: "swift-temporal-sdk", path: "../..", traits: [])
+    ],
+    targets: [
+        .executableTarget(
+            name: "linkageTest",
+            dependencies: [
+                .product(name: "Temporal", package: "swift-temporal-sdk")
+            ]
+        )
+    ]
+)

--- a/Tests/LinkageTest/Sources/linkageTest/main.swift
+++ b/Tests/LinkageTest/Sources/linkageTest/main.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+print("Linkage test binary built successfully")

--- a/Tests/TemporalTests/Client/AsyncActivityHandleTests.swift
+++ b/Tests/TemporalTests/Client/AsyncActivityHandleTests.swift
@@ -13,12 +13,16 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncAlgorithms
-import Foundation
 import Synchronization
 import Temporal
 import Testing
-
 import struct GRPCCore.RPCError
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.clientTests))

--- a/Tests/TemporalTests/Client/ClientTests.swift
+++ b/Tests/TemporalTests/Client/ClientTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import GRPCCore
 import GRPCNIOTransportHTTP2Posix
 import Logging
@@ -23,6 +22,12 @@ import Temporal
 import TemporalTestKit
 import Testing
 import X509
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.clientTests))

--- a/Tests/TemporalTests/Client/InterceptedOperationsTests+Schedules.swift
+++ b/Tests/TemporalTests/Client/InterceptedOperationsTests+Schedules.swift
@@ -12,12 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import Testing
-
 import struct GRPCCore.RPCError
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests.InterceptedOperationsTests {
     struct ScheduleEvent: Equatable {

--- a/Tests/TemporalTests/Client/InterceptedOperationsTests+Workflows.swift
+++ b/Tests/TemporalTests/Client/InterceptedOperationsTests+Workflows.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.clientTests))

--- a/Tests/TemporalTests/Client/NamespaceTests.swift
+++ b/Tests/TemporalTests/Client/NamespaceTests.swift
@@ -13,12 +13,17 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncAlgorithms
-import Foundation
 import GRPCCore
 import GRPCNIOTransportHTTP2Posix
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.clientTests))

--- a/Tests/TemporalTests/Client/ScheduleTests.swift
+++ b/Tests/TemporalTests/Client/ScheduleTests.swift
@@ -13,12 +13,17 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncAlgorithms
-import Foundation
 import GRPCCore
 import GRPCNIOTransportHTTP2Posix
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.clientTests))

--- a/Tests/TemporalTests/Client/UntypedScheduleHandleTests.swift
+++ b/Tests/TemporalTests/Client/UntypedScheduleHandleTests.swift
@@ -12,12 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import Testing
-
 import struct GRPCCore.RPCError
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.clientTests))

--- a/Tests/TemporalTests/Client/UntypedWorfklowHandleTests.swift
+++ b/Tests/TemporalTests/Client/UntypedWorfklowHandleTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.clientTests))

--- a/Tests/TemporalTests/Client/WorkflowExecutionDescriptionTests.swift
+++ b/Tests/TemporalTests/Client/WorkflowExecutionDescriptionTests.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Client/WorkflowExecutionStatusTests.swift
+++ b/Tests/TemporalTests/Client/WorkflowExecutionStatusTests.swift
@@ -13,10 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncAlgorithms
-import Foundation
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.clientTests))

--- a/Tests/TemporalTests/Converters/Activation+DecodingTests.swift
+++ b/Tests/TemporalTests/Converters/Activation+DecodingTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite
 struct ActivationDecodingTests {

--- a/Tests/TemporalTests/Converters/ActivationCompletion+EncodingTests.swift
+++ b/Tests/TemporalTests/Converters/ActivationCompletion+EncodingTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite
 struct ActivationCompletionEncodingTests {

--- a/Tests/TemporalTests/Converters/Base64Codec.swift
+++ b/Tests/TemporalTests/Converters/Base64Codec.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 struct Base64PayloadCodec: PayloadCodec {
     let encodingName = "application/base64"

--- a/Tests/TemporalTests/Converters/BinaryNilPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/BinaryNilPayloadConverterTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct BinaryNilPayloadConverterTests {

--- a/Tests/TemporalTests/Converters/BinaryPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/BinaryPayloadConverterTests.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct BinaryPayloadConverterTests {

--- a/Tests/TemporalTests/Converters/BinaryProtobufPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/BinaryProtobufPayloadConverterTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct BinaryProtobufPayloadConverterTests {

--- a/Tests/TemporalTests/Converters/CompositePayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/CompositePayloadConverterTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct CompositePayloadConverterTests {

--- a/Tests/TemporalTests/Converters/DataConverterTests.swift
+++ b/Tests/TemporalTests/Converters/DataConverterTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct DataConverterTests {

--- a/Tests/TemporalTests/Converters/DefaultFailureConverterTests.swift
+++ b/Tests/TemporalTests/Converters/DefaultFailureConverterTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct DefaultFailureConverterTests {

--- a/Tests/TemporalTests/Converters/DefaultPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/DefaultPayloadConverterTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct DefaultPayloadConverterTests {

--- a/Tests/TemporalTests/Converters/JSONPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/JSONPayloadConverterTests.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct JSONPayloadConverterTests {

--- a/Tests/TemporalTests/Converters/JSONProtobufPayloadConverterTests.swift
+++ b/Tests/TemporalTests/Converters/JSONProtobufPayloadConverterTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.converterTests))
 struct JSONProtobufPayloadConverterTests {

--- a/Tests/TemporalTests/Converters/TestCodable.swift
+++ b/Tests/TemporalTests/Converters/TestCodable.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 struct TestCodable: Codable, Hashable {
     var someString: String

--- a/Tests/TemporalTests/Converters/TestMessage.swift
+++ b/Tests/TemporalTests/Converters/TestMessage.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 struct TestMessage: Message, _MessageImplementationBase, _ProtoNameProviding, Sendable {
     var seconds: Int64 = 0

--- a/Tests/TemporalTests/Instrumentation/Metrics/ClientOTelMetricsInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Metrics/ClientOTelMetricsInterceptorTests.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import GRPCCore
 import Metrics
 import OTelSemanticConventions
 import TemporalInstrumentation
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.instrumentationTests))
 struct GRPCClientMetricsInterceptorTests {

--- a/Tests/TemporalTests/Instrumentation/Metrics/Utils/TestMetricsFactory.swift
+++ b/Tests/TemporalTests/Instrumentation/Metrics/Utils/TestMetricsFactory.swift
@@ -13,9 +13,14 @@
 //===----------------------------------------------------------------------===//
 
 import CoreMetrics
-import Foundation
 import Metrics
 import Synchronization
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Taken and adjusted from `swift-cluster-memberships`s own test target package.
 ///

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalClientOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalClientOutboundTracingInterceptorTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import GRPCCore
 import GRPCNIOTransportHTTP2Posix
 import Logging
@@ -21,6 +20,12 @@ import Temporal
 import TemporalTestKit
 import Testing
 import Tracing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.instrumentationTests))
 struct TemporalClientOutboundTracingInterceptorTests {

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerInboundTracingInterceptorTests.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import SwiftProtobuf
 import Temporal
 import Testing
 import Tracing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.instrumentationTests))
 struct TemporalWorkerInboundTracingInterceptorTests {

--- a/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
+++ b/Tests/TemporalTests/Instrumentation/Tracing/TemporalWorkerOutboundTracingInterceptorTests.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import SwiftProtobuf
 import Temporal
 import Testing
 import Tracing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.instrumentationTests))
 struct TemporalWorkerOutboundTracingInterceptorTests {

--- a/Tests/TemporalTests/Macros/MacroNameTests.swift
+++ b/Tests/TemporalTests/Macros/MacroNameTests.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite

--- a/Tests/TemporalTests/Shared/TestActivityWorker.swift
+++ b/Tests/TemporalTests/Shared/TestActivityWorker.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 protocol ActivityWorkerForwarding: ActivityWorkerProtocol where BridgeWorker: BridgeWorkerProtocol {
     var base: ActivityWorker<BridgeWorker> { get }

--- a/Tests/TemporalTests/Shared/TestBridgeWorker.swift
+++ b/Tests/TemporalTests/Shared/TestBridgeWorker.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 protocol BridgeWorkerForwarding: BridgeWorkerProtocol {
     var base: BridgeWorker { get }

--- a/Tests/TemporalTests/Shared/TestWorkflowWorker.swift
+++ b/Tests/TemporalTests/Shared/TestWorkflowWorker.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Temporal
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 protocol WorkflowWorkerForwarding: WorkflowWorkerProtocol where BridgeWorker: BridgeWorkerProtocol {
     var base: WorkflowWorker<BridgeWorker> { get }

--- a/Tests/TemporalTests/TestData/TestData.swift
+++ b/Tests/TemporalTests/TestData/TestData.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftASN1
 import X509
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 enum TestData {
     static let certificateChain: [Certificate]? = {

--- a/Tests/TemporalTests/TestHelpers/WorkerTestHelper.swift
+++ b/Tests/TemporalTests/TestHelpers/WorkerTestHelper.swift
@@ -12,14 +12,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import ServiceLifecycle
 import Temporal
 import TemporalTestKit
 import Testing
-
 import protocol GRPCCore.ClientTransport
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // Serialized: Makes it easier to understand which test fails and doesn't overwhelm the Temporal test server
 // TimeLimit: Ensures that nothing gets stuck forever

--- a/Tests/TemporalTests/Worker/Activities/ActivityRetryTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityRetryTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Activities/ActivityWorkerTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityWorkerTests.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import SwiftProtobuf
 import Synchronization
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 private final class MockBridgeWorker: BridgeWorkerProtocol {
     private let activityTaskStream: AsyncThrowingStream<Coresdk.ActivityTask.ActivityTask, any Error>

--- a/Tests/TemporalTests/Worker/TemporalWorkerGracefulShutdownTests.swift
+++ b/Tests/TemporalTests/Worker/TemporalWorkerGracefulShutdownTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import GRPCNIOTransportCore
 import GRPCNIOTransportHTTP2Posix
 import Logging
@@ -21,6 +20,12 @@ import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite

--- a/Tests/TemporalTests/Worker/Tuning/WorkerTunerTests.swift
+++ b/Tests/TemporalTests/Worker/Tuning/WorkerTunerTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/WithWorkerAndClientTests.swift
+++ b/Tests/TemporalTests/Worker/WithWorkerAndClientTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite

--- a/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowCancelActivityTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/Activities/WorkflowCancelActivityTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/HandlerUnfinishedPolicyTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/HandlerUnfinishedPolicyTests.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/TimeSkippingInterceptorTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/TimeSkippingInterceptorTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/UnregisteredWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/UnregisteredWorkflowTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowChildWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowChildWorkflowTests.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowEvictionTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     /// Regression tests for the fatal crash that previously occurred when a worker was torn

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowExternalWorkflowTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowExternalWorkflowTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowHistoryInfoTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowHistoryInfoTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowInfoTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowInfoTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowOptionsTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowOptionsTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftProtobuf
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite(.tags(.workflowTests))
 struct WorkflowOptionsTests {

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowPatchTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowPatchTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowQueryTests.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import GRPCCore
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowRawValueTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowRawValueTests.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import SwiftProtobuf
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSearchAttributeTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSearchAttributeTests.swift
@@ -13,11 +13,16 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncAlgorithms
-import Foundation
 import Logging
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests), .serialized)

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSignalTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowSleepTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowSleepTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowStateTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowStateTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowTimestampTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowTimestampTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowUpdateTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Synchronization
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowWaitConditionTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowWaitConditionTests.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension TestServerDependentTests {
     @Suite(.tags(.workflowTests))

--- a/Tests/TemporalTests/Worker/Workflow/WorkflowWorkerTests.swift
+++ b/Tests/TemporalTests/Worker/Workflow/WorkflowWorkerTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Synchronization
 import Temporal
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // Mock bridge worker for testing
 private final class MockBridgeWorker: BridgeWorkerProtocol {

--- a/Tests/TemporalTests/Worker/WorkflowReplayerTests.swift
+++ b/Tests/TemporalTests/Worker/WorkflowReplayerTests.swift
@@ -12,11 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import Temporal
 import TemporalTestKit
 import Testing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // MARK: - Test Suite
 

--- a/Tools/NamespaceRefactorTool/NamespaceRefactorTool.swift
+++ b/Tools/NamespaceRefactorTool/NamespaceRefactorTool.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftParser
 import SwiftSyntax
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // This tool transforms the underscored proto generated namespaces into dot seperated ones.
 // Ideally this would be part of SwiftProtobuf but the generation pattern has some problems discussed in

--- a/Tools/NamespaceRefactorTool/Rewriting/NamespaceRewriter.swift
+++ b/Tools/NamespaceRefactorTool/Rewriting/NamespaceRewriter.swift
@@ -12,10 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxBuilder
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // Swift reserved keywords that need to be escaped with backticks
 let swiftReservedKeywords: Set<String> = [

--- a/scripts/run-linkage-test.sh
+++ b/scripts/run-linkage-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Temporal SDK open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift Temporal SDK project authors
+## Licensed under MIT License
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+##
+## SPDX-License-Identifier: MIT
+##
+##===----------------------------------------------------------------------===##
+set -eu
+
+# Validate that we're running on Linux
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "Error: This script must be run on Linux. Current OS: $(uname -s)" >&2
+    exit 1
+fi
+
+echo "Running on Linux - proceeding with linkage test..."
+
+# Build the linkage test package
+echo "Building linkage test package..."
+swift build --package-path Tests/LinkageTest
+
+# Check the architecture and build path
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+    BUILD_PATH="Tests/LinkageTest/.build/x86_64-unknown-linux-gnu/debug/linkageTest"
+elif [[ "$ARCH" == "aarch64" ]]; then
+    BUILD_PATH="Tests/LinkageTest/.build/aarch64-unknown-linux-gnu/debug/linkageTest"
+else
+    echo "Error: Unsupported architecture: $ARCH" >&2
+    exit 1
+fi
+
+# Verify the binary exists
+if [[ ! -f "$BUILD_PATH" ]]; then
+    echo "Error: Built binary not found at $BUILD_PATH" >&2
+    exit 1
+fi
+
+echo "Checking linkage for binary: $BUILD_PATH"
+
+# Run ldd and check if libFoundation.so is linked
+LDD_OUTPUT=$(ldd "$BUILD_PATH")
+echo "LDD output:"
+echo "$LDD_OUTPUT"
+
+if echo "$LDD_OUTPUT" | grep -q "libFoundation.so"; then
+    echo "Error: Binary is linked against libFoundation.so - this indicates incorrect linkage. Ensure the full Foundation is not linked on Linux when default traits are disabled." >&2
+    exit 1
+else
+    echo "Success: Binary is not linked against libFoundation.so - linkage test passed."
+fi


### PR DESCRIPTION
### Motivation

Issue #123 asks whether the project can move to only importing `FoundationEssentials` instead of the full `Foundation` module. Several files in the client and instrumentation modules already use the `#if canImport(FoundationEssentials)` conditional import pattern, but 18 source files and ~80 test/example/tool files still import the full `Foundation` module unconditionally. This increases the dependency surface on platforms where `FoundationEssentials` is available as a standalone, lighter-weight module.

### Modifications

- Replaced all plain `import Foundation` with the conditional `#if canImport(FoundationEssentials)` pattern across Sources, Tests, Examples, and Tools directories (101 files total).
- Preserved `public import` / `internal import` access levels where the original import used them.
- Ensured import ordering complies with swift-format's `OrderedImports` rule (regular imports before `#if canImport` blocks).

### Result

On platforms where `FoundationEssentials` is importable (e.g., recent Swift toolchains on Linux), the project now uses the smaller module. On other platforms, it falls back to the full `Foundation` import. No behavioral change.

### Test Plan

- Ran `swift format lint --strict --recursive` on all changed directories — zero violations.
- CI will verify the build and test suite pass on both Linux (FoundationEssentials available) and macOS (Foundation fallback).

Resolves #123