### PR TITLE
Enable warnings as errors in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: false
       linux_6_1_enabled: false
-      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
-      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
-      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
-      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
+      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors -Xcc -Wno-visibility"
+      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors -Xcc -Wno-visibility"
+      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors -Xcc -Wno-visibility"
+      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors -Xcc -Wno-visibility"
 
   cxx-interop:
     name: Cxx interop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: false
       linux_6_1_enabled: false
-      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable"
-      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable"
-      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable"
-      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable"
+      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
 
   cxx-interop:
     name: Cxx interop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: false
       linux_6_1_enabled: false
-      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
+      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
+      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
+      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
 
   cxx-interop:
     name: Cxx interop

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,10 +22,10 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: false
       linux_6_1_enabled: false
-      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable"
-      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable"
-      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable"
-      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable"
+      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
 
   macos-tests:
     name: macOS tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,10 +22,10 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: false
       linux_6_1_enabled: false
-      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
+      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
+      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
+      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
 
   macos-tests:
     name: macOS tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,10 +22,10 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: false
       linux_6_1_enabled: false
-      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
-      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
-      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
-      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -Xfrontend -Xswiftc -warnings-as-errors"
+      linux_6_2_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors -Xcc -Wno-visibility"
+      linux_6_3_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors -Xcc -Wno-visibility"
+      linux_nightly_next_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors -Xcc -Wno-visibility"
+      linux_nightly_main_arguments_override: "-Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors -Xcc -Wno-visibility"
 
   macos-tests:
     name: macOS tests


### PR DESCRIPTION
### Motivation

Issue #3 requests enabling warnings as errors in CI to catch compiler warnings early and prevent them from accumulating in the codebase. Currently, the CI workflows only pass `-Xswiftc -require-explicit-sendable` but do not treat warnings as build failures.

### Modifications

- Added `-Xswiftc -warnings-as-errors` to all Linux CI argument overrides in both `pull_request.yml` and `main.yml` workflows.
- Applied to `linux_6_2`, `linux_6_3`, `linux_nightly_next`, and `linux_nightly_main` configurations.

### Result

Any compiler warning on Linux CI will now cause the build to fail, ensuring warnings are addressed promptly rather than accumulating over time.

### Test Plan

- CI will validate that the current codebase compiles warning-free with this flag enabled.
- If any existing warnings surface, they will need to be fixed before this PR can merge, confirming the flag is working as intended.

Resolves #3