### PR TITLE
Bump CoreSDK submodule to latest main (6e90e6d5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROTO_OUT := ./Sources/Temporal/Generated
-PROTO_BASE := ./dependencies/sdk-core/crates/common/protos
+PROTO_BASE := ./dependencies/sdk-core/crates/protos/protos
 # Split proto files: public (non-local) and local (package-only)
 PROTO_FILES_PUBLIC := $(shell find $(PROTO_BASE) -name "*.proto" -not -path "*/google/*" -not -path "*/health/*" -not -path "*/local/*")
 PROTO_FILES_LOCAL := $(shell find $(PROTO_BASE)/local -name "*.proto" 2>/dev/null)
@@ -16,7 +16,7 @@ $(PROTOC_GEN_SWIFT): Package.swift
 	swift build -c release --product protoc-gen-grpc-swift-2
 
 .PHONY: build-protos
-build-protos: $(PROTOC_GEN_SWIFT) $(PROTOC_GEN_GRPC_SWIFT) ./dependencies/sdk-core/crates/common/protos
+build-protos: $(PROTOC_GEN_SWIFT) $(PROTOC_GEN_GRPC_SWIFT) ./dependencies/sdk-core/crates/protos/protos
 	rm -rf $(PROTO_OUT)
 	mkdir -p $(PROTO_OUT)
 
@@ -27,12 +27,12 @@ build-protos: $(PROTOC_GEN_SWIFT) $(PROTOC_GEN_GRPC_SWIFT) ./dependencies/sdk-co
 		--swift_opt=Visibility=Public \
 		--swift_opt=UseAccessLevelOnImports=true \
 		--swift_opt=EnumGeneration=Nonexhaustive \
-		-I ./dependencies/sdk-core/crates/common/protos/api_cloud_upstream \
-		-I ./dependencies/sdk-core/crates/common/protos/api_upstream \
-		-I ./dependencies/sdk-core/crates/common/protos/google \
-		-I ./dependencies/sdk-core/crates/common/protos/grpc \
-		-I ./dependencies/sdk-core/crates/common/protos/local \
-		-I ./dependencies/sdk-core/crates/common/protos/testsrv_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/api_cloud_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/api_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/google \
+		-I ./dependencies/sdk-core/crates/protos/protos/grpc \
+		-I ./dependencies/sdk-core/crates/protos/protos/local \
+		-I ./dependencies/sdk-core/crates/protos/protos/testsrv_upstream \
 		${PROTO_FILES_PUBLIC}
 
 	# Generate proto message types (.pb.swift) - PACKAGE in Temporal module
@@ -41,12 +41,12 @@ build-protos: $(PROTOC_GEN_SWIFT) $(PROTOC_GEN_GRPC_SWIFT) ./dependencies/sdk-co
 		--swift_opt=FileNaming=PathToUnderscores \
 		--swift_opt=Visibility=Package \
 		--swift_opt=UseAccessLevelOnImports=true \
-		-I ./dependencies/sdk-core/crates/common/protos/api_cloud_upstream \
-		-I ./dependencies/sdk-core/crates/common/protos/api_upstream \
-		-I ./dependencies/sdk-core/crates/common/protos/google \
-		-I ./dependencies/sdk-core/crates/common/protos/grpc \
-		-I ./dependencies/sdk-core/crates/common/protos/local \
-		-I ./dependencies/sdk-core/crates/common/protos/testsrv_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/api_cloud_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/api_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/google \
+		-I ./dependencies/sdk-core/crates/protos/protos/grpc \
+		-I ./dependencies/sdk-core/crates/protos/protos/local \
+		-I ./dependencies/sdk-core/crates/protos/protos/testsrv_upstream \
 		${PROTO_FILES_LOCAL}
 
 
@@ -58,12 +58,12 @@ build-protos: $(PROTOC_GEN_SWIFT) $(PROTOC_GEN_GRPC_SWIFT) ./dependencies/sdk-co
 		--grpc-swift-2_opt=UseAccessLevelOnImports=true \
 		--grpc-swift-2_opt=Client=true \
 		--grpc-swift-2_opt=Server=false \
-		-I ./dependencies/sdk-core/crates/common/protos/api_cloud_upstream \
-		-I ./dependencies/sdk-core/crates/common/protos/api_upstream \
-		-I ./dependencies/sdk-core/crates/common/protos/google \
-		-I ./dependencies/sdk-core/crates/common/protos/grpc \
-		-I ./dependencies/sdk-core/crates/common/protos/local \
-		-I ./dependencies/sdk-core/crates/common/protos/testsrv_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/api_cloud_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/api_upstream \
+		-I ./dependencies/sdk-core/crates/protos/protos/google \
+		-I ./dependencies/sdk-core/crates/protos/protos/grpc \
+		-I ./dependencies/sdk-core/crates/protos/protos/local \
+		-I ./dependencies/sdk-core/crates/protos/protos/testsrv_upstream \
 		${PROTO_FILES_PUBLIC}
 
 	# Reorganize protobuf types into nested namespaces


### PR DESCRIPTION
## Summary

- Updates `dependencies/sdk-core` submodule from `c57f825` to `6e90e6d5` (134 commits on main)
- Includes the forward declarations fix for the C bridge header ([sdk-rust#1467](https://github.com/temporalio/sdk-rust/pull/1467)) which resolves the `-Wvisibility` warnings blocking [#167](https://github.com/apple/swift-temporal-sdk/pull/167)

### Notable upstream changes

- Forward declarations for `TemporalCoreCustomMetricMeter` and `TemporalCoreCustomSlotSupplierCallbacks` at file scope in cbindgen
- Activity execution interceptors (#1277)
- Typed search attributes API (#1346)
- Payload limit enforcement (#1363)
- Client and workflow interceptors (#1426, #1401)
- Plugins support (#1436)
- WorkflowReplayer (#1460)
- Temporal API 1.63.4 integration (#1423)

### Local build verification

Built the CoreSDK C bridge locally with `cargo build -p temporalio-sdk-core-c-bridge --release` — **compiles successfully** with no warnings.

The generated header includes the forward declarations fix:
```c
/* Forward declarations for structs referenced in callback typedefs */
struct TemporalCoreCustomMetricMeter;
struct TemporalCoreCustomSlotSupplierCallbacks;
```

### Notes

- The proto directory has moved from `crates/common/protos` to `crates/protos/protos` — Makefile `build-protos` paths will need updating
- `Package.swift` binary target URLs/checksums will need updating once the official release binary is produced

As discussed in #167, @FranzBusch can produce an official release binary for the CoreSDK from this updated submodule.

## Test plan

- [x] Verify CoreSDK C bridge compiles from updated submodule
- [x] Verify generated C header includes forward declarations fix
- [ ] Official release binary produced by maintainer
- [ ] Package.swift updated with new binary URLs/checksums
- [ ] Full Swift build verified with new binary