### PR TITLE
Fix a failing cancellation test under nightly-main toolchains

### DIFF
--- a/Tests/TemporalTests/Worker/Activities/ActivityWorkerTests.swift
+++ b/Tests/TemporalTests/Worker/Activities/ActivityWorkerTests.swift
@@ -669,7 +669,11 @@ struct ActivityWorkerTests {
             let completion = try await activityTaskCompletionIterator.next()
             let expectedCompletion = Coresdk.ActivityTaskCompletion.with {
                 $0.taskToken = Data([1])
+                #if compiler(>=6.5)
+                $0.result.failed.failure.message = "CancellationError(reason: unspecified)"
+                #else
                 $0.result.failed.failure.message = "CancellationError()"
+                #endif
                 $0.result.failed.failure.source = "swift-temporal-sdk"
                 $0.result.failed.failure.stackTrace = ""
                 $0.result.failed.failure.applicationFailureInfo.type = "CancellationError"


### PR DESCRIPTION
### Motivation

The test ActivityWorkerTests.activityThrowingCancellation is failing on main on nightly-main toolchains.

### Modifications

Adapted the test to the changes to the structure of the CancellationError struct.

### Result

Passing test on all platforms.

### Test Plan

Ran test locally, will verify on PR CI.
