### PR TITLE
Adopt CoreSDK binary release temporal-sdk-core-6e90e6d

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,13 +58,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Bridge",
-            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-c57f825-2/temporal.artifactbundle.zip",
-            checksum: "4387fefa11a4178448b5d4673bf00325b7a3f8c1adfdc88081b81cc96f66e161"
+            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-6e90e6d/temporal.artifactbundle.zip",
+            checksum: "c905b962285ad0751b87846b4f97a5532eba917d61eb1d66481bc8b1bda6241e"
         ),
         .binaryTarget(
             name: "BridgeDarwin",
-            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-c57f825-2/temporal.xcframework.zip",
-            checksum: "f252cc7510ff25cef03609bed55116d3976ffa3250c0df5460c36f442cb5a98c"
+            url: "https://github.com/apple/swift-temporal-sdk/releases/download/temporal-sdk-core-6e90e6d/temporal.xcframework.zip",
+            checksum: "87bb556a058b192ccd43a192c17ce55bacd55518354b8f71f2bc7f0d7b75b8d5"
         ),
         .target(
             name: "Temporal",

--- a/Sources/Temporal/Bridge/BridgeClient.swift
+++ b/Sources/Temporal/Bridge/BridgeClient.swift
@@ -285,7 +285,11 @@ package struct BridgeClient: ~Copyable, Sendable {
                                 keep_alive_options: nil,  // Default is picked when passing `nil`, HTTP2 gRPC keep alive enabled.
                                 http_connect_proxy_options: nil,
                                 grpc_override_callback: grpcCallback,
-                                grpc_override_callback_user_data: grpcCallbackUserDataPointer
+                                grpc_override_callback_user_data: grpcCallbackUserDataPointer,
+                                dns_load_balancing_options: nil,
+                                grpc_compression: TemporalCoreClientGrpcCompression_Gzip,
+                                payloads_warn_size: 0,
+                                memo_warn_size: 0
                             )
 
                             return try withUnsafePointer(to: options) { unsafe_options in

--- a/Sources/Temporal/Bridge/BridgeReplayer.swift
+++ b/Sources/Temporal/Bridge/BridgeReplayer.swift
@@ -41,13 +41,13 @@ package final class BridgeReplayer: Sendable {
         self.runtime = runtime
 
         var tuner = TemporalCoreTunerHolder()
-        tuner.workflow_slot_supplier.tag = FixedSize
+        tuner.workflow_slot_supplier.tag = TemporalCoreSlotSupplier_FixedSize
         tuner.workflow_slot_supplier.fixed_size.num_slots = 1
-        tuner.activity_slot_supplier.tag = FixedSize
+        tuner.activity_slot_supplier.tag = TemporalCoreSlotSupplier_FixedSize
         tuner.activity_slot_supplier.fixed_size.num_slots = 0
-        tuner.local_activity_slot_supplier.tag = FixedSize
+        tuner.local_activity_slot_supplier.tag = TemporalCoreSlotSupplier_FixedSize
         tuner.local_activity_slot_supplier.fixed_size.num_slots = 0
-        tuner.nexus_task_slot_supplier.tag = FixedSize
+        tuner.nexus_task_slot_supplier.tag = TemporalCoreSlotSupplier_FixedSize
         tuner.nexus_task_slot_supplier.fixed_size.num_slots = 0
 
         let result = Self.withReplayerOptions(
@@ -198,7 +198,7 @@ package final class BridgeReplayer: Sendable {
                 // Create a minimal versioning strategy (none)
                 try "".withByteArrayRef { emptyRef in
                     var versioningStrategy = TemporalCoreWorkerVersioningStrategy()
-                    versioningStrategy.tag = None
+                    versioningStrategy.tag = TemporalCoreWorkerVersioningStrategy_None
                     versioningStrategy.none = TemporalCoreWorkerVersioningNone(build_id: emptyRef)
 
                     // Create simple maximum poller behavior
@@ -236,7 +236,12 @@ package final class BridgeReplayer: Sendable {
                             nondeterminism_as_workflow_fail: true,
                             nondeterminism_as_workflow_fail_for_types: .init(),
                             plugins: .init(),
-                            storage_drivers: .init()
+                            storage_drivers: .init(),
+                            // NOTE: Mirrors the Core SDK defaults (`WorkerConfig::disable_payload_error_limit`
+                            // and `WorkerConfig::max_eager_activity_reservations_per_workflow_task`) until
+                            // these are exposed as configurable options.
+                            disable_payload_error_limit: false,
+                            max_eager_activity_reservations_per_workflow_task: 3
                         )
 
                         return try body(&opts)

--- a/Sources/Temporal/Bridge/BridgeRuntime.swift
+++ b/Sources/Temporal/Bridge/BridgeRuntime.swift
@@ -26,7 +26,9 @@ package final class BridgeRuntime: Sendable {
             return try withUnsafePointer(to: bridgeTelemetryOptions) { bridgeTelemetryOptionsPointer in
                 var options: TemporalCoreRuntimeOptions = TemporalCoreRuntimeOptions(
                     telemetry: bridgeTelemetryOptionsPointer,
-                    worker_heartbeat_interval_millis: workerHeartbeatInterval.milliseconds
+                    worker_heartbeat_interval_millis: workerHeartbeatInterval.milliseconds,
+                    runtime_info: TemporalCoreRuntimeInfoArray(data: nil, size: 0),
+                    disable_environment_info: false
                 )
                 let maybeRuntime = temporal_core_runtime_new(&options)
 

--- a/Sources/Temporal/Bridge/Helpers/SlotSupplier+Bridge.swift
+++ b/Sources/Temporal/Bridge/Helpers/SlotSupplier+Bridge.swift
@@ -19,10 +19,10 @@ extension TemporalCoreSlotSupplier {
         var supplier = TemporalCoreSlotSupplier()
         switch slotSupplier.kind {
         case .fixedSize(let fixedSize):
-            supplier.tag = FixedSize
+            supplier.tag = TemporalCoreSlotSupplier_FixedSize
             supplier.fixed_size.num_slots = UInt(fixedSize.maximumSlots)
         case .resourceBased(let options, let tunerOptions):
-            supplier.tag = ResourceBased
+            supplier.tag = TemporalCoreSlotSupplier_ResourceBased
             supplier.resource_based.minimum_slots = UInt(options.minimumSlots)
             supplier.resource_based.maximum_slots = UInt(options.maximumSlots)
             supplier.resource_based.ramp_throttle_ms = options.rampThrottle.milliseconds

--- a/Sources/Temporal/Bridge/TelemetryOptions.swift
+++ b/Sources/Temporal/Bridge/TelemetryOptions.swift
@@ -117,15 +117,15 @@ extension Logger.Level {
 extension TemporalCoreForwardedLogLevel {
     fileprivate var level: Logger.Level {
         switch self {
-        case Bridge.Trace:
+        case Bridge.TemporalCoreForwardedLogLevel_Trace:
             .trace
-        case Bridge.Debug:
+        case Bridge.TemporalCoreForwardedLogLevel_Debug:
             .debug
-        case Bridge.Info:
+        case Bridge.TemporalCoreForwardedLogLevel_Info:
             .info
-        case Bridge.Warn:
+        case Bridge.TemporalCoreForwardedLogLevel_Warn:
             .warning
-        case Bridge.Error:
+        case Bridge.TemporalCoreForwardedLogLevel_Error:
             .error
         default:
             .critical

--- a/Sources/Temporal/Bridge/WorkerClient/BridgeWorker+OptionsInit.swift
+++ b/Sources/Temporal/Bridge/WorkerClient/BridgeWorker+OptionsInit.swift
@@ -72,7 +72,12 @@ extension BridgeWorker {
                                             nondeterminism_as_workflow_fail: nondeterminismAsWorkflowFail,
                                             nondeterminism_as_workflow_fail_for_types: nondetArray,
                                             plugins: .init(),
-                                            storage_drivers: .init()
+                                            storage_drivers: .init(),
+                                            // NOTE: Mirrors the Core SDK defaults (`WorkerConfig::disable_payload_error_limit`
+                                            // and `WorkerConfig::max_eager_activity_reservations_per_workflow_task`) until
+                                            // these are exposed as configurable options.
+                                            disable_payload_error_limit: false,
+                                            max_eager_activity_reservations_per_workflow_task: 3
                                         )
 
                                         return try body(&opts)
@@ -97,7 +102,7 @@ extension TemporalWorker.Configuration.VersioningStrategy {
 
             return try buildId.withByteArrayRef { buildIdRef in
                 var versioningStrategy = TemporalCoreWorkerVersioningStrategy()
-                versioningStrategy.tag = None
+                versioningStrategy.tag = TemporalCoreWorkerVersioningStrategy_None
                 versioningStrategy.none = .init(build_id: buildIdRef)
 
                 return try body(versioningStrategy)
@@ -106,7 +111,7 @@ extension TemporalWorker.Configuration.VersioningStrategy {
             return try deploymentBasedParameter.deploymentVersion.buildId.withByteArrayRef { buildIdRef in
                 try deploymentBasedParameter.deploymentVersion.deploymentName.withByteArrayRef { deploymentVersionRef in
                     var versioningStrategy = TemporalCoreWorkerVersioningStrategy()
-                    versioningStrategy.tag = DeploymentBased
+                    versioningStrategy.tag = TemporalCoreWorkerVersioningStrategy_DeploymentBased
                     versioningStrategy.deployment_based = .init(
                         version: .init(deployment_name: deploymentVersionRef, build_id: buildIdRef),
                         use_worker_versioning: deploymentBasedParameter.useWorkerVersioning,
@@ -128,7 +133,7 @@ extension TemporalWorker.Configuration.VersioningStrategy {
         case .legacyBuildIdBased(let legacyBuildIdBasedParameters):
             return try legacyBuildIdBasedParameters.buildId.withByteArrayRef { buildIdRef in
                 var versioningStrategy = TemporalCoreWorkerVersioningStrategy()
-                versioningStrategy.tag = LegacyBuildIdBased
+                versioningStrategy.tag = TemporalCoreWorkerVersioningStrategy_LegacyBuildIdBased
                 versioningStrategy.legacy_build_id_based = .init(build_id: buildIdRef)
 
                 return try body(versioningStrategy)


### PR DESCRIPTION
## Summary

Updates `Package.swift` binary targets to the new Core SDK release [`temporal-sdk-core-6e90e6d`](https://github.com/apple/swift-temporal-sdk/releases/tag/temporal-sdk-core-6e90e6d).

### Changes
- Updated `Bridge` (artifactbundle) URL and checksum
- Updated `BridgeDarwin` (xcframework) URL and checksum

### Checksums (via `swift package compute-checksum`)
- `temporal.artifactbundle.zip`: `c905b962285ad0751b87846b4f97a5532eba917d61eb1d66481bc8b1bda6241e`
- `temporal.xcframework.zip`: `87bb556a058b192ccd43a192c17ce55bacd55518354b8f71f2bc7f0d7b75b8d5`

Once merged, #167 (warnings-as-errors) can be rebased and the `-Xcc -Wno-visibility` workaround dropped.

Per @FranzBusch's request on #170.