### PR TITLE
Use swift-subprocess for the time-skipping test server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,7 @@ let package = Package(
         .package(url: "https://github.com/grpc/grpc-swift-extras.git", from: "2.0.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-configuration.git", from: "1.0.0", traits: []),
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "1.0.0"),
     ],
     targets: [
         .binaryTarget(
@@ -121,6 +122,11 @@ let package = Package(
                 .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
                 .product(name: "GRPCServiceLifecycle", package: "grpc-swift-extras"),
                 .target(name: "Temporal"),
+                .product(
+                    name: "Subprocess",
+                    package: "swift-subprocess",
+                    condition: .when(platforms: [.macOS, .linux])
+                ),
             ]
         ),
         .target(

--- a/Sources/Temporal/Bridge/BridgeTestServer.swift
+++ b/Sources/Temporal/Bridge/BridgeTestServer.swift
@@ -15,6 +15,11 @@
 import Bridge
 
 package struct BridgeTestServer: ~Copyable, Sendable {
+    /// Options embedded into ``DevServerOptions`` for the dev server's download/spawn FFI call.
+    ///
+    /// The time-skipping test server no longer goes through this FFI bridge (see
+    /// `TemporalTestKit`'s `TestServerProcess` implementation), so this type now only
+    /// serves the dev server path.
     package struct TestServerOptions: Hashable, Sendable {
         /// The existing path of the downloaded test server.
         var existingPath: String
@@ -192,54 +197,6 @@ package struct BridgeTestServer: ~Copyable, Sendable {
     // only use one runtime for all test servers
     package static let bridgeRuntime = try! BridgeRuntime()
     private nonisolated(unsafe) let serverPointer: OpaquePointer
-
-    package static func withBridgeTestServer<Result>(
-        testServerOptions: BridgeTestServer.TestServerOptions = .default,
-        _ body: (borrowing BridgeTestServer, String) async throws -> Result
-    ) async throws -> Result {
-        let (serverPointer, connectTarget): (UnsafeTransfer<OpaquePointer>, String) = try await withCheckedThrowingContinuation { continuation in
-            testServerOptions.withBridgeTestServerOptions { testServerOptions in
-                withUnsafePointer(to: testServerOptions) { testServerOptionsPointer in
-                    let continuationHolder = ContinuationHolder(continuation)
-                    let opaqueContinuationHolder = Unmanaged.passRetained(continuationHolder).toOpaque()
-                    temporal_core_ephemeral_server_start_test_server(
-                        Self.bridgeRuntime.runtime,
-                        testServerOptionsPointer,
-                        opaqueContinuationHolder
-                    ) { userData, success, successTarget, fail in
-                        let continuation = Unmanaged<ContinuationHolder<(UnsafeTransfer<OpaquePointer>, String)>>
-                            .fromOpaque(userData!).takeRetainedValue().continuation
-                        if let fail {
-                            continuation.resume(throwing: BridgeError(messagePointer: fail))
-                        } else if let success, let successTarget {
-                            continuation.resume(
-                                returning: (
-                                    .init(wrapped: success),
-                                    String(byteArray: successTarget.pointee)
-                                )
-                            )
-                        } else {
-                            fatalError("Temporal Core SDK bug: No success or fail")
-                        }
-                    }
-                }
-            }
-        }
-
-        let bridgeTestServer = BridgeTestServer(
-            serverPointer: serverPointer.wrapped
-        )
-
-        let result: Result
-        do {
-            result = try await body(bridgeTestServer, connectTarget)
-        } catch {
-            try await bridgeTestServer.shutdown()
-            throw error
-        }
-        try await bridgeTestServer.shutdown()
-        return result
-    }
 
     package static func withBridgeDevServer<Result>(
         devServerOptions: BridgeTestServer.DevServerOptions = .default,

--- a/Sources/TemporalTestKit/TemporalTestServer.swift
+++ b/Sources/TemporalTestKit/TemporalTestServer.swift
@@ -235,7 +235,9 @@ public struct TemporalTestServer: Sendable {
     public static func withTimeSkippingTestServer(
         _ body: (borrowing TemporalTestServer) async throws -> Void
     ) async throws {
-        try await BridgeTestServer.withBridgeTestServer { bridgeTestServer, target in
+        #if canImport(Subprocess)
+        let executablePath = try await ensureTestServerDownloaded(options: .default)
+        try await withRunningTestServer(executablePath: executablePath, extraArguments: []) { target in
             let parts = target.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
             guard let host = parts.first.map(String.init),
                 parts.count > 1,
@@ -255,7 +257,7 @@ public struct TemporalTestServer: Sendable {
                 )
             )
 
-            return try await withThrowingTaskGroup(of: Void.self) { group in
+            try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
                     try await grpcClient.run()
                 }
@@ -269,6 +271,9 @@ public struct TemporalTestServer: Sendable {
                 grpcClient.beginGracefulShutdown()
             }
         }
+        #else
+        fatalError("The time-skipping test server requires swift-subprocess, which is unavailable on this platform.")
+        #endif
     }
 
     /// Creates a connected Temporal client for testing operations against the test server.

--- a/Sources/TemporalTestKit/TemporalTestServer.swift
+++ b/Sources/TemporalTestKit/TemporalTestServer.swift
@@ -236,8 +236,9 @@ public struct TemporalTestServer: Sendable {
         _ body: (borrowing TemporalTestServer) async throws -> Void
     ) async throws {
         #if canImport(Subprocess)
-        let executablePath = try await ensureTestServerDownloaded(options: .default)
-        try await withRunningTestServer(executablePath: executablePath, extraArguments: []) { target in
+        let options = TimeSkippingTestServerOptions.default
+        let executablePath = try await ensureTestServerDownloaded(options: options)
+        try await withRunningTestServer(executablePath: executablePath, extraArguments: options.extraArguments) { target in
             let parts = target.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
             guard let host = parts.first.map(String.init),
                 parts.count > 1,
@@ -272,7 +273,7 @@ public struct TemporalTestServer: Sendable {
             }
         }
         #else
-        fatalError("The time-skipping test server requires swift-subprocess, which is unavailable on this platform.")
+        throw TestServerProcessError.unavailableOnPlatform
         #endif
     }
 

--- a/Sources/TemporalTestKit/TestServerProcess/TestServerBinaryCache.swift
+++ b/Sources/TemporalTestKit/TestServerProcess/TestServerBinaryCache.swift
@@ -1,0 +1,198 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Subprocess)
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// Returns the path to a ready-to-run `temporal-test-server` binary, downloading and
+/// caching it first if necessary.
+func ensureTestServerDownloaded(options: TimeSkippingTestServerOptions) async throws -> FilePath {
+    if !options.existingPath.isEmpty {
+        return FilePath(options.existingPath)
+    }
+
+    let destination = cachedTestServerPath(options: options)
+
+    if isCachedTestServerValid(at: destination, ttl: options.downloadTtl) {
+        return destination
+    }
+
+    let maxAttempts = 3
+    for _ in 0..<maxAttempts {
+        if try await downloadTestServerIfNeeded(to: destination, options: options) {
+            return destination
+        }
+    }
+    throw TestServerProcessError.lockTimedOut(path: destination.string)
+}
+
+func cachedTestServerPath(options: TimeSkippingTestServerOptions) -> FilePath {
+    let destinationDirectory =
+        options.downloadDestinationDirectory.isEmpty
+        ? FilePath(NSTemporaryDirectory())
+        : FilePath(options.downloadDestinationDirectory)
+    let filename =
+        options.downloadVersion == "default"
+        ? "temporal-test-server-\(options.sdkName)-\(options.sdkVersion)"
+        : "temporal-test-server-\(options.downloadVersion)"
+    return destinationDirectory.appending(filename)
+}
+
+func isCachedTestServerValid(at destination: FilePath, ttl: Duration?) -> Bool {
+    guard FileManager.default.fileExists(atPath: destination.string) else {
+        return false
+    }
+    guard let ttl else {
+        return true
+    }
+    guard
+        let attributes = try? FileManager.default.attributesOfItem(atPath: destination.string),
+        let modificationDate = attributes[.modificationDate] as? Date
+    else {
+        return false
+    }
+    if Date.now.timeIntervalSince(modificationDate) < Double(ttl.components.seconds) {
+        return true
+    }
+    try? FileManager.default.removeItem(atPath: destination.string)
+    return false
+}
+
+/// Attempts a single download-or-wait cycle.
+///
+/// Returns `true` once `destination` is ready to use, `false` if the caller should retry
+/// (e.g. because an abandoned lock file was cleared and a fresh attempt is needed).
+private func downloadTestServerIfNeeded(
+    to destination: FilePath,
+    options: TimeSkippingTestServerOptions
+) async throws -> Bool {
+    if FileManager.default.fileExists(atPath: destination.string) {
+        return true
+    }
+
+    let lockPath = FilePath(destination.string + ".downloading")
+    let lockFile: FileDescriptor
+    do {
+        lockFile = try FileDescriptor.open(
+            lockPath,
+            .writeOnly,
+            options: [.create, .exclusiveCreate],
+            permissions: FilePermissions(rawValue: 0o755)
+        )
+    } catch Errno.fileExists {
+        return try await waitForConcurrentDownload(lockPath: lockPath, destination: destination)
+    }
+
+    do {
+        let info = try await resolveTestServerDownload(
+            downloadVersion: options.downloadVersion,
+            sdkName: options.sdkName,
+            sdkVersion: options.sdkVersion
+        )
+        try await downloadArchive(from: info.archiveUrl, extracting: info.fileToExtract, into: lockFile)
+        try lockFile.close()
+        guard rename(lockPath.string, destination.string) == 0 else {
+            throw TestServerProcessError.archiveDownloadFailed(
+                url: info.archiveUrl,
+                underlying: String(cString: strerror(errno))
+            )
+        }
+    } catch {
+        try? lockFile.close()
+        try? FileManager.default.removeItem(atPath: lockPath.string)
+        throw error
+    }
+    return true
+}
+
+/// Polls for a concurrently-downloading lock file to disappear, mirroring the Core SDK's
+/// coordination protocol: an abandoned lock (no update in 90s) is cleared and retried,
+/// otherwise wait up to 20s for the owning download to finish.
+func waitForConcurrentDownload(lockPath: FilePath, destination: FilePath) async throws -> Bool {
+    let lockAge = (try? FileManager.default.attributesOfItem(atPath: lockPath.string))
+        .flatMap { $0[.modificationDate] as? Date }
+        .map { Date.now.timeIntervalSince($0) }
+
+    if let lockAge, lockAge > 90 {
+        try? FileManager.default.removeItem(atPath: lockPath.string)
+        return false
+    }
+
+    for _ in 0..<20 {
+        try await Task.sleep(for: .seconds(1))
+        if !FileManager.default.fileExists(atPath: lockPath.string) {
+            return FileManager.default.fileExists(atPath: destination.string)
+        }
+    }
+    throw TestServerProcessError.lockTimedOut(path: lockPath.string)
+}
+
+/// Downloads the `.tar.gz` archive at `urlString` and streams the single `fileToExtract`
+/// member out of it into `destination`, by piping the downloaded bytes through the system `tar`.
+private func downloadArchive(
+    from urlString: String,
+    extracting fileToExtract: String,
+    into destination: FileDescriptor
+) async throws {
+    guard let url = URL(string: urlString) else {
+        throw TestServerProcessError.archiveDownloadFailed(url: urlString, underlying: "invalid URL")
+    }
+
+    let archiveData: Data
+    do {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
+            throw TestServerProcessError.invalidDownloadResponse(statusCode: (response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+        archiveData = data
+    } catch let error as TestServerProcessError {
+        throw error
+    } catch {
+        throw TestServerProcessError.archiveDownloadFailed(url: urlString, underlying: String(describing: error))
+    }
+
+    let result = try await Subprocess.run(
+        .name("tar"),
+        arguments: Arguments(["-x", "-z", "-f", "-", "-O", fileToExtract]),
+        input: .array(Array(archiveData)),
+        output: .fileDescriptor(destination, closeAfterSpawningProcess: false),
+        error: .string(limit: 4096)
+    )
+    guard result.terminationStatus.isSuccess else {
+        let exitCode: Int32
+        if case .exited(let code) = result.terminationStatus {
+            exitCode = code
+        } else {
+            exitCode = -1
+        }
+        throw TestServerProcessError.extractionFailed(exitCode: exitCode, standardError: result.standardError)
+    }
+}
+#endif

--- a/Sources/TemporalTestKit/TestServerProcess/TestServerBinaryCache.swift
+++ b/Sources/TemporalTestKit/TestServerProcess/TestServerBinaryCache.swift
@@ -110,6 +110,7 @@ private func downloadTestServerIfNeeded(
         return try await waitForConcurrentDownload(lockPath: lockPath, destination: destination)
     }
 
+    var lockFileClosed = false
     do {
         let info = try await resolveTestServerDownload(
             downloadVersion: options.downloadVersion,
@@ -118,6 +119,7 @@ private func downloadTestServerIfNeeded(
         )
         try await downloadArchive(from: info.archiveUrl, extracting: info.fileToExtract, into: lockFile)
         try lockFile.close()
+        lockFileClosed = true
         guard rename(lockPath.string, destination.string) == 0 else {
             throw TestServerProcessError.archiveDownloadFailed(
                 url: info.archiveUrl,
@@ -125,7 +127,9 @@ private func downloadTestServerIfNeeded(
             )
         }
     } catch {
-        try? lockFile.close()
+        if !lockFileClosed {
+            try? lockFile.close()
+        }
         try? FileManager.default.removeItem(atPath: lockPath.string)
         throw error
     }

--- a/Sources/TemporalTestKit/TestServerProcess/TestServerDownloadInfo.swift
+++ b/Sources/TemporalTestKit/TestServerProcess/TestServerDownloadInfo.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Subprocess)
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// The response from the `temporal.download` artifact resolution service.
+struct TestServerDownloadInfo: Decodable, Sendable {
+    let archiveUrl: String
+    let fileToExtract: String
+}
+
+enum TestServerDownloadPlatform {
+    static var current: String {
+        #if os(macOS)
+        "darwin"
+        #else
+        "linux"
+        #endif
+    }
+}
+
+enum TestServerDownloadArch {
+    static var current: String {
+        #if arch(x86_64)
+        "amd64"
+        #elseif arch(arm64)
+        "arm64"
+        #else
+        #error("Unsupported architecture for downloading the test server binary.")
+        #endif
+    }
+}
+
+func testServerDownloadURL(
+    downloadVersion: String,
+    sdkName: String,
+    sdkVersion: String
+) -> URL {
+    var components = URLComponents(string: "https://temporal.download/temporal-test-server/\(downloadVersion)")!
+    var queryItems = [
+        URLQueryItem(name: "arch", value: TestServerDownloadArch.current),
+        URLQueryItem(name: "platform", value: TestServerDownloadPlatform.current),
+    ]
+    if downloadVersion == "default" {
+        queryItems.append(URLQueryItem(name: "sdk-name", value: sdkName))
+        queryItems.append(URLQueryItem(name: "sdk-version", value: sdkVersion))
+    }
+    components.queryItems = queryItems
+    return components.url!
+}
+
+func resolveTestServerDownload(
+    downloadVersion: String,
+    sdkName: String,
+    sdkVersion: String
+) async throws -> TestServerDownloadInfo {
+    let url = testServerDownloadURL(downloadVersion: downloadVersion, sdkName: sdkName, sdkVersion: sdkVersion)
+
+    let (data, response): (Data, URLResponse)
+    do {
+        (data, response) = try await URLSession.shared.data(from: url)
+    } catch {
+        throw TestServerProcessError.downloadResolutionFailed(underlying: String(describing: error))
+    }
+
+    guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        throw TestServerProcessError.invalidDownloadResponse(statusCode: statusCode)
+    }
+
+    do {
+        return try JSONDecoder().decode(TestServerDownloadInfo.self, from: data)
+    } catch {
+        throw TestServerProcessError.downloadResolutionFailed(underlying: String(describing: error))
+    }
+}
+#endif

--- a/Sources/TemporalTestKit/TestServerProcess/TestServerProcessError.swift
+++ b/Sources/TemporalTestKit/TestServerProcess/TestServerProcessError.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Subprocess)
+package enum TestServerProcessError: Error, Sendable, CustomStringConvertible {
+    case invalidDownloadResponse(statusCode: Int)
+    case downloadResolutionFailed(underlying: String)
+    case archiveDownloadFailed(url: String, underlying: String)
+    case extractionFailed(exitCode: Int32, standardError: String)
+    case lockTimedOut(path: String)
+    case processFailedToStart(underlying: String)
+    case reachabilityTimeout(target: String)
+
+    package var description: String {
+        switch self {
+        case .invalidDownloadResponse(let statusCode):
+            "Test server download resolution returned an unexpected status code \(statusCode)."
+        case .downloadResolutionFailed(let underlying):
+            "Failed to resolve the test server download location: \(underlying)"
+        case .archiveDownloadFailed(let url, let underlying):
+            "Failed to download the test server archive from \(url): \(underlying)"
+        case .extractionFailed(let exitCode, let standardError):
+            "Failed to extract the test server binary (tar exited with \(exitCode)): \(standardError)"
+        case .lockTimedOut(let path):
+            "Timed out waiting for a concurrent test server download to finish at \(path)."
+        case .processFailedToStart(let underlying):
+            "Failed to start the test server process: \(underlying)"
+        case .reachabilityTimeout(let target):
+            "Test server did not become reachable at \(target) in time."
+        }
+    }
+}
+#endif

--- a/Sources/TemporalTestKit/TestServerProcess/TestServerProcessError.swift
+++ b/Sources/TemporalTestKit/TestServerProcess/TestServerProcessError.swift
@@ -12,8 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Subprocess)
 package enum TestServerProcessError: Error, Sendable, CustomStringConvertible {
+    /// The time-skipping test server was requested on a platform swift-subprocess doesn't support.
+    case unavailableOnPlatform
+    #if canImport(Subprocess)
     case invalidDownloadResponse(statusCode: Int)
     case downloadResolutionFailed(underlying: String)
     case archiveDownloadFailed(url: String, underlying: String)
@@ -21,9 +23,13 @@ package enum TestServerProcessError: Error, Sendable, CustomStringConvertible {
     case lockTimedOut(path: String)
     case processFailedToStart(underlying: String)
     case reachabilityTimeout(target: String)
+    #endif
 
     package var description: String {
         switch self {
+        case .unavailableOnPlatform:
+            "The time-skipping test server requires swift-subprocess, which is unavailable on this platform."
+        #if canImport(Subprocess)
         case .invalidDownloadResponse(let statusCode):
             "Test server download resolution returned an unexpected status code \(statusCode)."
         case .downloadResolutionFailed(let underlying):
@@ -38,7 +44,7 @@ package enum TestServerProcessError: Error, Sendable, CustomStringConvertible {
             "Failed to start the test server process: \(underlying)"
         case .reachabilityTimeout(let target):
             "Test server did not become reachable at \(target) in time."
+        #endif
         }
     }
 }
-#endif

--- a/Sources/TemporalTestKit/TestServerProcess/TestServerProcessLauncher.swift
+++ b/Sources/TemporalTestKit/TestServerProcess/TestServerProcessLauncher.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Subprocess)
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// Spawns the `temporal-test-server` binary at `executablePath`, waits until it's reachable,
+/// hands the `"host:port"` connect target to `body`, and gracefully tears the process down
+/// once `body` returns or throws.
+func withRunningTestServer<Result: Sendable>(
+    executablePath: FilePath,
+    extraArguments: [String],
+    _ body: (String) async throws -> Result
+) async throws -> Result {
+    let port = try reserveFreePort()
+    let target = "127.0.0.1:\(port)"
+    let teardownSequence: [TeardownStep] = [.gracefulShutDown(allowedDurationToNextStep: .seconds(5))]
+
+    let executionResult = try await Subprocess.run(
+        .path(executablePath),
+        arguments: Arguments([String(port)] + extraArguments),
+        input: .none,
+        output: .currentStandardOutput,
+        error: .currentStandardError
+    ) { execution in
+        do {
+            try await waitUntilReachable(target: target)
+            let result = try await body(target)
+            await execution.teardown(using: teardownSequence)
+            return result
+        } catch {
+            await execution.teardown(using: teardownSequence)
+            throw error
+        }
+    }
+    return executionResult.closureResult
+}
+
+#if canImport(Glibc)
+private let socketStreamType = Int32(SOCK_STREAM.rawValue)
+#else
+private let socketStreamType = SOCK_STREAM
+#endif
+
+/// Binds a TCP socket to an OS-assigned port on `0.0.0.0`, reads the assigned port back,
+/// then closes the socket so the test server binary can bind it — the same
+/// bind-then-release strategy the Core SDK's Rust implementation uses.
+private func reserveFreePort() throws -> UInt16 {
+    let handle = socket(AF_INET, socketStreamType, 0)
+    guard handle >= 0 else {
+        throw TestServerProcessError.processFailedToStart(underlying: "socket() failed: \(String(cString: strerror(errno)))")
+    }
+    defer { close(handle) }
+
+    var address = sockaddr_in()
+    address.sin_family = sa_family_t(AF_INET)
+    address.sin_addr.s_addr = INADDR_ANY
+    address.sin_port = 0
+    let bindResult = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+            bind(handle, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+    guard bindResult == 0 else {
+        throw TestServerProcessError.processFailedToStart(underlying: "bind() failed: \(String(cString: strerror(errno)))")
+    }
+
+    var boundAddress = sockaddr_in()
+    var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let nameResult = withUnsafeMutablePointer(to: &boundAddress) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+            getsockname(handle, sockaddrPointer, &length)
+        }
+    }
+    guard nameResult == 0 else {
+        throw TestServerProcessError.processFailedToStart(underlying: "getsockname() failed: \(String(cString: strerror(errno)))")
+    }
+    return UInt16(bigEndian: boundAddress.sin_port)
+}
+
+/// Polls `target` every 100ms for up to 5 seconds, mirroring the Core SDK's readiness check.
+private func waitUntilReachable(target: String) async throws {
+    let parts = target.split(separator: ":", maxSplits: 1)
+    guard parts.count == 2, let port = UInt16(parts[1]) else {
+        throw TestServerProcessError.reachabilityTimeout(target: target)
+    }
+    let host = String(parts[0])
+
+    for _ in 0..<50 {
+        if isReachable(host: host, port: port) {
+            return
+        }
+        try await Task.sleep(for: .milliseconds(100))
+    }
+    throw TestServerProcessError.reachabilityTimeout(target: target)
+}
+
+private func isReachable(host: String, port: UInt16) -> Bool {
+    let handle = socket(AF_INET, socketStreamType, 0)
+    guard handle >= 0 else {
+        return false
+    }
+    defer { close(handle) }
+
+    var address = sockaddr_in()
+    address.sin_family = sa_family_t(AF_INET)
+    address.sin_port = port.bigEndian
+    guard inet_pton(AF_INET, host, &address.sin_addr) == 1 else {
+        return false
+    }
+
+    let connectResult = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+            connect(handle, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+    return connectResult == 0
+}
+#endif

--- a/Sources/TemporalTestKit/TestServerProcess/TimeSkippingTestServerOptions.swift
+++ b/Sources/TemporalTestKit/TestServerProcess/TimeSkippingTestServerOptions.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Subprocess)
+/// Configuration for downloading and launching the time-skipping `temporal-test-server` binary.
+package struct TimeSkippingTestServerOptions: Hashable, Sendable {
+    /// An existing path to a `temporal-test-server` binary to use instead of downloading one.
+    package var existingPath: String
+    /// The SDK name reported to the download resolution service, e.g. `swift-temporal-sdk`.
+    package var sdkName: String
+    /// The SDK version reported to the download resolution service.
+    package var sdkVersion: String
+    /// The version of the test server to download. Use `default` for the SDK-pinned version.
+    package var downloadVersion: String
+    /// The directory the test server binary is cached in. Empty means the system temp directory.
+    package var downloadDestinationDirectory: String
+    /// Extra arguments passed to the spawned test server process.
+    package var extraArguments: [String]
+    /// How long a cached download is considered valid. `nil` means it never expires.
+    package var downloadTtl: Duration?
+
+    package init(
+        existingPath: String,
+        sdkName: String,
+        sdkVersion: String,
+        downloadVersion: String,
+        downloadDestinationDirectory: String,
+        extraArguments: [String],
+        downloadTtl: Duration?
+    ) {
+        self.existingPath = existingPath
+        self.sdkName = sdkName
+        self.sdkVersion = sdkVersion
+        self.downloadVersion = downloadVersion
+        self.downloadDestinationDirectory = downloadDestinationDirectory
+        self.extraArguments = extraArguments
+        self.downloadTtl = downloadTtl
+    }
+
+    package static let `default` = TimeSkippingTestServerOptions(
+        existingPath: "",
+        sdkName: "swift-temporal-sdk",
+        sdkVersion: "0.0.1",
+        downloadVersion: "default",
+        downloadDestinationDirectory: "",
+        extraArguments: [],
+        downloadTtl: .seconds(15 * 24 * 60 * 60)
+    )
+}
+#endif

--- a/Tests/TemporalTests/TestServerProcess/TestServerBinaryCacheTests.swift
+++ b/Tests/TemporalTests/TestServerProcess/TestServerBinaryCacheTests.swift
@@ -1,0 +1,172 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Temporal SDK open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Temporal SDK project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Temporal SDK project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Subprocess)
+import Foundation
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
+@testable import TemporalTestKit
+import Testing
+
+@Suite
+struct TestServerBinaryCacheTests {
+    private func makeTemporaryDirectory() throws -> String {
+        let directory = NSTemporaryDirectory() + "TestServerBinaryCacheTests-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    @Test
+    func cachedPathUsesSdkNameAndVersionForDefaultDownloadVersion() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        var options = TimeSkippingTestServerOptions.default
+        options.downloadDestinationDirectory = directory
+        options.sdkName = "swift-temporal-sdk"
+        options.sdkVersion = "1.2.3"
+        options.downloadVersion = "default"
+
+        let path = cachedTestServerPath(options: options)
+        #expect(path.string == directory + "/temporal-test-server-swift-temporal-sdk-1.2.3")
+    }
+
+    @Test
+    func cachedPathUsesFixedVersionWhenNotDefault() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        var options = TimeSkippingTestServerOptions.default
+        options.downloadDestinationDirectory = directory
+        options.downloadVersion = "1.9.0"
+
+        let path = cachedTestServerPath(options: options)
+        #expect(path.string == directory + "/temporal-test-server-1.9.0")
+    }
+
+    @Test
+    func cachedPathDefaultsToSystemTempDirectoryWhenUnset() {
+        var options = TimeSkippingTestServerOptions.default
+        options.downloadDestinationDirectory = ""
+
+        let path = cachedTestServerPath(options: options)
+        #expect(path.string.hasPrefix(NSTemporaryDirectory()))
+    }
+
+    @Test
+    func missingFileIsNeverValid() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        let missing = FilePath(directory + "/does-not-exist")
+        #expect(!isCachedTestServerValid(at: missing, ttl: nil))
+        #expect(!isCachedTestServerValid(at: missing, ttl: .seconds(60)))
+    }
+
+    @Test
+    func existingFileWithNilTtlIsAlwaysValid() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        let path = directory + "/binary"
+        FileManager.default.createFile(atPath: path, contents: Data())
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date.now.addingTimeInterval(-1_000_000)],
+            ofItemAtPath: path
+        )
+
+        #expect(isCachedTestServerValid(at: FilePath(path), ttl: nil))
+    }
+
+    @Test
+    func freshFileWithinTtlIsValid() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        let path = directory + "/binary"
+        FileManager.default.createFile(atPath: path, contents: Data())
+
+        #expect(isCachedTestServerValid(at: FilePath(path), ttl: .seconds(60)))
+        #expect(FileManager.default.fileExists(atPath: path))
+    }
+
+    @Test
+    func expiredFileIsInvalidAndRemoved() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        let path = directory + "/binary"
+        FileManager.default.createFile(atPath: path, contents: Data())
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date.now.addingTimeInterval(-120)],
+            ofItemAtPath: path
+        )
+
+        #expect(!isCachedTestServerValid(at: FilePath(path), ttl: .seconds(60)))
+        #expect(!FileManager.default.fileExists(atPath: path))
+    }
+
+    @Test
+    func abandonedLockFileIsClearedAndRetried() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        let destination = directory + "/binary"
+        let lockPath = destination + ".downloading"
+        FileManager.default.createFile(atPath: lockPath, contents: Data())
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date.now.addingTimeInterval(-91)],
+            ofItemAtPath: lockPath
+        )
+
+        let shouldRetry = try await waitForConcurrentDownload(
+            lockPath: FilePath(lockPath),
+            destination: FilePath(destination)
+        )
+
+        #expect(!shouldRetry)
+        #expect(!FileManager.default.fileExists(atPath: lockPath))
+    }
+}
+
+@Suite
+struct TestServerDownloadInfoTests {
+    @Test
+    func defaultVersionIncludesSdkQueryItems() {
+        let url = testServerDownloadURL(downloadVersion: "default", sdkName: "swift-temporal-sdk", sdkVersion: "0.0.1")
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+
+        #expect(components.path == "/temporal-test-server/default")
+        let queryItems = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+        #expect(queryItems["sdk-name"] == "swift-temporal-sdk")
+        #expect(queryItems["sdk-version"] == "0.0.1")
+        #expect(queryItems["arch"] != nil)
+        #expect(queryItems["platform"] != nil)
+    }
+
+    @Test
+    func fixedVersionOmitsSdkQueryItems() {
+        let url = testServerDownloadURL(downloadVersion: "1.9.0", sdkName: "swift-temporal-sdk", sdkVersion: "0.0.1")
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+
+        #expect(components.path == "/temporal-test-server/1.9.0")
+        let queryItems = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+        #expect(queryItems["sdk-name"] == nil)
+        #expect(queryItems["sdk-version"] == nil)
+    }
+}
+#endif


### PR DESCRIPTION
### Motivation

The time-skipping test server was started through the Core SDK's Rust FFI bridge, which opaquely handled downloading the `temporal-test-server` binary and spawning it. Issue #117 asks us to use `swift-subprocess` instead, giving us direct control over the process and letting it plug into Swift's structured concurrency.

### Modifications

- Added `swift-subprocess` as a dependency of `TemporalTestKit` (macOS/Linux only).
- New `TestServerProcess` module that resolves, downloads, caches (with TTL and lock-file coordination for concurrent test runs), and extracts the `temporal-test-server` binary, then spawns and supervises it.
- `TemporalTestServer.withTimeSkippingTestServer` now uses this instead of the Core SDK FFI bridge. The dev server path is untouched.
- Removed the now-unused `BridgeTestServer.withBridgeTestServer` FFI call.
- New code is gated behind `#if canImport(Subprocess)` so `TemporalTestKit` still builds on iOS, where swift-subprocess isn't available; calling the time-skipping server there throws instead.

### Result

Same public API and behavior for `TemporalTestServer.withTimeSkippingTestServer`, now backed by a Swift-native download/spawn implementation instead of Rust FFI.

### Test Plan

- Full test suite passes locally (395 tests, 81 suites), including the existing `TimeSkippingInterceptorTests` integration tests, unmodified.
- Verified end-to-end: binary downloads, extracts (0o755), caches, spawns, and connects successfully.
- Added unit tests for cache-path computation, TTL expiry, and lock-file staleness handling.
